### PR TITLE
fix: ctrl + click to import

### DIFF
--- a/app.js
+++ b/app.js
@@ -432,17 +432,32 @@ function ensureWave(m) {
 }
 
 /* ═══════════════════════════ MEDIA IMPORT ═══════════════════════════ */
+/* Windows often leaves File.type empty for video/audio — fall back to extension. */
+function mediaKindFromFile(file) {
+  const t = file.type || "";
+  if (t === "image/svg+xml" || t === "image/svg") return "svg";
+  if (t.startsWith("video/")) return "video";
+  if (t.startsWith("audio/")) return "audio";
+  if (t.startsWith("image/")) return "image";
+  const ext = (file.name.split(".").pop() || "").toLowerCase();
+  if (ext === "svg") return "svg";
+  if (["mp4", "mov", "webm", "mkv", "m4v", "avi", "mpg", "mpeg"].includes(ext)) return "video";
+  if (["mp3", "wav", "m4a", "aac", "ogg", "flac", "wma"].includes(ext)) return "audio";
+  if (["png", "jpg", "jpeg", "gif", "webp", "bmp", "avif"].includes(ext)) return "image";
+  return null;
+}
 async function importFiles(fileList) {
-  for (const file of fileList) {
-    const kind = file.type === "image/svg+xml" ? "svg"
-               : file.type.startsWith("video") ? "video"
-               : file.type.startsWith("audio") ? "audio"
-               : file.type.startsWith("image") ? "image" : null;
-    if (!kind) continue;
+  const files = [...fileList];
+  if (!files.length) return;
+  let added = 0, skipped = 0;
+  for (const file of files) {
+    const kind = mediaKindFromFile(file);
+    if (!kind) { skipped++; continue; }
     let src, transient = false;
     if (state.connected) {
       try {
         const res = await fetch("/api/upload?name=" + encodeURIComponent(file.name), { method: "POST", body: file });
+        if (!res.ok) throw new Error("upload " + res.status);
         src = (await res.json()).src;
       } catch { src = URL.createObjectURL(file); transient = true; }
     } else {
@@ -461,10 +476,15 @@ async function importFiles(fileList) {
         if (kind === "video") grabThumb(m).catch(() => {});
         ensureWave(m);
       }
-    } catch { continue; }
+    } catch { skipped++; continue; }
     project.media.push(m);
+    added++;
   }
   renderBin(); scheduleSave();
+  if (!added && skipped)
+    toast("Couldn't import — unsupported or unreadable file type");
+  else if (skipped)
+    toast(`Imported ${added}, skipped ${skipped}`);
 }
 
 function renderBin() {
@@ -497,6 +517,27 @@ function renderBin() {
     els.binList.appendChild(item);
   }
 }
+
+/* Open the native file dialog. Windows anchors it to the <input>'s screen
+   position — park the input under the cursor and open after the mouse
+   gesture finishes so the dialog doesn't appear then jump. */
+function openFileImport(clientX, clientY) {
+  const input = els.fileInput;
+  if (clientX != null && clientY != null) {
+    input.style.cssText =
+      `position:fixed;left:${clientX}px;top:${clientY}px;width:1px;height:1px;` +
+      `opacity:0;margin:0;padding:0;border:0;overflow:hidden;z-index:-1;`;
+  }
+  setTimeout(() => input.click(), 0);
+}
+
+/* Ctrl/Cmd+click in the Project bin opens the file importer. */
+els.binList.addEventListener("click", (e) => {
+  if (!(e.ctrlKey || e.metaKey) || e.button !== 0) return;
+  if (e.target.closest(".bin-del")) return;
+  e.preventDefault();
+  openFileImport(e.clientX, e.clientY);
+});
 
 /* ═══════════════════ ASSET LIBRARY (./library on the server) ═══════════════
    Read-only default assets in four tabs: Elements (overlay art), Sound FX,
@@ -2639,7 +2680,6 @@ function finishExport(keep) {
 }
 
 /* ═══════════════════════════ WIRING ═══════════════════════════ */
-$("btnImport").addEventListener("click", () => els.fileInput.click());
 els.fileInput.addEventListener("change", () => { importFiles(els.fileInput.files); els.fileInput.value = ""; });
 $("btnTitle").addEventListener("click", addTitle);
 $("btnAdjust").addEventListener("click", addAdjust);

--- a/index.html
+++ b/index.html
@@ -30,18 +30,18 @@
       <div class="panel-head">
         <span>Assets</span>
         <span class="panel-head-actions">
-          <button class="btn tiny" id="btnTitle" title="Add a title card at the playhead">+ Title</button>
-          <button class="btn tiny" id="btnAdjust" title="Add an adjustment layer (grades everything below it)">+ Adjust</button>
-          <button class="btn tiny accent" id="btnImport">+ Import</button>
+          <button type="button" class="btn tiny" id="btnTitle" title="Add a title card at the playhead">+ Title</button>
+          <button type="button" class="btn tiny" id="btnAdjust" title="Add an adjustment layer (grades everything below it)">+ Adjust</button>
+          <label class="btn tiny accent" id="btnImport" for="fileInput" title="Import media files">+ Import</label>
         </span>
       </div>
       <div class="bin-tabs" id="binTabs">
-        <button data-tab="project" class="on" title="Media used by this project">Project</button>
-        <button data-tab="elements" title="Overlay art from library/elements">Elements</button>
-        <button data-tab="sfx" title="Sound effects from library/sfx">Sound FX</button>
-        <button data-tab="svg" title="Vector animations from library/svg">SVG</button>
+        <button type="button" data-tab="project" class="on" title="Media used by this project">Project</button>
+        <button type="button" data-tab="elements" title="Overlay art from library/elements">Elements</button>
+        <button type="button" data-tab="sfx" title="Sound effects from library/sfx">Sound FX</button>
+        <button type="button" data-tab="svg" title="Vector animations from library/svg">SVG</button>
       </div>
-      <input type="file" id="fileInput" multiple accept="video/*,audio/*,image/*" hidden>
+      <input type="file" id="fileInput" class="sr-only" multiple accept="video/*,audio/*,image/*,.mp4,.mov,.webm,.mkv,.mp3,.wav,.m4a,.png,.jpg,.jpeg,.gif,.webp,.svg">
       <div class="bin-list" id="binList">
         <div class="bin-empty" id="binEmpty">
           <div class="bin-empty-icon">🎬</div>
@@ -153,7 +153,8 @@
       <tr><td><kbd>S</kbd></td><td>Split clip(s) at playhead</td></tr>
       <tr><td><kbd>Del</kbd></td><td>Delete selected clip(s)</td></tr>
       <tr><td>Drag empty area</td><td>Marquee-select clips (drag a box around them)</td></tr>
-      <tr><td><kbd>Ctrl</kbd>+click</td><td>Add / remove a clip from the selection</td></tr>
+      <tr><td><kbd>Ctrl</kbd>+click bin</td><td>Import media files</td></tr>
+      <tr><td><kbd>Ctrl</kbd>+click clip</td><td>Add / remove a clip from the selection</td></tr>
       <tr><td><kbd>Ctrl</kbd>+<kbd>A</kbd> / <kbd>Esc</kbd></td><td>Select all clips / deselect</td></tr>
       <tr><td><kbd>←</kbd> <kbd>→</kbd></td><td>Step 1 frame (⇧ = 1 second)</td></tr>
       <tr><td><kbd>[</kbd> / <kbd>]</kbd></td><td>Trim selected clip's in / out to playhead</td></tr>

--- a/style.css
+++ b/style.css
@@ -24,6 +24,11 @@ body {
 .hidden { display: none !important; }
 .dim { color: var(--dim); }
 .flex-spacer { flex: 1; }
+/* Visually hidden but still activatable (file picker via <label for>) */
+.sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}
 
 /* ── Top bar ── */
 .topbar {
@@ -42,7 +47,7 @@ body {
 
 /* ── Buttons ── */
 .btn {
-  background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+  display: inline-block; background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
   border-radius: 6px; padding: 6px 12px; font: inherit; cursor: pointer; white-space: nowrap;
 }
 .btn:hover { background: #2c2c34; border-color: #3c3c46; }
@@ -63,8 +68,9 @@ body {
   padding: 7px 10px; font-size: 12px; font-weight: 600; letter-spacing: .4px;
   color: var(--dim); text-transform: uppercase; border-bottom: 1px solid var(--border);
 }
-.panel-head-actions { display: flex; gap: 6px; text-transform: none; }
-.upper { display: grid; grid-template-columns: 250px minmax(0,1fr) 280px; gap: 6px; min-height: 0; }
+.panel-head-actions { display: flex; gap: 6px; text-transform: none; flex-wrap: wrap; justify-content: flex-end; }
+.upper { display: grid; grid-template-columns: 280px minmax(0,1fr) 280px; gap: 6px; min-height: 0; }
+.panel.bin { z-index: 1; } /* keep overflowing head buttons above the monitor */
 
 /* ── Media bin ── */
 .bin-tabs { display: flex; gap: 2px; padding: 6px 8px 0; border-bottom: 1px solid var(--border); }


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

Enables Ctrl + Click to import media

Closes #

## Type of change

- [X] Bug fix
- [ ] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved media importing with broader file-type support, including SVG, video, audio, and image files.
  - Added Ctrl/Cmd-click on the project bin to open the native file importer.
  - Added notifications when files are skipped or none can be imported.
  - Updated help guidance for importing and multi-selecting clips.

- **Accessibility & UI**
  - Improved keyboard-accessible import controls.
  - Refined panel layouts, button styling, and bin controls for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->