### PR TITLE
fix: snapping behaviour in UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -943,10 +943,17 @@ function startClipGesture(e, c, mode, collapseOnClick) {
     if (Math.abs(dt * state.pps) > 3) moved = true;
     if (!moved) return;
     if (mode === "move") {
-      let ns = snapTime(orig.start + dt, groupIds);
-      const nsEnd = snapTime(orig.start + orig.duration + dt, groupIds);
-      if (Math.abs(nsEnd - (orig.start + orig.duration + dt)) < Math.abs(ns - (orig.start + dt)))
-        ns = nsEnd - orig.duration;
+      // Snap whichever edge is closer to a target. A non-snapping edge has
+      // distance 0, which must NOT beat a real snap on the other edge.
+      const rawStart = orig.start + dt;
+      const rawEnd = orig.start + orig.duration + dt;
+      const snapStart = snapTime(rawStart, groupIds);
+      const snapEnd = snapTime(rawEnd, groupIds);
+      const dStart = Math.abs(snapStart - rawStart);
+      const dEnd = Math.abs(snapEnd - rawEnd);
+      let ns = rawStart;
+      if (dEnd > 0 && (dStart === 0 || dEnd < dStart)) ns = snapEnd - orig.duration;
+      else if (dStart > 0) ns = snapStart;
       // one time-delta for the whole group, clamped so nothing crosses 0
       let d = ns - orig.start;
       d = Math.max(d, -Math.min(...group.map((x) => groupOrig.get(x.id))));


### PR DESCRIPTION
When only one edge was near a snap target, the other edge’s distance was 0 and won the comparison, so move-snapping never engaged

<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

Fix snapping behaviour in UI

Closes #

## Type of change

- [X] Bug fix
- [ ] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [ ] Opened the editor and confirmed the change in **preview**
- [] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline drag snapping for single clips and multi-selections.
  * Clips now snap more reliably to the closest timeline edge while preserving their duration.
  * Maintained group movement limits and track adjustments when repositioning individual clips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->