### PR TITLE
Layout switcher

### DIFF
--- a/app.js
+++ b/app.js
@@ -2842,6 +2842,12 @@ function setTimelineHeight(px) {
   state.dirtyTimeline = true;
   return h;
 }
+function resetTimelineHeight() {
+  const h = setTimelineHeight(window.innerHeight * 0.32);
+  localStorage.removeItem(TL_H_KEY);
+  state.dirtyTimeline = true;
+  return h;
+}
 function clampTimelineHeight() {
   const cur = $("timelinePanel")?.getBoundingClientRect().height;
   if (cur) setTimelineHeight(cur);
@@ -2852,7 +2858,7 @@ function initPanelSplit() {
   if (!handle || !tl) return;
   const saved = parseFloat(localStorage.getItem(TL_H_KEY));
   if (saved > 0) setTimelineHeight(saved);
-  else setTimelineHeight(tl.getBoundingClientRect().height || window.innerHeight * 0.32);
+  else resetTimelineHeight();
 
   handle.addEventListener("pointerdown", (e) => {
     if (e.button !== 0) return;
@@ -2874,6 +2880,10 @@ function initPanelSplit() {
     };
     handle.addEventListener("pointermove", onMove);
     handle.addEventListener("pointerup", onUp);
+  });
+  handle.addEventListener("dblclick", (e) => {
+    e.preventDefault();
+    resetTimelineHeight();
   });
 }
 

--- a/app.js
+++ b/app.js
@@ -16,6 +16,14 @@ const TRACKS = [
   { id: "A2", kind: "audio", h: 42, color: "#5a9e3a" },
   { id: "A3", kind: "audio", h: 42, color: "#4a8a2f" },
 ];
+/* Three timeline density presets. L matches the original track heights (with thumbs).
+   S is compact solid-color rows; M is in between. */
+const TRACK_SIZE_PRESETS = {
+  s: { thumbs: false, h: { V4: 26, V3: 26, V2: 26, V1: 26, A1: 22, A2: 22, A3: 22 } },
+  m: { thumbs: true,  h: { V4: 36, V3: 36, V2: 44, V1: 44, A1: 32, A2: 32, A3: 32 } },
+  l: { thumbs: true,  h: { V4: 44, V3: 44, V2: 58, V1: 58, A1: 42, A2: 42, A3: 42 } },
+};
+const TRACK_SIZE_KEY = "fablecut-track-size";
 const RULER_H = 26;
 const SNAP_PX = 8;
 const MIN_DUR = 0.05;
@@ -128,6 +136,7 @@ const state = {
   time: 0, playing: false, pps: 60, snap: true,
   selId: null,           // primary selection (drives the inspector)
   selIds: new Set(),     // full multi-selection (includes selId)
+  trackSize: "l",        // s | m | l — timeline track density preset
   connected: false, exporting: false,
   rendering: false,      // fast (server/ffmpeg) export in progress
   guides: false,         // safe-area overlay on the monitor
@@ -834,7 +843,7 @@ function rebuildClips() {
     div.style.left = c.start * state.pps + "px";
     div.style.width = Math.max(8, c.duration * state.pps) + "px";
     let inner = "";
-    if (c.kind === "video") {
+    if (c.kind === "video" && trackSizeShowsThumbs()) {
       const thumb = runtime.mediaAux.get(c.mediaId)?.thumb;
       if (thumb) inner += `<div class="thumbs" style="background-image:url('${thumb}')"></div>`;
     }
@@ -2751,6 +2760,11 @@ els.btnSnap.addEventListener("click", () => {
   state.snap = !state.snap;
   els.btnSnap.classList.toggle("on", state.snap);
 });
+$("btnLayoutReset").addEventListener("click", restoreDefaultLayout);
+$("trackSizeGroup").addEventListener("click", (e) => {
+  const b = e.target.closest("[data-track-size]");
+  if (b) setTrackSize(b.dataset.trackSize);
+});
 els.binTabs.addEventListener("click", (e) => {
   const b = e.target.closest("[data-tab]");
   if (b) setBinTab(b.dataset.tab);
@@ -2842,11 +2856,56 @@ function setTimelineHeight(px) {
   state.dirtyTimeline = true;
   return h;
 }
+/* Tall enough for the toolbar + ruler + every track row (no vertical overflow). */
+function defaultTimelineHeight() {
+  const tracksH = TRACKS.reduce((s, t) => s + t.h, 0);
+  const toolbar = document.querySelector(".timeline-toolbar");
+  const toolbarH = toolbar ? toolbar.getBoundingClientRect().height : 40;
+  return tracksH + RULER_H + toolbarH + 8;
+}
 function resetTimelineHeight() {
-  const h = setTimelineHeight(window.innerHeight * 0.32);
+  const h = setTimelineHeight(defaultTimelineHeight());
   localStorage.removeItem(TL_H_KEY);
   state.dirtyTimeline = true;
   return h;
+}
+function trackSizeShowsThumbs() {
+  return !!(TRACK_SIZE_PRESETS[state.trackSize] || TRACK_SIZE_PRESETS.l).thumbs;
+}
+function syncTrackSizeButtons() {
+  const group = $("trackSizeGroup");
+  if (!group) return;
+  for (const b of group.querySelectorAll("[data-track-size]"))
+    b.classList.toggle("on", b.dataset.trackSize === state.trackSize);
+  document.body.classList.toggle("track-size-s", state.trackSize === "s");
+  document.body.classList.toggle("track-size-m", state.trackSize === "m");
+  document.body.classList.toggle("track-size-l", state.trackSize === "l");
+}
+function applyTrackHeights() {
+  const preset = TRACK_SIZE_PRESETS[state.trackSize] || TRACK_SIZE_PRESETS.l;
+  for (const t of TRACKS) {
+    if (preset.h[t.id] != null) t.h = preset.h[t.id];
+  }
+}
+/* Switch S/M/L track density, rebuild the timeline, and grow/shrink the pane
+   so every track fits without a vertical scrollbar. */
+function setTrackSize(size, { persist = true, fitPane = true } = {}) {
+  if (!TRACK_SIZE_PRESETS[size]) size = "l";
+  state.trackSize = size;
+  applyTrackHeights();
+  if (persist) localStorage.setItem(TRACK_SIZE_KEY, size);
+  syncTrackSizeButtons();
+  buildTrackDOM();
+  state.dirtyTimeline = true;
+  rebuildClips();
+  if (fitPane) {
+    const h = setTimelineHeight(defaultTimelineHeight());
+    localStorage.setItem(TL_H_KEY, String(h));
+  }
+}
+function restoreDefaultLayout() {
+  setTrackSize("l", { persist: true, fitPane: false });
+  resetTimelineHeight();
 }
 function clampTimelineHeight() {
   const cur = $("timelinePanel")?.getBoundingClientRect().height;
@@ -2856,6 +2915,11 @@ function initPanelSplit() {
   const handle = $("splitUpperTimeline");
   const tl = $("timelinePanel");
   if (!handle || !tl) return;
+  const savedSize = localStorage.getItem(TRACK_SIZE_KEY);
+  if (TRACK_SIZE_PRESETS[savedSize]) state.trackSize = savedSize;
+  applyTrackHeights();
+  syncTrackSizeButtons();
+
   const saved = parseFloat(localStorage.getItem(TL_H_KEY));
   if (saved > 0) setTimelineHeight(saved);
   else resetTimelineHeight();

--- a/app.js
+++ b/app.js
@@ -2822,9 +2822,63 @@ window.addEventListener("keydown", (e) => {
   else if ((e.ctrlKey || e.metaKey) && (k === "y" || k === "Y")) { e.preventDefault(); redo(); }
 });
 
-window.addEventListener("resize", () => { state.dirtyTimeline = true; });
+window.addEventListener("resize", () => { state.dirtyTimeline = true; clampTimelineHeight(); });
+
+/* ── Resizable upper / timeline split ── */
+const TL_H_KEY = "fablecut-timeline-h";
+const TL_H_MIN = 180;
+const UPPER_MIN = 140;
+function availableTimelineMax() {
+  const app = $("app").getBoundingClientRect();
+  const topbar = document.querySelector(".topbar")?.getBoundingClientRect();
+  const topbarH = topbar ? topbar.height : 46;
+  const split = 6;
+  const gaps = 18; // three 6px flex gaps between four children
+  return Math.floor(app.height - topbarH - UPPER_MIN - split - gaps);
+}
+function setTimelineHeight(px) {
+  const h = clamp(Math.round(px), TL_H_MIN, Math.max(TL_H_MIN, availableTimelineMax()));
+  $("app").style.setProperty("--timeline-h", h + "px");
+  state.dirtyTimeline = true;
+  return h;
+}
+function clampTimelineHeight() {
+  const cur = $("timelinePanel")?.getBoundingClientRect().height;
+  if (cur) setTimelineHeight(cur);
+}
+function initPanelSplit() {
+  const handle = $("splitUpperTimeline");
+  const tl = $("timelinePanel");
+  if (!handle || !tl) return;
+  const saved = parseFloat(localStorage.getItem(TL_H_KEY));
+  if (saved > 0) setTimelineHeight(saved);
+  else setTimelineHeight(tl.getBoundingClientRect().height || window.innerHeight * 0.32);
+
+  handle.addEventListener("pointerdown", (e) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    handle.setPointerCapture(e.pointerId);
+    handle.classList.add("dragging");
+    document.body.classList.add("resizing-panels");
+    const y0 = e.clientY;
+    const h0 = tl.getBoundingClientRect().height;
+    const onMove = (ev) => setTimelineHeight(h0 - (ev.clientY - y0));
+    const onUp = () => {
+      handle.releasePointerCapture(e.pointerId);
+      handle.classList.remove("dragging");
+      document.body.classList.remove("resizing-panels");
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onUp);
+      localStorage.setItem(TL_H_KEY, String(Math.round(tl.getBoundingClientRect().height)));
+      state.dirtyTimeline = true;
+    };
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onUp);
+  });
+}
 
 /* ── Boot ── */
+initPanelSplit();
 buildTrackDOM();
 rebuildClips();
 renderBin();

--- a/index.html
+++ b/index.html
@@ -17,6 +17,14 @@
     <div class="logo"><span class="logo-mark">▶</span> Fable<b>Cut</b></div>
     <div class="topbar-center" id="projectName">Untitled Project</div>
     <div class="topbar-right">
+      <span class="layout-tools">
+        <button type="button" class="btn tiny" id="btnLayoutReset" title="Restore default layout">⊡ Layout</button>
+        <span class="btn-group" id="trackSizeGroup" title="Timeline track height">
+          <button type="button" class="btn tiny" data-track-size="s" title="Compact tracks (no thumbnails)">S</button>
+          <button type="button" class="btn tiny" data-track-size="m" title="Medium tracks">M</button>
+          <button type="button" class="btn tiny" data-track-size="l" title="Large tracks">L</button>
+        </span>
+      </span>
       <button class="btn ghost" id="btnHelp" title="Keyboard shortcuts">?</button>
       <button class="btn primary" id="btnExport">⬇ Export</button>
     </div>

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
     </aside>
   </div>
 
-  <div class="v-split" id="splitUpperTimeline" role="separator" aria-orientation="horizontal" title="Drag to resize"></div>
+  <div class="v-split" id="splitUpperTimeline" role="separator" aria-orientation="horizontal" title="Drag to resize · double-click to reset"></div>
 
   <!-- ══════════ TIMELINE ══════════ -->
   <section class="panel timeline-panel" id="timelinePanel">

--- a/index.html
+++ b/index.html
@@ -92,8 +92,10 @@
     </aside>
   </div>
 
+  <div class="v-split" id="splitUpperTimeline" role="separator" aria-orientation="horizontal" title="Drag to resize"></div>
+
   <!-- ══════════ TIMELINE ══════════ -->
-  <section class="panel timeline-panel">
+  <section class="panel timeline-panel" id="timelinePanel">
     <div class="timeline-toolbar">
       <button class="btn tiny" id="btnSplit" title="Split at playhead (S)">✂ Split</button>
       <button class="btn tiny" id="btnDelete" title="Delete selected (Del)">🗑 Delete</button>

--- a/style.css
+++ b/style.css
@@ -20,7 +20,25 @@ body {
   color: var(--text);
   font: 13px/1.45 "Segoe UI", system-ui, -apple-system, sans-serif;
 }
-.app { display: grid; grid-template-rows: 46px minmax(0, 1fr) minmax(230px, 38%); height: 100vh; gap: 6px; padding: 6px; }
+.app {
+  display: flex; flex-direction: column; height: 100vh; gap: 6px; padding: 6px;
+}
+.topbar { flex: 0 0 46px; }
+.upper { flex: 1 1 0; min-height: 140px; min-width: 0; }
+.timeline-panel {
+  flex: 0 0 var(--timeline-h, 32vh); min-height: 180px; overflow: hidden;
+}
+.v-split {
+  flex: 0 0 6px; cursor: ns-resize; position: relative; z-index: 5;
+  border-radius: 3px;
+}
+.v-split::after {
+  content: ""; position: absolute; left: 18%; right: 18%; top: 2px; height: 2px;
+  border-radius: 1px; background: var(--border); transition: background .15s;
+}
+.v-split:hover::after, .v-split.dragging::after { background: var(--accent); }
+body.resizing-panels { cursor: ns-resize !important; }
+body.resizing-panels * { cursor: ns-resize !important; user-select: none !important; }
 .hidden { display: none !important; }
 .dim { color: var(--dim); }
 .flex-spacer { flex: 1; }
@@ -167,7 +185,6 @@ input[type=range] { accent-color: var(--accent); height: 18px; }
 .kf-btn.has { color: #ffd166; border-color: #ffd16666; }
 
 /* ── Timeline ── */
-.timeline-panel { overflow: hidden; }
 .timeline-toolbar { display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-bottom: 1px solid var(--border); }
 .tiny-label { font-size: 11px; }
 #zoomSlider { width: 130px; }

--- a/style.css
+++ b/style.css
@@ -13,288 +13,1115 @@
   --track-h-video: 58px;
   --track-h-audio: 42px;
 }
-* { box-sizing: border-box; margin: 0; padding: 0; user-select: none; }
-html, body { height: 100%; overflow: hidden; }
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  user-select: none;
+}
+
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   background: var(--bg);
   color: var(--text);
   font: 13px/1.45 "Segoe UI", system-ui, -apple-system, sans-serif;
 }
+
 .app {
-  display: flex; flex-direction: column; height: 100vh; gap: 6px; padding: 6px;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  gap: 6px;
+  padding: 6px;
 }
-.topbar { flex: 0 0 46px; }
-.upper { flex: 1 1 0; min-height: 140px; min-width: 0; }
+
+.topbar {
+  flex: 0 0 46px;
+}
+
+.upper {
+  flex: 1 1 0;
+  min-height: 140px;
+  min-width: 0;
+}
+
 .timeline-panel {
-  flex: 0 0 var(--timeline-h, 32vh); min-height: 180px; overflow: hidden;
+  flex: 0 0 var(--timeline-h, 400px);
+  min-height: 180px;
+  overflow: hidden;
 }
+
 .v-split {
-  flex: 0 0 6px; cursor: ns-resize; position: relative; z-index: 5;
+  flex: 0 0 6px;
+  cursor: ns-resize;
+  position: relative;
+  z-index: 5;
   border-radius: 3px;
 }
+
 .v-split::after {
-  content: ""; position: absolute; left: 18%; right: 18%; top: 2px; height: 2px;
-  border-radius: 1px; background: var(--border); transition: background .15s;
+  content: "";
+  position: absolute;
+  left: 18%;
+  right: 18%;
+  top: 2px;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--border);
+  transition: background .15s;
 }
-.v-split:hover::after, .v-split.dragging::after { background: var(--accent); }
-body.resizing-panels { cursor: ns-resize !important; }
-body.resizing-panels * { cursor: ns-resize !important; user-select: none !important; }
-.hidden { display: none !important; }
-.dim { color: var(--dim); }
-.flex-spacer { flex: 1; }
+
+.v-split:hover::after,
+.v-split.dragging::after {
+  background: var(--accent);
+}
+
+body.resizing-panels {
+  cursor: ns-resize !important;
+}
+
+body.resizing-panels * {
+  cursor: ns-resize !important;
+  user-select: none !important;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.dim {
+  color: var(--dim);
+}
+
+.flex-spacer {
+  flex: 1;
+}
+
 /* Visually hidden but still activatable (file picker via <label for>) */
 .sr-only {
-  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
-  overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* ── Top bar ── */
 .topbar {
-  display: flex; align-items: center; gap: 12px; padding: 0 12px;
-  background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
 }
-.logo { font-size: 15px; letter-spacing: .3px; color: #fff; }
-.logo b { color: var(--accent); }
+
+.logo {
+  font-size: 15px;
+  letter-spacing: .3px;
+  color: #fff;
+}
+
+.logo b {
+  color: var(--accent);
+}
+
 .logo-mark {
-  display: inline-flex; width: 22px; height: 22px; border-radius: 6px; margin-right: 6px;
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  margin-right: 6px;
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
-  color: #fff; font-size: 10px; align-items: center; justify-content: center; vertical-align: -5px;
+  color: #fff;
+  font-size: 10px;
+  align-items: center;
+  justify-content: center;
+  vertical-align: -5px;
 }
-.topbar-center { flex: 1; text-align: center; color: var(--dim); }
-.topbar-right { display: flex; gap: 8px; }
+
+.topbar-center {
+  flex: 1;
+  text-align: center;
+  color: var(--dim);
+}
+
+.topbar-right {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.layout-tools {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-right: 4px;
+}
+
+.btn-group {
+  display: inline-flex;
+  gap: 0px;
+}
+
+.btn-group .btn:first-child {
+  border-radius: 5px 0 0 5px;
+}
+
+.btn-group .btn:not(:first-child):not(:last-child) {
+  border-radius: 0;
+  margin: 0;
+}
+
+.btn-group .btn:last-child {
+  border-radius: 0 5px 5px 0;
+}
+
+.btn-group .btn.on {
+  border-color: var(--accent);
+  z-index: 1;
+}
+
+body.track-size-s .clip .clip-label {
+  font-size: 10px;
+  padding: 1px 6px;
+}
+
+body.track-size-s .clip .fade {
+  display: none;
+}
+
+body.track-size-s .clip.c-audio::after {
+  height: 12px;
+}
+
+body.track-size-s .clip {
+  border-width: 1px;
+  border-radius: 2px;
+  box-shadow: none;
+}
+
+body.track-size-s .clip .handle.l { border-left-width: 1px; }
+body.track-size-s .clip .handle.r { border-right-width: 1px; }
+
+body.track-size-s .clip.selected {
+  outline-width: 1px;
+  box-shadow: 0 0 0 1px #7b6cff55;
+}
 
 /* ── Buttons ── */
 .btn {
-  display: inline-block; background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
-  border-radius: 6px; padding: 6px 12px; font: inherit; cursor: pointer; white-space: nowrap;
+  display: inline-block;
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font: inherit;
+  cursor: pointer;
+  white-space: nowrap;
 }
-.btn:hover { background: #2c2c34; border-color: #3c3c46; }
-.btn:active { transform: translateY(1px); }
-.btn.primary { background: linear-gradient(135deg, var(--accent), var(--accent-2)); border: none; color: #fff; font-weight: 600; }
-.btn.primary:hover { filter: brightness(1.12); }
-.btn.ghost { background: transparent; }
-.btn.tiny { padding: 3px 9px; font-size: 12px; border-radius: 5px; }
-.btn.tiny.accent { border-color: var(--accent); color: #cfc8ff; }
-.btn.icon { width: 34px; padding: 6px 0; text-align: center; }
-.btn.icon.big { width: 44px; font-size: 15px; }
-.btn.toggle.on { border-color: var(--accent); color: #cfc8ff; background: #7b6cff1a; }
+
+.btn:hover {
+  background: #2c2c34;
+  border-color: #3c3c46;
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  border: none;
+  color: #fff;
+  font-weight: 600;
+}
+
+.btn.primary:hover {
+  filter: brightness(1.12);
+}
+
+.btn.ghost {
+  background: transparent;
+}
+
+.btn.tiny {
+  padding: 3px 9px;
+  font-size: 12px;
+  border-radius: 5px;
+}
+
+.btn.tiny.accent {
+  border-color: var(--accent);
+  color: #cfc8ff;
+}
+
+.btn.icon {
+  width: 34px;
+  padding: 6px 0;
+  text-align: center;
+}
+
+.btn.icon.big {
+  width: 44px;
+  font-size: 15px;
+}
+
+.btn.toggle.on {
+  border-color: var(--accent);
+  color: #cfc8ff;
+  background: #7b6cff1a;
+}
 
 /* ── Panels ── */
-.panel { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; display: flex; flex-direction: column; min-height: 0; min-width: 0; }
-.panel-head {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 7px 10px; font-size: 12px; font-weight: 600; letter-spacing: .4px;
-  color: var(--dim); text-transform: uppercase; border-bottom: 1px solid var(--border);
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
 }
-.panel-head-actions { display: flex; gap: 6px; text-transform: none; flex-wrap: wrap; justify-content: flex-end; }
-.upper { display: grid; grid-template-columns: 280px minmax(0,1fr) 280px; gap: 6px; min-height: 0; }
-.panel.bin { z-index: 1; } /* keep overflowing head buttons above the monitor */
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .4px;
+  color: var(--dim);
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--border);
+}
+
+.panel-head-actions {
+  display: flex;
+  gap: 6px;
+  text-transform: none;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.upper {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr) 280px;
+  gap: 6px;
+  min-height: 0;
+}
+
+.panel.bin {
+  z-index: 1;
+}
+
+/* keep overflowing head buttons above the monitor */
 
 /* ── Media bin ── */
-.bin-tabs { display: flex; gap: 2px; padding: 6px 8px 0; border-bottom: 1px solid var(--border); }
+.bin-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 6px 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+
 .bin-tabs button {
-  flex: 1; background: none; border: none; border-bottom: 2px solid transparent;
-  color: var(--dim); font: 600 11px/1.2 "Segoe UI", sans-serif; padding: 5px 2px 7px;
-  cursor: pointer; letter-spacing: .2px; white-space: nowrap;
+  flex: 1;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--dim);
+  font: 600 11px/1.2 "Segoe UI", sans-serif;
+  padding: 5px 2px 7px;
+  cursor: pointer;
+  letter-spacing: .2px;
+  white-space: nowrap;
 }
-.bin-tabs button:hover { color: var(--text); }
-.bin-tabs button.on { color: #cfc8ff; border-bottom-color: var(--accent); }
-.bin-list { flex: 1; overflow-y: auto; padding: 8px; display: flex; flex-direction: column; gap: 6px; }
-.lib-item .lib-play, .lib-item .lib-add { flex: none; width: 26px; padding: 3px 0; text-align: center; }
-.bin-thumb.svg { background-color: #2a2a33; background-size: contain; background-repeat: no-repeat; background-position: center; }
-.bin-empty { margin: auto; text-align: center; color: var(--dim); padding: 20px 10px; }
-.bin-empty-icon { font-size: 34px; margin-bottom: 10px; opacity: .8; }
-.bin-empty .hint { margin-top: 8px; font-size: 11px; opacity: .7; }
+
+.bin-tabs button:hover {
+  color: var(--text);
+}
+
+.bin-tabs button.on {
+  color: #cfc8ff;
+  border-bottom-color: var(--accent);
+}
+
+.bin-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lib-item .lib-play,
+.lib-item .lib-add {
+  flex: none;
+  width: 26px;
+  padding: 3px 0;
+  text-align: center;
+}
+
+.bin-thumb.svg {
+  background-color: #2a2a33;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.bin-empty {
+  margin: auto;
+  text-align: center;
+  color: var(--dim);
+  padding: 20px 10px;
+}
+
+.bin-empty-icon {
+  font-size: 34px;
+  margin-bottom: 10px;
+  opacity: .8;
+}
+
+.bin-empty .hint {
+  margin-top: 8px;
+  font-size: 11px;
+  opacity: .7;
+}
+
 .bin-item {
-  display: flex; gap: 8px; align-items: center; padding: 6px; border-radius: 6px;
-  background: var(--panel-2); border: 1px solid var(--border); cursor: grab; position: relative;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 6px;
+  border-radius: 6px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  cursor: grab;
+  position: relative;
 }
-.bin-item:hover { border-color: #454552; }
-.bin-item:active { cursor: grabbing; }
+
+.bin-item:hover {
+  border-color: #454552;
+}
+
+.bin-item:active {
+  cursor: grabbing;
+}
+
 .bin-thumb {
-  width: 58px; height: 34px; border-radius: 4px; flex: none; background: #000 center/cover no-repeat;
-  display: flex; align-items: center; justify-content: center; font-size: 16px;
+  width: 58px;
+  height: 34px;
+  border-radius: 4px;
+  flex: none;
+  background: #000 center/cover no-repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
 }
-.bin-meta { min-width: 0; flex: 1; }
-.bin-name { font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #e8e8ee; }
-.bin-sub { font-size: 11px; color: var(--dim); }
-.bin-del { position: absolute; top: 2px; right: 4px; color: var(--dim); cursor: pointer; font-size: 12px; padding: 2px 4px; display: none; }
-.bin-item:hover .bin-del { display: block; }
-.bin-del:hover { color: var(--danger); }
+
+.bin-meta {
+  min-width: 0;
+  flex: 1;
+}
+
+.bin-name {
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #e8e8ee;
+}
+
+.bin-sub {
+  font-size: 11px;
+  color: var(--dim);
+}
+
+.bin-del {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  color: var(--dim);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 4px;
+  display: none;
+}
+
+.bin-item:hover .bin-del {
+  display: block;
+}
+
+.bin-del:hover {
+  color: var(--danger);
+}
 
 /* ── Monitor ── */
-.monitor-stage { flex: 1; display: flex; align-items: center; justify-content: center; background: #000; min-height: 0; margin: 8px; border-radius: 6px; overflow: hidden; position: relative; }
-#preview { max-width: 100%; max-height: 100%; display: block; background: #000; }
+.monitor-stage {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+  min-height: 0;
+  margin: 8px;
+  border-radius: 6px;
+  overflow: hidden;
+  position: relative;
+}
+
+#preview {
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+  background: #000;
+}
+
 .head-select {
-  background: var(--panel-2); border: 1px solid var(--border); color: var(--text);
-  border-radius: 5px; padding: 2px 6px; font: 12px "Segoe UI", sans-serif; max-width: 170px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 5px;
+  padding: 2px 6px;
+  font: 12px "Segoe UI", sans-serif;
+  max-width: 170px;
 }
 
 /* ── Safe-area guides (positioned over the canvas by JS) ── */
-#safeOverlay { position: absolute; pointer-events: none; z-index: 5; }
-#safeOverlay .sa-action { position: absolute; inset: 5%; border: 1px dashed #ffffff59; }
-#safeOverlay .sa-title { position: absolute; inset: 10%; border: 1px dashed #ffffff30; }
-#safeOverlay .sa-ui-bottom, #safeOverlay .sa-ui-right { display: none; }
+#safeOverlay {
+  position: absolute;
+  pointer-events: none;
+  z-index: 5;
+}
+
+#safeOverlay .sa-action {
+  position: absolute;
+  inset: 5%;
+  border: 1px dashed #ffffff59;
+}
+
+#safeOverlay .sa-title {
+  position: absolute;
+  inset: 10%;
+  border: 1px dashed #ffffff30;
+}
+
+#safeOverlay .sa-ui-bottom,
+#safeOverlay .sa-ui-right {
+  display: none;
+}
+
 #safeOverlay.vertical .sa-ui-bottom {
-  display: block; position: absolute; left: 0; right: 0; bottom: 0; height: 34%;
+  display: block;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 34%;
   background: repeating-linear-gradient(45deg, #ff4d6a14 0 8px, transparent 8px 16px);
   border-top: 1px dashed #ff4d6a80;
 }
+
 #safeOverlay.vertical .sa-ui-right {
-  display: block; position: absolute; top: 30%; right: 0; bottom: 0; width: 13%;
+  display: block;
+  position: absolute;
+  top: 30%;
+  right: 0;
+  bottom: 0;
+  width: 13%;
   background: repeating-linear-gradient(45deg, #ff4d6a14 0 8px, transparent 8px 16px);
   border-left: 1px dashed #ff4d6a80;
 }
-.transport { display: flex; align-items: center; justify-content: space-between; padding: 4px 14px 10px; gap: 12px; }
-.transport-btns { display: flex; gap: 6px; }
-.timecode { font: 600 14px/1 "Consolas", monospace; color: #b9b3ff; min-width: 86px; }
-.timecode.dim { color: var(--dim); text-align: right; }
+
+.transport {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 14px 10px;
+  gap: 12px;
+}
+
+.transport-btns {
+  display: flex;
+  gap: 6px;
+}
+
+.timecode {
+  font: 600 14px/1 "Consolas", monospace;
+  color: #b9b3ff;
+  min-width: 86px;
+}
+
+.timecode.dim {
+  color: var(--dim);
+  text-align: right;
+}
 
 /* ── Inspector ── */
-.inspector-body { flex: 1; overflow-y: auto; padding: 10px; }
-.inspector-empty { margin: auto; text-align: center; color: var(--dim); padding-top: 40px; }
+.inspector-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+}
+
+.inspector-empty {
+  margin: auto;
+  text-align: center;
+  color: var(--dim);
+  padding-top: 40px;
+}
+
 .insp-multi {
-  margin-bottom: 12px; padding: 7px 9px; border-radius: 6px; font-size: 11px;
-  color: #cfd0ff; background: #7b6cff1c; border: 1px solid #7b6cff44;
+  margin-bottom: 12px;
+  padding: 7px 9px;
+  border-radius: 6px;
+  font-size: 11px;
+  color: #cfd0ff;
+  background: #7b6cff1c;
+  border: 1px solid #7b6cff44;
 }
-.insp-section { margin-bottom: 14px; }
+
+.insp-section {
+  margin-bottom: 14px;
+}
+
 .insp-section h3 {
-  font-size: 11px; text-transform: uppercase; letter-spacing: .5px; color: var(--dim);
-  border-bottom: 1px solid var(--border); padding-bottom: 4px; margin-bottom: 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  color: var(--dim);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 4px;
+  margin-bottom: 8px;
 }
-.insp-row { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
-.insp-row label { width: 78px; flex: none; font-size: 12px; color: var(--dim); }
-.insp-row input[type=range] { flex: 1; }
-.insp-row .val { width: 42px; flex: none; text-align: right; font-size: 11px; color: var(--text); font-family: Consolas, monospace; }
-.insp-row input[type=number], .insp-row input[type=text], .insp-row select {
-  flex: 1; min-width: 0; background: var(--panel-2); border: 1px solid var(--border);
-  color: var(--text); border-radius: 4px; padding: 4px 6px; font: inherit;
+
+.insp-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
 }
-.insp-row input[type=color] { width: 40px; height: 26px; padding: 0; border: 1px solid var(--border); border-radius: 4px; background: none; }
+
+.insp-row label {
+  width: 78px;
+  flex: none;
+  font-size: 12px;
+  color: var(--dim);
+}
+
+.insp-row input[type=range] {
+  flex: 1;
+}
+
+.insp-row .val {
+  width: 42px;
+  flex: none;
+  text-align: right;
+  font-size: 11px;
+  color: var(--text);
+  font-family: Consolas, monospace;
+}
+
+.insp-row input[type=number],
+.insp-row input[type=text],
+.insp-row select {
+  flex: 1;
+  min-width: 0;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 4px;
+  padding: 4px 6px;
+  font: inherit;
+}
+
+.insp-row input[type=color] {
+  width: 40px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: none;
+}
+
 .insp-row textarea {
-  flex: 1; background: var(--panel-2); border: 1px solid var(--border); color: var(--text);
-  border-radius: 4px; padding: 4px 6px; font: inherit; resize: vertical; min-height: 48px;
+  flex: 1;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 4px;
+  padding: 4px 6px;
+  font: inherit;
+  resize: vertical;
+  min-height: 48px;
 }
-input[type=range] { accent-color: var(--accent); height: 18px; }
-.kf-ctl { display: flex; gap: 2px; flex: none; }
+
+input[type=range] {
+  accent-color: var(--accent);
+  height: 18px;
+}
+
+.kf-ctl {
+  display: flex;
+  gap: 2px;
+  flex: none;
+}
+
 .kf-btn {
-  background: none; border: 1px solid var(--border); color: var(--dim);
-  border-radius: 4px; font-size: 10px; padding: 2px 5px; cursor: pointer; line-height: 1;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--dim);
+  border-radius: 4px;
+  font-size: 10px;
+  padding: 2px 5px;
+  cursor: pointer;
+  line-height: 1;
 }
-.kf-btn:hover { color: #fff; border-color: #4a4a56; }
-.kf-btn.has { color: #ffd166; border-color: #ffd16666; }
+
+.kf-btn:hover {
+  color: #fff;
+  border-color: #4a4a56;
+}
+
+.kf-btn.has {
+  color: #ffd166;
+  border-color: #ffd16666;
+}
 
 /* ── Timeline ── */
-.timeline-toolbar { display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-bottom: 1px solid var(--border); }
-.tiny-label { font-size: 11px; }
-#zoomSlider { width: 130px; }
-.timeline { flex: 1; display: flex; min-height: 0; }
-.track-headers { width: 92px; flex: none; border-right: 1px solid var(--border); padding-top: 26px; background: var(--panel); z-index: 2; overflow: hidden; }
-.track-head {
-  display: flex; align-items: center; gap: 8px; padding: 0 10px; border-bottom: 1px solid #232328;
-  font-size: 11px; font-weight: 700; color: var(--dim); letter-spacing: .5px;
+.timeline-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
 }
-.track-head .track-dot { width: 8px; height: 8px; border-radius: 50%; }
-.timeline-scroll { flex: 1; overflow-x: auto; overflow-y: auto; position: relative; }
-.ruler { position: sticky; top: 0; left: 0; display: block; height: 26px; z-index: 3; cursor: ew-resize; background: var(--panel-2); }
-.tracks-content { position: relative; }
-.track { position: relative; border-bottom: 1px solid #232328; background: repeating-linear-gradient(90deg, transparent 0 59px, #ffffff05 59px 60px); }
-.track.drop-hint { background-color: #7b6cff14; }
+
+.tiny-label {
+  font-size: 11px;
+}
+
+#zoomSlider {
+  width: 130px;
+}
+
+.timeline {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.track-headers {
+  width: 92px;
+  flex: none;
+  border-right: 1px solid var(--border);
+  padding-top: 26px;
+  background: var(--panel);
+  z-index: 2;
+  overflow: hidden;
+}
+
+.track-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border-bottom: 1px solid #232328;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--dim);
+  letter-spacing: .5px;
+}
+
+.track-head .track-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.timeline-scroll {
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: auto;
+  position: relative;
+}
+
+.ruler {
+  position: sticky;
+  top: 0;
+  left: 0;
+  display: block;
+  height: 26px;
+  z-index: 3;
+  cursor: ew-resize;
+  background: var(--panel-2);
+}
+
+.tracks-content {
+  position: relative;
+}
+
+.track {
+  position: relative;
+  border-bottom: 1px solid #232328;
+  background: repeating-linear-gradient(90deg, transparent 0 59px, #ffffff05 59px 60px);
+}
+
+.track.drop-hint {
+  background-color: #7b6cff14;
+}
 
 /* ── Clips ── */
 .clip {
-  position: absolute; top: 3px; bottom: 3px; border-radius: 5px; overflow: hidden;
-  border: 1px solid #0007; cursor: grab; min-width: 8px;
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  border-radius: 5px;
+  overflow: hidden;
+  border: 1px solid #0007;
+  cursor: grab;
+  min-width: 8px;
   box-shadow: 0 1px 3px #0006;
 }
-.clip:active { cursor: grabbing; }
-.clip.selected { outline: 2px solid #b9baff; outline-offset: -1px; box-shadow: 0 0 0 3px #7b6cff55; }
-.clip.selected.primary { outline-color: #fff; }
+
+.clip:active {
+  cursor: grabbing;
+}
+
+.clip.selected {
+  outline: 2px solid #b9baff;
+  outline-offset: -1px;
+  box-shadow: 0 0 0 3px #7b6cff55;
+}
+
+.clip.selected.primary {
+  outline-color: #fff;
+}
 
 /* rubber-band selection box drawn while dragging on empty timeline area */
 .marquee {
-  position: absolute; z-index: 5; pointer-events: none;
-  border: 1px solid #7b6cffcc; background: #7b6cff22; border-radius: 2px;
+  position: absolute;
+  z-index: 5;
+  pointer-events: none;
+  border: 1px solid #7b6cffcc;
+  background: #7b6cff22;
+  border-radius: 2px;
 }
+
 .clip .clip-label {
-  position: absolute; inset: 0; padding: 3px 8px; font-size: 11px; font-weight: 600; color: #fff;
-  text-shadow: 0 1px 2px #000c; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; pointer-events: none;
+  position: absolute;
+  inset: 0;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  text-shadow: 0 1px 2px #000c;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
 }
-.clip .fade { position: absolute; inset: 0; background: linear-gradient(180deg, #ffffff1f, transparent 40%); pointer-events: none; }
-.clip .handle { position: absolute; top: 0; bottom: 0; width: 8px; cursor: ew-resize; z-index: 2; }
-.clip .handle.l { left: 0; border-left: 3px solid #ffffff55; }
-.clip .handle.r { right: 0; border-right: 3px solid #ffffff55; }
-.clip.c-video { background: linear-gradient(180deg, #4c66ff33, #4c66ff11), #273575; }
-.clip.c-video .thumbs { position: absolute; inset: 0; background-repeat: repeat-x; background-size: auto 100%; opacity: .5; pointer-events: none; }
-.clip.c-image { background: linear-gradient(180deg, #2dbd8533, #2dbd8511), #1d5b45; }
-.clip.c-audio { background: linear-gradient(180deg, #7ec24933, #7ec24911), #33531f; }
+
+.clip .fade {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, #ffffff1f, transparent 40%);
+  pointer-events: none;
+}
+
+.clip .handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  cursor: ew-resize;
+  z-index: 2;
+}
+
+.clip .handle.l {
+  left: 0;
+  border-left: 3px solid #ffffff55;
+}
+
+.clip .handle.r {
+  right: 0;
+  border-right: 3px solid #ffffff55;
+}
+
+.clip.c-video {
+  background: linear-gradient(180deg, #4c66ff33, #4c66ff11), #273575;
+}
+
+.clip.c-video .thumbs {
+  position: absolute;
+  inset: 0;
+  background-repeat: repeat-x;
+  background-size: auto 100%;
+  opacity: .5;
+  pointer-events: none;
+}
+
+.clip.c-image {
+  background: linear-gradient(180deg, #2dbd8533, #2dbd8511), #1d5b45;
+}
+
+.clip.c-audio {
+  background: linear-gradient(180deg, #7ec24933, #7ec24911), #33531f;
+}
+
 .clip.c-audio::after {
-  content: ""; position: absolute; left: 0; right: 0; top: 50%; height: 22px; transform: translateY(-50%);
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 22px;
+  transform: translateY(-50%);
   background: repeating-linear-gradient(90deg, #a5e07588 0 2px, transparent 2px 5px);
   clip-path: polygon(0 50%, 5% 20%, 10% 70%, 15% 35%, 20% 80%, 25% 25%, 30% 60%, 35% 15%, 40% 75%, 45% 40%, 50% 85%, 55% 30%, 60% 65%, 65% 20%, 70% 78%, 75% 42%, 80% 68%, 85% 25%, 90% 72%, 95% 38%, 100% 50%, 100% 100%, 0 100%);
-  opacity: .55; pointer-events: none;
+  opacity: .55;
+  pointer-events: none;
 }
-.clip.c-audio.has-wave::after { display: none; } /* real waveform replaces the CSS placeholder */
-.clip .wave { position: absolute; inset: 3px 0; width: 100%; height: calc(100% - 6px); pointer-events: none; }
-.clip.c-text { background: linear-gradient(180deg, #ff7ac833, #ff7ac811), #6b2a53; }
-.clip.c-svg { background: linear-gradient(180deg, #ffd16633, #ffd16611), #6b5420; }
+
+.clip.c-audio.has-wave::after {
+  display: none;
+}
+
+/* real waveform replaces the CSS placeholder */
+.clip .wave {
+  position: absolute;
+  inset: 3px 0;
+  width: 100%;
+  height: calc(100% - 6px);
+  pointer-events: none;
+}
+
+.clip.c-text {
+  background: linear-gradient(180deg, #ff7ac833, #ff7ac811), #6b2a53;
+}
+
+.clip.c-svg {
+  background: linear-gradient(180deg, #ffd16633, #ffd16611), #6b5420;
+}
+
 .clip.c-adjust {
   background: repeating-linear-gradient(135deg, #38bdf822 0 10px, transparent 10px 20px), #155e75;
 }
 
 /* ── Playhead ── */
-.playhead { position: absolute; top: 0; bottom: 0; width: 1px; background: #ff4d6a; z-index: 4; pointer-events: none; }
+.playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: #ff4d6a;
+  z-index: 4;
+  pointer-events: none;
+}
+
 .playhead-cap {
-  position: absolute; top: 0; left: -6px; width: 13px; height: 14px; background: #ff4d6a;
+  position: absolute;
+  top: 0;
+  left: -6px;
+  width: 13px;
+  height: 14px;
+  background: #ff4d6a;
   clip-path: polygon(0 0, 100% 0, 100% 55%, 50% 100%, 0 55%);
 }
 
 /* ── Overlays / dialogs ── */
-.overlay { position: fixed; inset: 0; background: #000a; backdrop-filter: blur(3px); display: flex; align-items: center; justify-content: center; z-index: 50; }
-.dialog { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 24px 28px; width: 420px; box-shadow: 0 20px 60px #000a; }
-.dialog h2 { font-size: 16px; margin-bottom: 6px; color: #fff; }
-.dialog p { margin-bottom: 16px; }
-.progress { height: 8px; border-radius: 4px; background: var(--panel-2); overflow: hidden; margin-bottom: 18px; }
-.progress-fill { height: 100%; width: 0%; background: linear-gradient(90deg, var(--accent), var(--accent-2)); transition: width .2s; }
-.dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
-.engine-opt {
-  display: flex; gap: 10px; align-items: flex-start; padding: 10px 12px; margin-bottom: 10px;
-  border: 1px solid var(--border); border-radius: 8px; cursor: pointer; background: var(--panel-2);
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: #000a;
+  backdrop-filter: blur(3px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
 }
-.engine-opt:hover { border-color: #454552; }
-.engine-opt:has(input:checked) { border-color: var(--accent); background: #7b6cff12; }
-.engine-opt:has(input:disabled) { opacity: .5; cursor: not-allowed; }
-.engine-opt input { margin-top: 3px; accent-color: var(--accent); }
-.engine-opt .dim { font-size: 12px; }
-.dialog.help .keys { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
-.dialog.help .keys td { padding: 5px 6px; border-bottom: 1px solid #26262c; font-size: 12px; }
-.dialog.help .keys td:first-child { width: 46%; color: var(--dim); }
+
+.dialog {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px 28px;
+  width: 420px;
+  box-shadow: 0 20px 60px #000a;
+}
+
+.dialog h2 {
+  font-size: 16px;
+  margin-bottom: 6px;
+  color: #fff;
+}
+
+.dialog p {
+  margin-bottom: 16px;
+}
+
+.progress {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--panel-2);
+  overflow: hidden;
+  margin-bottom: 18px;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  transition: width .2s;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.engine-opt {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--panel-2);
+}
+
+.engine-opt:hover {
+  border-color: #454552;
+}
+
+.engine-opt:has(input:checked) {
+  border-color: var(--accent);
+  background: #7b6cff12;
+}
+
+.engine-opt:has(input:disabled) {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.engine-opt input {
+  margin-top: 3px;
+  accent-color: var(--accent);
+}
+
+.engine-opt .dim {
+  font-size: 12px;
+}
+
+.dialog.help .keys {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 16px;
+}
+
+.dialog.help .keys td {
+  padding: 5px 6px;
+  border-bottom: 1px solid #26262c;
+  font-size: 12px;
+}
+
+.dialog.help .keys td:first-child {
+  width: 46%;
+  color: var(--dim);
+}
+
 kbd {
-  background: var(--panel-2); border: 1px solid var(--border); border-bottom-width: 2px;
-  border-radius: 4px; padding: 1px 6px; font: 11px Consolas, monospace; color: #fff;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font: 11px Consolas, monospace;
+  color: #fff;
 }
 
 /* ── Scrollbars ── */
-::-webkit-scrollbar { width: 10px; height: 10px; }
-::-webkit-scrollbar-thumb { background: #35353e; border-radius: 5px; border: 2px solid var(--panel); }
-::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #35353e;
+  border-radius: 5px;
+  border: 2px solid var(--panel);
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
 
 /* ── Toast ── */
 #toast {
-  position: fixed; left: 50%; bottom: 26px; transform: translate(-50%, 20px);
-  background: var(--panel-2); border: 1px solid var(--border); color: var(--text);
-  padding: 9px 16px; border-radius: 8px; font-size: 12px; box-shadow: 0 8px 30px #000a;
-  opacity: 0; pointer-events: none; transition: opacity .25s, transform .25s; z-index: 80;
+  position: fixed;
+  left: 50%;
+  bottom: 26px;
+  transform: translate(-50%, 20px);
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 9px 16px;
+  border-radius: 8px;
+  font-size: 12px;
+  box-shadow: 0 8px 30px #000a;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .25s, transform .25s;
+  z-index: 80;
   max-width: 60vw;
 }
-#toast.show { opacity: 1; transform: translate(-50%, 0); }
+
+#toast.show {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
 
 /* ── Inspector checkboxes ── */
-.insp-row input[type=checkbox] { width: 15px; height: 15px; accent-color: var(--accent); flex: none; }
+.insp-row input[type=checkbox] {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--accent);
+  flex: none;
+}
 
 /* ── Drop highlight ── */
 body.file-drag::after {
-  content: "Drop files to import"; position: fixed; inset: 10px; border: 2px dashed var(--accent);
-  border-radius: 14px; background: #7b6cff14; color: #cfc8ff; font-size: 18px; font-weight: 600;
-  display: flex; align-items: center; justify-content: center; z-index: 99; pointer-events: none;
+  content: "Drop files to import";
+  position: fixed;
+  inset: 10px;
+  border: 2px dashed var(--accent);
+  border-radius: 14px;
+  background: #7b6cff14;
+  color: #cfc8ff;
+  font-size: 18px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 99;
+  pointer-events: none;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

Top toolbar has a track height switcher that allows to switch track height between three predefined values:

1. Large (original)
2. Medium - reduced track height
3. Small - tracks without thumbnails with outline size set to 1px 

Choosing the track height resizes the monitor/timeline panels to show all the tracks without overflowing

Closes #

## Type of change

- [ ] Bug fix
- [X] New feature (GUI - resizable tracks)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Small, Medium, and Large timeline track density options.
  - Added controls to resize the upper workspace and timeline panels.
  - Added a Layout reset option.
  - Timeline panel sizing now persists and automatically adjusts to fit tracks.
  - Video thumbnails adapt to the selected track density.

- **UI Improvements**
  - Updated the workspace layout and resizing interactions for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->