### PR TITLE
fix: widen the bin panel to fit buttons inside

### DIFF
--- a/style.css
+++ b/style.css
@@ -64,7 +64,7 @@ body {
   color: var(--dim); text-transform: uppercase; border-bottom: 1px solid var(--border);
 }
 .panel-head-actions { display: flex; gap: 6px; text-transform: none; }
-.upper { display: grid; grid-template-columns: 250px minmax(0,1fr) 280px; gap: 6px; min-height: 0; }
+.upper { display: grid; grid-template-columns: 280px minmax(0,1fr) 280px; gap: 6px; min-height: 0; }
 
 /* ── Media bin ── */
 .bin-tabs { display: flex; gap: 2px; padding: 6px 8px 0; border-bottom: 1px solid var(--border); }


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

Adjust bin width to fit buttons inside

Closes #

## Type of change

- [X] Bug fix
- [ ] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Widened the left section of the upper layout for improved spacing and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->