### PR TITLE
Resizeable panels

### DIFF
--- a/app.js
+++ b/app.js
@@ -2842,6 +2842,12 @@ function setTimelineHeight(px) {
   state.dirtyTimeline = true;
   return h;
 }
+function resetTimelineHeight() {
+  const h = setTimelineHeight(window.innerHeight * 0.32);
+  localStorage.removeItem(TL_H_KEY);
+  state.dirtyTimeline = true;
+  return h;
+}
 function clampTimelineHeight() {
   const cur = $("timelinePanel")?.getBoundingClientRect().height;
   if (cur) setTimelineHeight(cur);
@@ -2852,7 +2858,7 @@ function initPanelSplit() {
   if (!handle || !tl) return;
   const saved = parseFloat(localStorage.getItem(TL_H_KEY));
   if (saved > 0) setTimelineHeight(saved);
-  else setTimelineHeight(tl.getBoundingClientRect().height || window.innerHeight * 0.32);
+  else resetTimelineHeight();
 
   handle.addEventListener("pointerdown", (e) => {
     if (e.button !== 0) return;
@@ -2874,6 +2880,10 @@ function initPanelSplit() {
     };
     handle.addEventListener("pointermove", onMove);
     handle.addEventListener("pointerup", onUp);
+  });
+  handle.addEventListener("dblclick", (e) => {
+    e.preventDefault();
+    resetTimelineHeight();
   });
 }
 

--- a/app.js
+++ b/app.js
@@ -2822,9 +2822,63 @@ window.addEventListener("keydown", (e) => {
   else if ((e.ctrlKey || e.metaKey) && (k === "y" || k === "Y")) { e.preventDefault(); redo(); }
 });
 
-window.addEventListener("resize", () => { state.dirtyTimeline = true; });
+window.addEventListener("resize", () => { state.dirtyTimeline = true; clampTimelineHeight(); });
+
+/* ── Resizable upper / timeline split ── */
+const TL_H_KEY = "fablecut-timeline-h";
+const TL_H_MIN = 180;
+const UPPER_MIN = 140;
+function availableTimelineMax() {
+  const app = $("app").getBoundingClientRect();
+  const topbar = document.querySelector(".topbar")?.getBoundingClientRect();
+  const topbarH = topbar ? topbar.height : 46;
+  const split = 6;
+  const gaps = 18; // three 6px flex gaps between four children
+  return Math.floor(app.height - topbarH - UPPER_MIN - split - gaps);
+}
+function setTimelineHeight(px) {
+  const h = clamp(Math.round(px), TL_H_MIN, Math.max(TL_H_MIN, availableTimelineMax()));
+  $("app").style.setProperty("--timeline-h", h + "px");
+  state.dirtyTimeline = true;
+  return h;
+}
+function clampTimelineHeight() {
+  const cur = $("timelinePanel")?.getBoundingClientRect().height;
+  if (cur) setTimelineHeight(cur);
+}
+function initPanelSplit() {
+  const handle = $("splitUpperTimeline");
+  const tl = $("timelinePanel");
+  if (!handle || !tl) return;
+  const saved = parseFloat(localStorage.getItem(TL_H_KEY));
+  if (saved > 0) setTimelineHeight(saved);
+  else setTimelineHeight(tl.getBoundingClientRect().height || window.innerHeight * 0.32);
+
+  handle.addEventListener("pointerdown", (e) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    handle.setPointerCapture(e.pointerId);
+    handle.classList.add("dragging");
+    document.body.classList.add("resizing-panels");
+    const y0 = e.clientY;
+    const h0 = tl.getBoundingClientRect().height;
+    const onMove = (ev) => setTimelineHeight(h0 - (ev.clientY - y0));
+    const onUp = () => {
+      handle.releasePointerCapture(e.pointerId);
+      handle.classList.remove("dragging");
+      document.body.classList.remove("resizing-panels");
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onUp);
+      localStorage.setItem(TL_H_KEY, String(Math.round(tl.getBoundingClientRect().height)));
+      state.dirtyTimeline = true;
+    };
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onUp);
+  });
+}
 
 /* ── Boot ── */
+initPanelSplit();
 buildTrackDOM();
 rebuildClips();
 renderBin();

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
     </aside>
   </div>
 
-  <div class="v-split" id="splitUpperTimeline" role="separator" aria-orientation="horizontal" title="Drag to resize"></div>
+  <div class="v-split" id="splitUpperTimeline" role="separator" aria-orientation="horizontal" title="Drag to resize · double-click to reset"></div>
 
   <!-- ══════════ TIMELINE ══════════ -->
   <section class="panel timeline-panel" id="timelinePanel">

--- a/index.html
+++ b/index.html
@@ -92,8 +92,10 @@
     </aside>
   </div>
 
+  <div class="v-split" id="splitUpperTimeline" role="separator" aria-orientation="horizontal" title="Drag to resize"></div>
+
   <!-- ══════════ TIMELINE ══════════ -->
-  <section class="panel timeline-panel">
+  <section class="panel timeline-panel" id="timelinePanel">
     <div class="timeline-toolbar">
       <button class="btn tiny" id="btnSplit" title="Split at playhead (S)">✂ Split</button>
       <button class="btn tiny" id="btnDelete" title="Delete selected (Del)">🗑 Delete</button>

--- a/style.css
+++ b/style.css
@@ -20,7 +20,25 @@ body {
   color: var(--text);
   font: 13px/1.45 "Segoe UI", system-ui, -apple-system, sans-serif;
 }
-.app { display: grid; grid-template-rows: 46px minmax(0, 1fr) minmax(230px, 38%); height: 100vh; gap: 6px; padding: 6px; }
+.app {
+  display: flex; flex-direction: column; height: 100vh; gap: 6px; padding: 6px;
+}
+.topbar { flex: 0 0 46px; }
+.upper { flex: 1 1 0; min-height: 140px; min-width: 0; }
+.timeline-panel {
+  flex: 0 0 var(--timeline-h, 32vh); min-height: 180px; overflow: hidden;
+}
+.v-split {
+  flex: 0 0 6px; cursor: ns-resize; position: relative; z-index: 5;
+  border-radius: 3px;
+}
+.v-split::after {
+  content: ""; position: absolute; left: 18%; right: 18%; top: 2px; height: 2px;
+  border-radius: 1px; background: var(--border); transition: background .15s;
+}
+.v-split:hover::after, .v-split.dragging::after { background: var(--accent); }
+body.resizing-panels { cursor: ns-resize !important; }
+body.resizing-panels * { cursor: ns-resize !important; user-select: none !important; }
 .hidden { display: none !important; }
 .dim { color: var(--dim); }
 .flex-spacer { flex: 1; }
@@ -167,7 +185,6 @@ input[type=range] { accent-color: var(--accent); height: 18px; }
 .kf-btn.has { color: #ffd166; border-color: #ffd16666; }
 
 /* ── Timeline ── */
-.timeline-panel { overflow: hidden; }
 .timeline-toolbar { display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-bottom: 1px solid var(--border); }
 .tiny-label { font-size: 11px; }
 #zoomSlider { width: 130px; }


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

Make monitor/timeline panes resizeable. There is a handle between panes that allows to resize, double click restores the default layout

Closes #

## Type of change

- [ ] Bug fix
- [X] New feature (GUI)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a draggable divider between the upper panels and timeline.
  * Timeline height now adjusts within valid limits as the window resizes.
  * Double-clicking the divider resets the split.
  * The selected timeline height is saved and restored automatically.
  * Added accessibility semantics and interaction guidance for the resize control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->