### PR TITLE
feat: use multiple clips for 'zoom to selection' ('z')

### DIFF
--- a/app.js
+++ b/app.js
@@ -1219,17 +1219,20 @@ function zoomToFit() {
   setZoom(w / span);
   els.timelineScroll.scrollLeft = 0;
 }
-/* Zoom so the primary selected clip fills 90% of the timeline width and is centered. */
+/* Zoom so the selection fills 90% of the timeline width and is centered.
+   One clip → that clip; multiple → the time range covering all of them. */
 function zoomToSelection() {
-  const c = getClip(state.selId) || selectedClips()[0];
-  if (!c) { toast("Select a clip to zoom to"); return; }
+  const clips = selectedClips();
+  if (!clips.length) { toast("Select a clip to zoom to"); return; }
+  const t0 = Math.min(...clips.map((c) => c.start));
+  const t1 = Math.max(...clips.map((c) => c.start + c.duration));
+  const dur = Math.max(t1 - t0, MIN_DUR);
   const w = els.timelineScroll.clientWidth || 800;
-  const dur = Math.max(c.duration, MIN_DUR);
   const pps = clamp((0.9 * w) / dur, ZOOM_MIN, ZOOM_MAX);
   state.pps = pps;
   els.zoomSlider.value = pps;
   rebuildClips();
-  const center = c.start + c.duration / 2;
+  const center = (t0 + t1) / 2;
   const maxScroll = Math.max(0, contentWidth() - w);
   els.timelineScroll.scrollLeft = clamp(center * pps - w / 2, 0, maxScroll);
 }

--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
       <tr><td><kbd>M</kbd></td><td>Add / remove marker at playhead (tap on the beat while playing)</td></tr>
       <tr><td><kbd>N</kbd></td><td>Toggle snapping</td></tr>
       <tr><td><kbd>+</kbd> / <kbd>-</kbd></td><td>Zoom timeline</td></tr>
-      <tr><td><kbd>Z</kbd></td><td>Zoom to selected clip</td></tr>
+      <tr><td><kbd>Z</kbd></td><td>Zoom to selected clip(s)</td></tr>
       <tr><td><kbd>⇧</kbd>+<kbd>Z</kbd></td><td>Zoom timeline to fit</td></tr>
       <tr><td><kbd>Ctrl</kbd>+<kbd>Z</kbd> / <kbd>Ctrl</kbd>+<kbd>⇧</kbd>+<kbd>Z</kbd></td><td>Undo / redo</td></tr>
       <tr><td><kbd>Ctrl</kbd>+wheel</td><td>Zoom timeline at cursor</td></tr>


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

'Zoom to selection' invoked by a shortcut 'z' now uses multiple selected clips.
Closes #

## Type of change

- [ ] Bug fix
- [X] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Zooming to a selection now frames the full time span of all selected clips and centers the timeline accordingly.

- **Documentation**
  - Updated the keyboard shortcut help text to clarify that the `Z` key zooms to selected clips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->