### PR TITLE
Add timeline 'zoom to project width' and 'zoom to clip' features

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,9 @@ const TRACKS = [
 const RULER_H = 26;
 const SNAP_PX = 8;
 const MIN_DUR = 0.05;
+const ZOOM_MIN = 1;
+const ZOOM_MAX = 300;
+const TIMELINE_PAD_SEC = 15; // trailing empty seconds in the scrollable content
 
 const DEFAULT_PROPS = {
   x: 0, y: 0, scale: 1, rotation: 0, opacity: 1, volume: 1,
@@ -761,7 +764,7 @@ els.timelineScroll.addEventListener("scroll", () => {
 });
 function contentWidth() {
   const minSec = (els.timelineScroll.clientWidth || 800) / state.pps;
-  return Math.max(projDur() + 15, minSec) * state.pps;
+  return Math.max(projDur() + TIMELINE_PAD_SEC, minSec) * state.pps;
 }
 function rebuildClips() {
   const w = contentWidth();
@@ -1139,13 +1142,22 @@ function setZoom(pps, anchorClientX) {
   const rect = scroller.getBoundingClientRect();
   const ax = anchorClientX != null ? anchorClientX - rect.left : rect.width / 2;
   const tAtAnchor = (scroller.scrollLeft + ax) / state.pps;
-  state.pps = clamp(pps, 8, 300);
+  state.pps = clamp(pps, ZOOM_MIN, ZOOM_MAX);
   els.zoomSlider.value = state.pps;
   state.dirtyTimeline = true;
   rebuildClips();
   scroller.scrollLeft = Math.max(0, tAtAnchor * state.pps - ax);
 }
+/* Fit the full timeline (clips + trailing pad) into the visible scroll area
+   with no horizontal overflow, then scroll to the start. */
+function zoomToFit() {
+  const w = els.timelineScroll.clientWidth || 800;
+  const span = Math.max(projDur() + TIMELINE_PAD_SEC, 1);
+  setZoom(w / span);
+  els.timelineScroll.scrollLeft = 0;
+}
 els.zoomSlider.addEventListener("input", () => setZoom(+els.zoomSlider.value));
+$("btnZoomFit").addEventListener("click", zoomToFit);
 els.timelineScroll.addEventListener("wheel", (e) => {
   if (e.ctrlKey || e.metaKey) {
     e.preventDefault();
@@ -2724,6 +2736,7 @@ window.addEventListener("keydown", (e) => {
   }
   else if (k === "+" || k === "=") setZoom(state.pps * 1.25);
   else if (k === "-") setZoom(state.pps / 1.25);
+  else if (k === "Z" && !e.ctrlKey && !e.metaKey && !e.altKey) { e.preventDefault(); zoomToFit(); }
   else if ((e.ctrlKey || e.metaKey) && (k === "z" || k === "Z")) {
     e.preventDefault();
     e.shiftKey ? redo() : undo();

--- a/app.js
+++ b/app.js
@@ -245,6 +245,18 @@ function toast(msg) {
   toastTimer = setTimeout(() => els.toast.classList.remove("show"), 3200);
 }
 
+/* True when keyboard events should go to a text-entry control (not range/checkbox). */
+function isTypingTarget(el) {
+  if (!el || el === document.body || el === document.documentElement) return false;
+  const tag = el.tagName;
+  if (tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (tag === "INPUT") {
+    const t = (el.type || "text").toLowerCase();
+    return !["range", "checkbox", "radio", "button", "submit", "reset", "color", "file", "hidden"].includes(t);
+  }
+  return !!el.isContentEditable;
+}
+
 /* ═══════════════════════ SERVER SYNC (optional) ═══════════════════════ */
 async function connectServer() {
   try {
@@ -899,6 +911,9 @@ function trackAtEvent(e) {
 
 els.tracksContent.addEventListener("pointerdown", (e) => {
   if (e.button !== 0) return;
+  // Clicking the timeline should release inspector text fields so shortcuts (z, s, …) work
+  if (isTypingTarget(document.activeElement) && els.inspector.contains(document.activeElement))
+    document.activeElement.blur();
   const clipDiv = e.target.closest(".clip");
   if (!clipDiv) {
     // empty track background: drag = marquee select, plain click = seek + deselect
@@ -1155,6 +1170,20 @@ function zoomToFit() {
   const span = Math.max(projDur() + TIMELINE_PAD_SEC, 1);
   setZoom(w / span);
   els.timelineScroll.scrollLeft = 0;
+}
+/* Zoom so the primary selected clip fills 90% of the timeline width and is centered. */
+function zoomToSelection() {
+  const c = getClip(state.selId) || selectedClips()[0];
+  if (!c) { toast("Select a clip to zoom to"); return; }
+  const w = els.timelineScroll.clientWidth || 800;
+  const dur = Math.max(c.duration, MIN_DUR);
+  const pps = clamp((0.9 * w) / dur, ZOOM_MIN, ZOOM_MAX);
+  state.pps = pps;
+  els.zoomSlider.value = pps;
+  rebuildClips();
+  const center = c.start + c.duration / 2;
+  const maxScroll = Math.max(0, contentWidth() - w);
+  els.timelineScroll.scrollLeft = clamp(center * pps - w / 2, 0, maxScroll);
 }
 els.zoomSlider.addEventListener("input", () => setZoom(+els.zoomSlider.value));
 $("btnZoomFit").addEventListener("click", zoomToFit);
@@ -2715,8 +2744,7 @@ function updateSafeOverlay() {
 }
 
 window.addEventListener("keydown", (e) => {
-  const tag = document.activeElement?.tagName;
-  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+  if (isTypingTarget(document.activeElement)) return;
   const k = e.key;
   if (k === " ") { e.preventDefault(); state.playing ? pause() : play(); }
   else if (k === "s" || k === "S") splitAtPlayhead();
@@ -2736,7 +2764,10 @@ window.addEventListener("keydown", (e) => {
   }
   else if (k === "+" || k === "=") setZoom(state.pps * 1.25);
   else if (k === "-") setZoom(state.pps / 1.25);
-  else if (k === "Z" && !e.ctrlKey && !e.metaKey && !e.altKey) { e.preventDefault(); zoomToFit(); }
+  else if (e.code === "KeyZ" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+    e.preventDefault();
+    e.shiftKey ? zoomToFit() : zoomToSelection();
+  }
   else if ((e.ctrlKey || e.metaKey) && (k === "z" || k === "Z")) {
     e.preventDefault();
     e.shiftKey ? redo() : undo();

--- a/index.html
+++ b/index.html
@@ -100,7 +100,8 @@
       <button class="btn tiny toggle on" id="btnSnap" title="Toggle snapping (N)">🧲 Snap</button>
       <span class="flex-spacer"></span>
       <span class="dim tiny-label">Zoom</span>
-      <input type="range" id="zoomSlider" min="8" max="300" value="60">
+      <input type="range" id="zoomSlider" min="1" max="300" value="60">
+      <button class="btn tiny" id="btnZoomFit" title="Zoom timeline to fit (⇧Z)"><span class="fit-icon">│<span class="fit-arrow">↔</span>│</span> Fit</button>
     </div>
     <div class="timeline">
       <div class="track-headers" id="trackHeaders"></div>
@@ -161,6 +162,7 @@
       <tr><td><kbd>M</kbd></td><td>Add / remove marker at playhead (tap on the beat while playing)</td></tr>
       <tr><td><kbd>N</kbd></td><td>Toggle snapping</td></tr>
       <tr><td><kbd>+</kbd> / <kbd>-</kbd></td><td>Zoom timeline</td></tr>
+      <tr><td><kbd>⇧</kbd>+<kbd>Z</kbd></td><td>Zoom timeline to fit</td></tr>
       <tr><td><kbd>Ctrl</kbd>+<kbd>Z</kbd> / <kbd>Ctrl</kbd>+<kbd>⇧</kbd>+<kbd>Z</kbd></td><td>Undo / redo</td></tr>
       <tr><td><kbd>Ctrl</kbd>+wheel</td><td>Zoom timeline at cursor</td></tr>
     </table>

--- a/index.html
+++ b/index.html
@@ -162,6 +162,7 @@
       <tr><td><kbd>M</kbd></td><td>Add / remove marker at playhead (tap on the beat while playing)</td></tr>
       <tr><td><kbd>N</kbd></td><td>Toggle snapping</td></tr>
       <tr><td><kbd>+</kbd> / <kbd>-</kbd></td><td>Zoom timeline</td></tr>
+      <tr><td><kbd>Z</kbd></td><td>Zoom to selected clip</td></tr>
       <tr><td><kbd>⇧</kbd>+<kbd>Z</kbd></td><td>Zoom timeline to fit</td></tr>
       <tr><td><kbd>Ctrl</kbd>+<kbd>Z</kbd> / <kbd>Ctrl</kbd>+<kbd>⇧</kbd>+<kbd>Z</kbd></td><td>Undo / redo</td></tr>
       <tr><td><kbd>Ctrl</kbd>+wheel</td><td>Zoom timeline at cursor</td></tr>

--- a/style.css
+++ b/style.css
@@ -165,6 +165,10 @@ input[type=range] { accent-color: var(--accent); height: 18px; }
 .timeline-toolbar { display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-bottom: 1px solid var(--border); }
 .tiny-label { font-size: 11px; }
 #zoomSlider { width: 130px; }
+#btnZoomFit .fit-arrow {
+  font-size: 1.45em; line-height: 0; vertical-align: -0.12em;
+  margin: 0 -0.18em;
+}
 .timeline { flex: 1; display: flex; min-height: 0; }
 .track-headers { width: 92px; flex: none; border-right: 1px solid var(--border); padding-top: 26px; background: var(--panel); z-index: 2; overflow: hidden; }
 .track-head {


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

Adds GUI enhancements: 

1. 'Zoom to project width' - **Shift+z** - zooms the whole timeline to be visible without a horizontal overflow
2. 'Zoom to clip' - **z** - zooms the timeline so that a selected clip is centered and scaled to the 90% of the viewport width

Closes #

## Type of change

- [ ] Bug fix
- [X] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive
