### PR TITLE
feat: represent a/v tracks on the timeline separately

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
       "in": 2.5,                 // offset into source media, seconds (0 for image/svg/text)
       "duration": 5,             // clip length on timeline, seconds
       "name": "intro",
+      "linkGroup": "lg_abc",     // OPTIONAL — AV link: video + its L/R audio companions share one id
       "props": { /* all optional — see the props reference below */ },
       // OPTIONAL — keyframe animation. Times are seconds RELATIVE TO CLIP START.
       // "ease" sits on the DESTINATION keyframe of each segment:
@@ -316,10 +317,14 @@ glitch (RGB split + jitter) · pop (overshoot scale — stickers/captions).
 
 ### Semantics
 
-- Rendering order: V1 is drawn first, then V2, V3 on top. A video clip's own
-  audio plays with it (control via `props.volume`); A1–A4 are for standalone
-  audio files. SVG/image/text clips go on any V track (V2/V3 are handy overlay
-  lanes).
+- Rendering order: V1 is drawn first, then V2, V3 on top. SVG/image/text clips
+  go on any V track (V2/V3 are handy overlay lanes).
+- **Audio tracks A1–A4** hold both standalone audio files *and* linked companions
+  for imported video. Dropping a video creates the picture on a V track
+  (`props.volume: 0` so it isn't doubled) plus stereo L/R `kind:"audio"` clips
+  on A1/A2 that share a `linkGroup` (and the same `mediaId` / timing). Standalone
+  music/SFX also live on A1–A4. Linked partners move/trim/split together — edit
+  timing on any member of the group; do not treat A-tracks as music-only.
 - Media is `fit`-ted to the canvas (default "contain"), then crop → scale/x/y/
   rotation → flips apply.
 - `props` keys are all optional — missing keys get the defaults above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
       "id": "c_xyz",             // unique string
       "mediaId": "m_abc",        // null for kind:"text" and kind:"adjust"
       "kind": "video",           // video | audio | image | svg | text | adjust
-      "track": "V1",             // V4 V3 V2 V1 (top→bottom video) | A1 A2 A3 (audio)
+      "track": "V1",             // V3 V2 V1 (top→bottom video) | A1 A2 A3 A4 (audio)
       "start": 0,                // timeline position, seconds
       "in": 2.5,                 // offset into source media, seconds (0 for image/svg/text)
       "duration": 5,             // clip length on timeline, seconds
@@ -301,9 +301,9 @@ canvas-aware placement is applied only when a title is first created.
 everything drawn *below* it (lower tracks + earlier clips) through its own
 filter stack — Premiere-style. Supports all Filter/Color props, vignette,
 grain, rgbSplit, temperature/tint, whole-frame `shake`, and `opacity` as the
-intensity. Keyframe/transition it like any clip. Put it on V3/V4 above the
+intensity. Keyframe/transition it like any clip. Put it on V2/V3 above the
 footage. Example: 0.3 s impact shake over everything =
-`{kind:"adjust", track:"V4", duration:0.3, props:{shake:18}}`.
+`{kind:"adjust", track:"V3", duration:0.3, props:{shake:18}}`.
 
 **Animatable props** (usable in `keyframes`): x, y, scale, rotation, opacity,
 volume, speed, brightness, contrast, saturation, hue, blur, grayscale, sepia,
@@ -316,9 +316,9 @@ glitch (RGB split + jitter) · pop (overshoot scale — stickers/captions).
 
 ### Semantics
 
-- Rendering order: V1 is drawn first, then V2, V3, V4 on top. A video clip's own
-  audio plays with it (control via `props.volume`); A1/A2/A3 are for standalone
-  audio files. SVG/image/text clips go on any V track (V3/V4 are handy overlay
+- Rendering order: V1 is drawn first, then V2, V3 on top. A video clip's own
+  audio plays with it (control via `props.volume`); A1–A4 are for standalone
+  audio files. SVG/image/text clips go on any V track (V2/V3 are handy overlay
   lanes).
 - Media is `fit`-ted to the canvas (default "contain"), then crop → scale/x/y/
   rotation → flips apply.
@@ -434,11 +434,11 @@ Remember the source window is `duration × speed`.
 — sync the drop (t:1.3) to a marker; add `transitionIn:{type:"whip",duration:0.2}` before it.
 
 **Impact hit**: adjustment layer, 0.25–0.4 s at the hit:
-`{kind:"adjust", track:"V4", props:{shake:20, rgbSplit:8}}` + `impact-hit.mp3`
+`{kind:"adjust", track:"V3", props:{shake:20, rgbSplit:8}}` + `impact-hit.mp3`
 from `library/sfx` on A2.
 
 **VHS / glitch look**: `props: {rgbSplit:4, grain:35, saturation:120}` +
-`library/elements/vhs-scanlines.svg` on V4 with `blend:"soft-light", fit:"stretch"`.
+`library/elements/vhs-scanlines.svg` on V3 with `blend:"soft-light", fit:"stretch"`.
 Cut between shots with `transitionIn:{type:"glitch",duration:0.3}`.
 
 **Film look**: adjustment layer across the whole edit:
@@ -447,11 +447,11 @@ Cut between shots with `transitionIn:{type:"glitch",duration:0.3}`.
 **Neon caption**: `props: {glow:60, glowColor:"#22d3ee", color:"#ffffff",
 font:"Bebas Neue", textAnim:"wave"}` on a dark shot.
 
-**Light leak accent**: `library/elements/light-leak-warm.svg` on V4,
+**Light leak accent**: `library/elements/light-leak-warm.svg` on V3,
 `props:{blend:"screen", fit:"cover", opacity:0.7}`, 1–2 s at scene changes,
 `transitionIn/Out: fade`.
 
-**Light-leak / dust overlay**: element from `library/elements` on V4 with
+**Light-leak / dust overlay**: element from `library/elements` on V3 with
 `props: {blend:"screen", opacity:0.6, fit:"cover"}`.
 
 **Reel caption**: text clip with `props: {textAnim:"word-pop", wordRate:0.15,
@@ -484,7 +484,7 @@ behind its baseline. Pair with a `serifDrop`/`zoom-in` kicker above it.
 `props.font: "MyBrand"`.
 
 **Animated sticker**: author an SVG (convention above) into `library/svg/`,
-register `{kind:"svg", src:"/library/svg/foo.svg"}`, clip on V3/V4. Scale/move/
+register `{kind:"svg", src:"/library/svg/foo.svg"}`, clip on V2/V3. Scale/move/
 rotate with normal props & keyframes; the SVG's own CSS animation plays on top,
 frame-accurately.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ same time.
 
 **Editing**
 
-- 4 video tracks + 3 audio tracks, drag/trim/split/snap, undo/redo
+- 3 video tracks + 4 audio tracks, drag/trim/split/snap, undo/redo
 - **Direct manipulation on the monitor** — click a clip or title on the preview to
   move, resize (corner handles), or rotate (top handle, Shift-snap) it directly
 - **Timeline multi-select** — rubber-band marquee (drag on empty track area),

--- a/app.js
+++ b/app.js
@@ -8,20 +8,20 @@
 
 /* ── Constants ─────────────────────────────────────────────────────────── */
 const TRACKS = [
-  { id: "V4", kind: "video", h: 44, color: "#ff8a5c" },
   { id: "V3", kind: "video", h: 44, color: "#ffd166" },
   { id: "V2", kind: "video", h: 58, color: "#7b6cff" },
   { id: "V1", kind: "video", h: 58, color: "#4f8cff" },
   { id: "A1", kind: "audio", h: 42, color: "#7ec249" },
   { id: "A2", kind: "audio", h: 42, color: "#5a9e3a" },
   { id: "A3", kind: "audio", h: 42, color: "#4a8a2f" },
+  { id: "A4", kind: "audio", h: 42, color: "#3a7226" },
 ];
 /* Three timeline density presets. L matches the original track heights (with thumbs).
    S is compact solid-color rows; M is in between. */
 const TRACK_SIZE_PRESETS = {
-  s: { thumbs: false, h: { V4: 26, V3: 26, V2: 26, V1: 26, A1: 22, A2: 22, A3: 22 } },
-  m: { thumbs: true, h: { V4: 36, V3: 36, V2: 44, V1: 44, A1: 32, A2: 32, A3: 32 } },
-  l: { thumbs: true, h: { V4: 44, V3: 44, V2: 58, V1: 58, A1: 42, A2: 42, A3: 42 } },
+  s: { thumbs: false, h: { V3: 26, V2: 26, V1: 26, A1: 22, A2: 22, A3: 22, A4: 22 } },
+  m: { thumbs: true, h: { V3: 36, V2: 44, V1: 44, A1: 32, A2: 32, A3: 32, A4: 32 } },
+  l: { thumbs: true, h: { V3: 44, V2: 58, V1: 58, A1: 42, A2: 42, A3: 42, A4: 42 } },
 };
 const TRACK_SIZE_KEY = "fablecut-track-size";
 const LAST_TRANS_KEY = { in: "fablecut-last-trans-in", out: "fablecut-last-trans-out" };

--- a/app.js
+++ b/app.js
@@ -1481,8 +1481,49 @@ function rebuildClips() {
     row.appendChild(div);
     if (hasWave) drawClipWave(div.querySelector(".wave"), c, tr.h);
   }
+  paintAudioOverlaps();
   state.dirtyTimeline = false;
   updateWorkArea();
+}
+/* Hatched bands where two+ audio clips share a track (CSS draw, O(n²) per track). */
+function paintAudioOverlaps() {
+  const byTrack = new Map();
+  for (const c of project.clips) {
+    if (c.kind !== "audio") continue;
+    let list = byTrack.get(c.track);
+    if (!list) byTrack.set(c.track, list = []);
+    list.push(c);
+  }
+  for (const [trackId, clips] of byTrack) {
+    if (clips.length < 2) continue;
+    const row = els.tracks.querySelector(`[data-track="${trackId}"]`);
+    if (!row) continue;
+    const intervals = [];
+    for (let i = 0; i < clips.length; i++) {
+      for (let j = i + 1; j < clips.length; j++) {
+        const t0 = Math.max(clips[i].start, clips[j].start);
+        const t1 = Math.min(clipEnd(clips[i]), clipEnd(clips[j]));
+        if (t1 - t0 > 1e-4) intervals.push([t0, t1]);
+      }
+    }
+    if (!intervals.length) continue;
+    intervals.sort((a, b) => a[0] - b[0]);
+    const merged = [[intervals[0][0], intervals[0][1]]];
+    for (let k = 1; k < intervals.length; k++) {
+      const last = merged[merged.length - 1];
+      const cur = intervals[k];
+      if (cur[0] <= last[1] + 1e-6) last[1] = Math.max(last[1], cur[1]);
+      else merged.push([cur[0], cur[1]]);
+    }
+    for (const [t0, t1] of merged) {
+      const el = document.createElement("div");
+      el.className = "track-overlap";
+      el.style.left = (t0 * state.pps) + "px";
+      el.style.width = Math.max(2, (t1 - t0) * state.pps) + "px";
+      el.title = "Overlapping audio";
+      row.appendChild(el);
+    }
+  }
 }
 
 /* Render decoded peaks for the [in, in+duration] slice of the clip's media */
@@ -1717,12 +1758,14 @@ function startClipGesture(e, c, mode, collapseOnClick) {
   }]));
   const groupIds = new Set(group.map((x) => x.id));
   const t0 = timeAtEvent(e);
+  const x0 = e.clientX, y0 = e.clientY;
   let moved = false;
   const snapshot = JSON.stringify(project.clips);
 
   const onMove = (ev) => {
     const dt = timeAtEvent(ev) - t0;
-    if (Math.abs(dt * state.pps) > 3) moved = true;
+    // Count vertical motion too — track changes are often pure Y drags
+    if (!moved && (Math.abs(ev.clientX - x0) > 3 || Math.abs(ev.clientY - y0) > 3)) moved = true;
     if (!moved) return;
     if (mode === "move") {
       // Snap whichever edge is closer to a target. A non-snapping edge has

--- a/app.js
+++ b/app.js
@@ -226,6 +226,14 @@ const ctx2d = els.preview.getContext("2d");
 /* ── Utils ─────────────────────────────────────────────────────────────── */
 const uid = () => Math.random().toString(36).slice(2, 9);
 const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+function escapeHtml(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
 function fmt(t) {
   t = Math.max(0, t);
   const m = Math.floor(t / 60), s = Math.floor(t % 60),
@@ -1468,11 +1476,12 @@ function rebuildClips() {
                   (c.transitionIn || c.transitionOut ? "⇄ " : "");
     const chTag = c.props?.audioChannel === 0 ? "L · "
                 : c.props?.audioChannel === 1 ? "R · " : "";
+    const label = c.kind === "text" ? "T · " + (c.props.text || "").split("\n")[0]
+      : c.kind === "adjust" ? "FX · " + (c.name || "")
+      : c.kind === "audio" ? chTag + (c.name || "")
+      : (c.name || "");
     body += `<div class="fade"></div>
-      <div class="clip-label">${badge}${c.kind === "text" ? "T · " + (c.props.text || "").split("\n")[0]
-        : c.kind === "adjust" ? "FX · " + c.name
-        : c.kind === "audio" ? chTag + c.name
-        : c.name}</div>`;
+      <div class="clip-label">${badge}${escapeHtml(label)}</div>`;
     let inner = `<div class="clip-body">${body}</div>`;
     inner += transitionMarksHtml(c, tr.h);
     inner += `<div class="handle l"></div><div class="handle r"></div>`;

--- a/app.js
+++ b/app.js
@@ -1654,7 +1654,10 @@ function startClipGesture(e, c, mode, collapseOnClick) {
       const tk = trackAtEvent(ev);
       if (tk) {
         const trk = TRACKS.find((t) => t.id === tk);
-        if (trk && (c.kind === "audio") === (trk.kind === "audio")) c.track = tk;
+        if (trk && (c.kind === "audio") === (trk.kind === "audio")) {
+          c.track = tk;
+          routeClipGain(c);
+        }
       }
     } else if (mode === "trim-l") {
       let ns = snapTime(orig.start + dt, groupIds);
@@ -2287,11 +2290,22 @@ function ensureAudio() {
   const ctx = new (window.AudioContext || window.webkitAudioContext)();
   const master = ctx.createGain();
   const recDest = ctx.createMediaStreamDestination();
-  // Meter is inserted as a pass-through once the worklet loads; until then
-  // master goes straight to the speakers.
+  const audioTracks = TRACKS.filter((t) => t.kind === "audio");
+  const trackBus = {};
+  for (const t of audioTracks) {
+    trackBus[t.id] = ctx.createGain();
+  }
+  // Until the worklet is ready, audio-track buses and master both feed speakers.
   master.connect(ctx.destination);
   master.connect(recDest);
-  runtime.audio = { ctx, master, recDest, meter: null, meterReady: false };
+  for (const id of Object.keys(trackBus)) {
+    trackBus[id].connect(master);
+  }
+  runtime.audio = {
+    ctx, master, recDest, trackBus,
+    audioTrackIds: audioTracks.map((t) => t.id),
+    meter: null, meterReady: false,
+  };
   installMeterWorklet(runtime.audio).catch(() => {});
   for (const [id, el] of runtime.clipEls) {
     const c = getClip(id);
@@ -2305,51 +2319,113 @@ function hookAudio(c, el) {
   try {
     const src = runtime.audio.ctx.createMediaElementSource(el);
     const g = runtime.audio.ctx.createGain();
-    src.connect(g); g.connect(runtime.audio.master);
+    src.connect(g);
     runtime.clipGain.set(c.id, g);
-  } catch { }
+    routeClipGain(c);
+  } catch {}
+}
+/** Reconnect a clip's gain to the correct track bus (or master for video tracks). */
+function routeClipGain(c) {
+  const g = runtime.clipGain.get(c.id);
+  if (!g || !runtime.audio) return;
+  const bus = runtime.audio.trackBus[c.track] || runtime.audio.master;
+  if (g._fcBus === bus) return;
+  try { g.disconnect(); } catch {}
+  g.connect(bus);
+  g._fcBus = bus;
 }
 
-/* ── Master RMS meter (AudioWorklet) ── */
+/* ── Per-track meters: RMS / LUFS-M / Peak (AudioWorklet) ── */
 const METER_SEGS = 16;
 const METER_DB_MIN = -48;
 const METER_DB_MAX = 0;
+const METER_MODES = ["rms", "lufs", "peak"];
+const METER_MODE_LABEL = { rms: "RMS", lufs: "LUFS", peak: "PEAK" };
 const meterState = {
-  rms: [0, 0],       // raw from worklet
-  peak: [0, 0],
-  disp: [METER_DB_MIN, METER_DB_MIN], // ballistics (dBFS)
-  peakHold: [METER_DB_MIN, METER_DB_MIN],
-  peakHoldT: [0, 0],
-  segs: [[], []],
+  mode: (() => {
+    try {
+      const m = localStorage.getItem("fablecut-meter-mode");
+      return METER_MODES.includes(m) ? m : "rms";
+    } catch { return "rms"; }
+  })(),
+  trackIds: [],
+  rms: {},
+  peak: {},
+  lufs: {},
+  disp: {},
+  peakHold: {},
+  peakHoldT: {},
+  segs: {},
+  modeBtn: null,
 };
+function audioMeterTracks() {
+  return TRACKS.filter((t) => t.kind === "audio");
+}
+function cycleMeterMode(ev) {
+  if (ev) { ev.preventDefault(); ev.stopPropagation(); }
+  const i = METER_MODES.indexOf(meterState.mode);
+  meterState.mode = METER_MODES[(i + 1) % METER_MODES.length];
+  try { localStorage.setItem("fablecut-meter-mode", meterState.mode); } catch {}
+  if (meterState.modeBtn) meterState.modeBtn.textContent = METER_MODE_LABEL[meterState.mode];
+  const root = $("vuMeter");
+  if (root) root.title = `Mode: ${METER_MODE_LABEL[meterState.mode]} — click to switch`;
+  // Reset ballistics so the bar doesn't linger from the previous scale reading
+  for (const id of meterState.trackIds) {
+    meterState.disp[id] = METER_DB_MIN;
+    meterState.peakHold[id] = METER_DB_MIN;
+    meterState.peakHoldT[id] = 0;
+  }
+}
 async function installMeterWorklet(audio) {
   if (audio.meterReady || !audio.ctx.audioWorklet || meterState._loading) return;
   meterState._loading = true;
+  const trackIds = audio.audioTrackIds.slice();
   try {
-    await audio.ctx.audioWorklet.addModule("meter-worklet.js");
+    await audio.ctx.audioWorklet.addModule("meter-worklet.js?v=2");
+    const n = trackIds.length;
     const meter = new AudioWorkletNode(audio.ctx, "fablecut-meter", {
-      numberOfInputs: 1,
+      numberOfInputs: n,
       numberOfOutputs: 1,
       outputChannelCount: [2],
       channelCount: 2,
       channelCountMode: "explicit",
-      processorOptions: { hopBlocks: 8 },
+      processorOptions: { hopBlocks: 8, nTracks: n, trackIds },
     });
     meter.port.onmessage = (ev) => {
       const msg = ev.data;
       if (!msg || msg.type !== "meter") return;
-      meterState.rms[0] = msg.rms[0] || 0;
-      meterState.rms[1] = msg.rms[1] != null ? msg.rms[1] : meterState.rms[0];
-      meterState.peak[0] = msg.peak[0] || 0;
-      meterState.peak[1] = msg.peak[1] != null ? msg.peak[1] : meterState.peak[0];
-      // msg.lufs reserved for momentary/short-term LUFS
+      const ids = msg.trackIds || trackIds;
+      for (let i = 0; i < ids.length; i++) {
+        const id = ids[i];
+        meterState.rms[id] = msg.rms[i] || 0;
+        meterState.peak[id] = msg.peak[i] || 0;
+        meterState.lufs[id] = msg.lufs[i] != null ? msg.lufs[i] : -70;
+      }
     };
-    // Insert: master → meter → destination (pass-through); recDest stays on master
+
+    // Reroute: trackBus → meter inputs → speakers/rec (no double via master)
+    for (const id of trackIds) {
+      const bus = audio.trackBus[id];
+      try { bus.disconnect(); } catch {}
+      bus.connect(meter, 0, trackIds.indexOf(id));
+    }
+    // master still carries video-track embedded audio (recDest already wired)
     try { audio.master.disconnect(audio.ctx.destination); } catch {}
-    audio.master.connect(meter);
+    audio.master.connect(audio.ctx.destination);
     meter.connect(audio.ctx.destination);
+    meter.connect(audio.recDest);
+
     audio.meter = meter;
     audio.meterReady = true;
+    meterState.trackIds = trackIds;
+    for (const id of trackIds) {
+      meterState.rms[id] = 0;
+      meterState.peak[id] = 0;
+      meterState.lufs[id] = -70;
+      meterState.disp[id] = METER_DB_MIN;
+      meterState.peakHold[id] = METER_DB_MIN;
+      meterState.peakHoldT[id] = 0;
+    }
     buildMeterDOM();
   } catch (err) {
     console.warn("[FableCut] meter worklet unavailable:", err);
@@ -2359,52 +2435,100 @@ async function installMeterWorklet(audio) {
 }
 function buildMeterDOM() {
   const root = $("vuMeter");
-  if (!root || meterState.segs[0].length) return;
-  for (const ch of [0, 1]) {
-    const host = root.querySelector(`.vu-channel[data-ch="${ch}"] .vu-segs`);
-    if (!host) continue;
-    host.innerHTML = "";
-    meterState.segs[ch] = [];
+  if (!root) return;
+  const tracks = audioMeterTracks();
+  root.innerHTML = "";
+  root.title = `Mode: ${METER_MODE_LABEL[meterState.mode]} — click to switch`;
+
+  const modeBtn = document.createElement("button");
+  modeBtn.type = "button";
+  modeBtn.className = "vu-mode";
+  modeBtn.textContent = METER_MODE_LABEL[meterState.mode];
+  modeBtn.title = "Cycle RMS → LUFS → Peak";
+  modeBtn.addEventListener("click", cycleMeterMode);
+  root.appendChild(modeBtn);
+  meterState.modeBtn = modeBtn;
+
+  const row = document.createElement("div");
+  row.className = "vu-channels";
+  meterState.segs = {};
+  meterState.trackIds = tracks.map((t) => t.id);
+  for (const t of tracks) {
+    if (meterState.disp[t.id] == null) {
+      meterState.disp[t.id] = METER_DB_MIN;
+      meterState.peakHold[t.id] = METER_DB_MIN;
+      meterState.peakHoldT[t.id] = 0;
+      meterState.rms[t.id] = 0;
+      meterState.peak[t.id] = 0;
+      meterState.lufs[t.id] = -70;
+    }
+    const col = document.createElement("div");
+    col.className = "vu-channel";
+    col.dataset.track = t.id;
+    const segs = document.createElement("div");
+    segs.className = "vu-segs";
+    meterState.segs[t.id] = [];
     for (let i = 0; i < METER_SEGS; i++) {
       const seg = document.createElement("div");
-      const t = i / (METER_SEGS - 1); // 0 = bottom (quiet), 1 = top (hot)
-      seg.className = "vu-seg " + (t < 0.6 ? "g" : t < 0.85 ? "y" : "r");
-      host.appendChild(seg);
-      meterState.segs[ch].push(seg);
+      const u = i / (METER_SEGS - 1);
+      seg.className = "vu-seg " + (u < 0.6 ? "g" : u < 0.85 ? "y" : "r");
+      segs.appendChild(seg);
+      meterState.segs[t.id].push(seg);
     }
+    const label = document.createElement("span");
+    label.className = "vu-label";
+    label.textContent = t.id;
+    col.appendChild(segs);
+    col.appendChild(label);
+    row.appendChild(col);
   }
+  root.appendChild(row);
 }
 function rmsToDb(rms) {
   return rms > 1e-8 ? 20 * Math.log10(rms) : METER_DB_MIN;
 }
+function meterReadingDb(id) {
+  const mode = meterState.mode;
+  if (mode === "peak") return rmsToDb(meterState.peak[id] || 0);
+  if (mode === "lufs") {
+    const v = meterState.lufs[id];
+    return v == null || v < METER_DB_MIN ? METER_DB_MIN : Math.min(METER_DB_MAX, v);
+  }
+  return rmsToDb(meterState.rms[id] || 0);
+}
 function updateMeterUI(dt) {
-  if (!runtime.audio?.meterReady) return;
-  const playing = state.playing;
-  const attack = 1 - Math.exp(-dt / 0.015);   // ~15 ms
-  const release = 1 - Math.exp(-dt / 0.180);  // ~180 ms
+  const ids = meterState.trackIds;
+  if (!ids.length) return;
+  const playing = state.playing && runtime.audio?.meterReady;
+  const mode = meterState.mode;
+  // Peak: snappy; LUFS already smoothed in-worklet (400 ms); RMS: classic VU feel
+  const atkMs = mode === "peak" ? 0.005 : mode === "lufs" ? 0.04 : 0.015;
+  const relMs = mode === "peak" ? 0.35 : mode === "lufs" ? 0.12 : 0.18;
+  const attack = 1 - Math.exp(-dt / atkMs);
+  const release = 1 - Math.exp(-dt / relMs);
   const now = performance.now();
-  for (let ch = 0; ch < 2; ch++) {
-    const target = playing ? rmsToDb(meterState.rms[ch]) : METER_DB_MIN;
-    const cur = meterState.disp[ch];
+  for (const id of ids) {
+    const target = playing ? meterReadingDb(id) : METER_DB_MIN;
+    const cur = meterState.disp[id] ?? METER_DB_MIN;
     const a = target > cur ? attack : release;
     const next = cur + (target - cur) * a;
-    meterState.disp[ch] = next;
+    meterState.disp[id] = next;
 
-    // Peak hold from worklet sample peaks (visual tip)
-    const pk = playing ? rmsToDb(meterState.peak[ch]) : METER_DB_MIN;
-    if (pk >= meterState.peakHold[ch]) {
-      meterState.peakHold[ch] = pk;
-      meterState.peakHoldT[ch] = now;
-    } else if (now - meterState.peakHoldT[ch] > 800) {
-      meterState.peakHold[ch] += (METER_DB_MIN - meterState.peakHold[ch]) * release;
+    // Hold tip follows the active mode reading (not always sample-peak)
+    const pk = target;
+    if (pk >= (meterState.peakHold[id] ?? METER_DB_MIN)) {
+      meterState.peakHold[id] = pk;
+      meterState.peakHoldT[id] = now;
+    } else if (now - (meterState.peakHoldT[id] || 0) > 800) {
+      meterState.peakHold[id] += (METER_DB_MIN - meterState.peakHold[id]) * release;
     }
 
-    const segs = meterState.segs[ch];
-    if (!segs.length) continue;
+    const segs = meterState.segs[id];
+    if (!segs || !segs.length) continue;
     const level = (next - METER_DB_MIN) / (METER_DB_MAX - METER_DB_MIN);
     const lit = Math.round(clamp(level, 0, 1) * METER_SEGS);
     const hold = Math.round(clamp(
-      (meterState.peakHold[ch] - METER_DB_MIN) / (METER_DB_MAX - METER_DB_MIN), 0, 1
+      ((meterState.peakHold[id] ?? METER_DB_MIN) - METER_DB_MIN) / (METER_DB_MAX - METER_DB_MIN), 0, 1
     ) * (METER_SEGS - 1));
     for (let i = 0; i < METER_SEGS; i++) {
       segs[i].classList.toggle("on", i < lit || i === hold);

--- a/app.js
+++ b/app.js
@@ -199,7 +199,7 @@ const runtime = {
   customFonts: [],      // family names loaded from /library/fonts
   googleLoaded: new Set(),
   undo: [], redo: [],
-  audio: null,          // {ctx, master, recDest}
+  audio: null,          // {ctx, master, recDest, meter?, meterReady?}
   saveTimer: null, pendingSync: false,
   sfxPreview: null,     // <audio> element for library sound previews
 };
@@ -2287,10 +2287,12 @@ function ensureAudio() {
   const ctx = new (window.AudioContext || window.webkitAudioContext)();
   const master = ctx.createGain();
   const recDest = ctx.createMediaStreamDestination();
+  // Meter is inserted as a pass-through once the worklet loads; until then
+  // master goes straight to the speakers.
   master.connect(ctx.destination);
   master.connect(recDest);
-  runtime.audio = { ctx, master, recDest };
-  // hook any elements created before the audio context existed
+  runtime.audio = { ctx, master, recDest, meter: null, meterReady: false };
+  installMeterWorklet(runtime.audio).catch(() => {});
   for (const [id, el] of runtime.clipEls) {
     const c = getClip(id);
     if (c) hookAudio(c, el);
@@ -2306,6 +2308,108 @@ function hookAudio(c, el) {
     src.connect(g); g.connect(runtime.audio.master);
     runtime.clipGain.set(c.id, g);
   } catch { }
+}
+
+/* ── Master RMS meter (AudioWorklet) ── */
+const METER_SEGS = 16;
+const METER_DB_MIN = -48;
+const METER_DB_MAX = 0;
+const meterState = {
+  rms: [0, 0],       // raw from worklet
+  peak: [0, 0],
+  disp: [METER_DB_MIN, METER_DB_MIN], // ballistics (dBFS)
+  peakHold: [METER_DB_MIN, METER_DB_MIN],
+  peakHoldT: [0, 0],
+  segs: [[], []],
+};
+async function installMeterWorklet(audio) {
+  if (audio.meterReady || !audio.ctx.audioWorklet || meterState._loading) return;
+  meterState._loading = true;
+  try {
+    await audio.ctx.audioWorklet.addModule("meter-worklet.js");
+    const meter = new AudioWorkletNode(audio.ctx, "fablecut-meter", {
+      numberOfInputs: 1,
+      numberOfOutputs: 1,
+      outputChannelCount: [2],
+      channelCount: 2,
+      channelCountMode: "explicit",
+      processorOptions: { hopBlocks: 8 },
+    });
+    meter.port.onmessage = (ev) => {
+      const msg = ev.data;
+      if (!msg || msg.type !== "meter") return;
+      meterState.rms[0] = msg.rms[0] || 0;
+      meterState.rms[1] = msg.rms[1] != null ? msg.rms[1] : meterState.rms[0];
+      meterState.peak[0] = msg.peak[0] || 0;
+      meterState.peak[1] = msg.peak[1] != null ? msg.peak[1] : meterState.peak[0];
+      // msg.lufs reserved for momentary/short-term LUFS
+    };
+    // Insert: master → meter → destination (pass-through); recDest stays on master
+    try { audio.master.disconnect(audio.ctx.destination); } catch {}
+    audio.master.connect(meter);
+    meter.connect(audio.ctx.destination);
+    audio.meter = meter;
+    audio.meterReady = true;
+    buildMeterDOM();
+  } catch (err) {
+    console.warn("[FableCut] meter worklet unavailable:", err);
+  } finally {
+    meterState._loading = false;
+  }
+}
+function buildMeterDOM() {
+  const root = $("vuMeter");
+  if (!root || meterState.segs[0].length) return;
+  for (const ch of [0, 1]) {
+    const host = root.querySelector(`.vu-channel[data-ch="${ch}"] .vu-segs`);
+    if (!host) continue;
+    host.innerHTML = "";
+    meterState.segs[ch] = [];
+    for (let i = 0; i < METER_SEGS; i++) {
+      const seg = document.createElement("div");
+      const t = i / (METER_SEGS - 1); // 0 = bottom (quiet), 1 = top (hot)
+      seg.className = "vu-seg " + (t < 0.6 ? "g" : t < 0.85 ? "y" : "r");
+      host.appendChild(seg);
+      meterState.segs[ch].push(seg);
+    }
+  }
+}
+function rmsToDb(rms) {
+  return rms > 1e-8 ? 20 * Math.log10(rms) : METER_DB_MIN;
+}
+function updateMeterUI(dt) {
+  if (!runtime.audio?.meterReady) return;
+  const playing = state.playing;
+  const attack = 1 - Math.exp(-dt / 0.015);   // ~15 ms
+  const release = 1 - Math.exp(-dt / 0.180);  // ~180 ms
+  const now = performance.now();
+  for (let ch = 0; ch < 2; ch++) {
+    const target = playing ? rmsToDb(meterState.rms[ch]) : METER_DB_MIN;
+    const cur = meterState.disp[ch];
+    const a = target > cur ? attack : release;
+    const next = cur + (target - cur) * a;
+    meterState.disp[ch] = next;
+
+    // Peak hold from worklet sample peaks (visual tip)
+    const pk = playing ? rmsToDb(meterState.peak[ch]) : METER_DB_MIN;
+    if (pk >= meterState.peakHold[ch]) {
+      meterState.peakHold[ch] = pk;
+      meterState.peakHoldT[ch] = now;
+    } else if (now - meterState.peakHoldT[ch] > 800) {
+      meterState.peakHold[ch] += (METER_DB_MIN - meterState.peakHold[ch]) * release;
+    }
+
+    const segs = meterState.segs[ch];
+    if (!segs.length) continue;
+    const level = (next - METER_DB_MIN) / (METER_DB_MAX - METER_DB_MIN);
+    const lit = Math.round(clamp(level, 0, 1) * METER_SEGS);
+    const hold = Math.round(clamp(
+      (meterState.peakHold[ch] - METER_DB_MIN) / (METER_DB_MAX - METER_DB_MIN), 0, 1
+    ) * (METER_SEGS - 1));
+    for (let i = 0; i < METER_SEGS; i++) {
+      segs[i].classList.toggle("on", i < lit || i === hold);
+    }
+  }
 }
 
 function play() {
@@ -3427,6 +3531,7 @@ function loop(ts) {
   els.playhead.style.left = state.time * state.pps + "px";
   drawRuler();
   updateSafeOverlay();
+  updateMeterUI(dt);
   els.tcCurrent.textContent = fmt(state.time);
   els.tcTotal.textContent = fmt(projDur());
   if (state.exporting && !state.rendering) {
@@ -3935,5 +4040,6 @@ buildTrackDOM();
 rebuildClips();
 renderBin();
 syncTrimIOButton();
+buildMeterDOM();
 connectServer().then(loadLibraryFonts);
 requestAnimationFrame(loop);

--- a/app.js
+++ b/app.js
@@ -194,7 +194,7 @@ const runtime = {
   clipGain: new Map(),  // clipId -> GainNode
   mediaAux: new Map(),  // mediaId -> {img?, thumb?, svgText?, svgAnimated?}
   audioBufs: new Map(), // mediaId -> Promise<AudioBuffer> (waveforms + export mix)
-  wavePeaks: new Map(), // mediaId -> Float32Array peaks at WAVE_PEAKS_PER_SEC
+  wavePeaks: new Map(), // mediaId -> {channels: Float32Array[], max: Float32Array} | Float32Array (legacy) | null (pending)
   library: {},          // dir -> [{name, rel, src, size}] cached /api/library results
   customFonts: [],      // family names loaded from /library/fonts
   googleLoaded: new Set(),
@@ -507,20 +507,40 @@ function ensureWave(m) {
   runtime.wavePeaks.set(m.id, null); // pending
   getAudioBuffer(m).then((buf) => {
     const n = Math.max(1, Math.ceil(buf.duration * WAVE_PEAKS_PER_SEC));
-    const peaks = new Float32Array(n);
     const step = buf.length / n;
+    const channels = [];
     for (let ch = 0; ch < buf.numberOfChannels; ch++) {
       const data = buf.getChannelData(ch);
+      const peaks = new Float32Array(n);
       for (let i = 0; i < n; i++) {
         let mx = 0;
         const i0 = Math.floor(i * step), i1 = Math.min(data.length, Math.floor((i + 1) * step));
         for (let j = i0; j < i1; j += 8) { const a = Math.abs(data[j]); if (a > mx) mx = a; }
-        if (mx > peaks[i]) peaks[i] = mx;
+        peaks[i] = mx;
       }
+      channels.push(peaks);
     }
-    runtime.wavePeaks.set(m.id, peaks);
+    // Combined max envelope for clips that play full stereo
+    const max = new Float32Array(n);
+    for (let i = 0; i < n; i++) {
+      let mx = 0;
+      for (const p of channels) if (p[i] > mx) mx = p[i];
+      max[i] = mx;
+    }
+    runtime.wavePeaks.set(m.id, { channels, max });
+    if (m.channels == null) m.channels = buf.numberOfChannels;
     state.dirtyTimeline = true;
   }).catch(() => runtime.wavePeaks.delete(m.id));
+}
+function wavePeaksFor(c) {
+  const w = runtime.wavePeaks.get(c.mediaId);
+  if (!w) return null;
+  // Legacy: bare Float32Array
+  if (w instanceof Float32Array) return w;
+  if (!w.max) return null;
+  const ch = c.props?.audioChannel;
+  if ((ch === 0 || ch === 1) && w.channels?.[ch]) return w.channels[ch];
+  return w.max;
 }
 
 /* ═══════════════════════════ MEDIA IMPORT ═══════════════════════════ */
@@ -771,23 +791,37 @@ function defaultTrackFor(kind) {
 function linkedClip(c) {
   return c?.linkedId ? getClip(c.linkedId) : null;
 }
-/* Expand a clip list so each AV-linked partner is included once. */
+/* Expand a clip list so each AV-linked partner is included once.
+   Supports N-way `linkGroup` (video + L + R) and legacy pairwise `linkedId`. */
 function withLinked(clips) {
   const out = new Map();
+  const groups = new Set();
   for (const c of clips) {
     out.set(c.id, c);
-    const L = linkedClip(c);
-    if (L) out.set(L.id, L);
+    if (c.linkGroup) groups.add(c.linkGroup);
+    else {
+      const L = linkedClip(c);
+      if (L) out.set(L.id, L);
+    }
+  }
+  if (groups.size) {
+    for (const x of project.clips) {
+      if (x.linkGroup && groups.has(x.linkGroup)) out.set(x.id, x);
+    }
   }
   return [...out.values()];
 }
 function syncLinkedTiming(c) {
-  const L = linkedClip(c);
-  if (!L) return;
-  L.start = c.start;
-  L.in = c.in;
-  L.duration = c.duration;
-  if (c.props?.speed != null) L.props.speed = c.props.speed;
+  for (const L of withLinked([c])) {
+    if (L.id === c.id) continue;
+    L.start = c.start;
+    L.in = c.in;
+    L.duration = c.duration;
+    if (c.props?.speed != null) {
+      L.props = L.props || {};
+      L.props.speed = c.props.speed;
+    }
+  }
 }
 
 function addClipFromMedia(m, trackId, at) {
@@ -805,18 +839,25 @@ function addClipFromMedia(m, trackId, at) {
     props: { ...DEFAULT_PROPS },
   };
   project.clips.push(c);
-  // Video+audio: put picture on a V track and a linked sound clip on A1.
+  // Video+audio: picture on a V track; stereo L/R as separate linked clips on A1/A2.
   // Mute the video clip so audio isn't doubled.
   if (kind === "video") {
     c.props.volume = 0;
-    const a = {
+    const lg = "lg_" + uid();
+    c.linkGroup = lg;
+    const aL = {
       id: "c_" + uid(), mediaId: m.id, kind: "audio", track: "A1",
       start, in: 0, duration, name,
-      props: { ...DEFAULT_PROPS },
-      linkedId: c.id,
+      props: { ...DEFAULT_PROPS, audioChannel: 0 },
+      linkGroup: lg,
     };
-    c.linkedId = a.id;
-    project.clips.push(a);
+    const aR = {
+      id: "c_" + uid(), mediaId: m.id, kind: "audio", track: "A2",
+      start, in: 0, duration, name,
+      props: { ...DEFAULT_PROPS, audioChannel: 1 },
+      linkGroup: lg,
+    };
+    project.clips.push(aL, aR);
     ensureWave(m);
   }
   selectClip(c.id); scheduleSave();
@@ -1123,6 +1164,7 @@ function splitClipAt(c, t) {
     keyframes: shiftKF(c.keyframes, cut, clipEnd(c) - t),
     transitionIn: undefined,
     linkedId: undefined,
+    linkGroup: undefined,
   };
   c.duration = cut;
   c.keyframes = shiftKF(c.keyframes, 0, cut);
@@ -1132,14 +1174,21 @@ function splitClipAt(c, t) {
 }
 /* After splitting a set of clips, wire each new right half to its partner's right half. */
 function relinkSplitRights(targets, newLink) {
+  const newGroups = new Map(); // old linkGroup -> new linkGroup for right halves
   for (const c of targets) {
     const right = newLink.get(c.id);
-    const partner = c.linkedId ? newLink.get(c.linkedId) : null;
-    if (right && partner) {
-      right.linkedId = partner.id;
-      partner.linkedId = right.id;
-    } else if (right) {
-      delete right.linkedId;
+    if (!right) continue;
+    if (c.linkGroup) {
+      if (!newGroups.has(c.linkGroup)) newGroups.set(c.linkGroup, "lg_" + uid());
+      right.linkGroup = newGroups.get(c.linkGroup);
+    } else {
+      const partner = c.linkedId ? newLink.get(c.linkedId) : null;
+      if (partner) {
+        right.linkedId = partner.id;
+        partner.linkedId = right.id;
+      } else {
+        delete right.linkedId;
+      }
     }
   }
 }
@@ -1377,12 +1426,17 @@ function rebuildClips() {
       const thumb = runtime.mediaAux.get(c.mediaId)?.thumb;
       if (thumb) body += `<div class="thumbs" style="background-image:url('${thumb}')"></div>`;
     }
-    const hasWave = c.kind === "audio" && runtime.wavePeaks.get(c.mediaId) instanceof Float32Array;
+    const hasWave = c.kind === "audio" && !!wavePeaksFor(c);
     if (hasWave) body += `<canvas class="wave"></canvas>`;
-    const badge = c.keyframes && Object.keys(c.keyframes).length ? "◆ " : "";
+    const badge = (c.keyframes && Object.keys(c.keyframes).length ? "◆ " : "") +
+                  (c.transitionIn || c.transitionOut ? "⇄ " : "");
+    const chTag = c.props?.audioChannel === 0 ? "L · "
+                : c.props?.audioChannel === 1 ? "R · " : "";
     body += `<div class="fade"></div>
       <div class="clip-label">${badge}${c.kind === "text" ? "T · " + (c.props.text || "").split("\n")[0]
-        : c.kind === "adjust" ? "FX · " + c.name : c.name}</div>`;
+        : c.kind === "adjust" ? "FX · " + c.name
+        : c.kind === "audio" ? chTag + c.name
+        : c.name}</div>`;
     let inner = `<div class="clip-body">${body}</div>`;
     inner += transitionMarksHtml(c, tr.h);
     inner += `<div class="handle l"></div><div class="handle r"></div>`;
@@ -1397,7 +1451,7 @@ function rebuildClips() {
 
 /* Render decoded peaks for the [in, in+duration] slice of the clip's media */
 function drawClipWave(cv, c, trackH) {
-  const peaks = runtime.wavePeaks.get(c.mediaId);
+  const peaks = wavePeaksFor(c);
   if (!(peaks instanceof Float32Array)) return;
   const w = Math.min(2400, Math.max(8, Math.round(c.duration * state.pps)));
   const h = trackH - 8;
@@ -2082,7 +2136,10 @@ function renderInspector(lite) {
     </div>`;
   }
   if (c.kind === "video" || c.kind === "audio") {
+    const chLabel = c.props?.audioChannel === 0 ? "Left"
+                  : c.props?.audioChannel === 1 ? "Right" : null;
     html += `<div class="insp-section"><h3>Audio / Time</h3>
+      ${chLabel ? row("Channel", `<span style="opacity:.75">${chLabel}</span>`) : ""}
       ${slider("volume", 0, 2, 0.01, p.volume)}
       ${slider("speed", 0.25, 4, 0.05, p.speed, "×")}
     </div>`;
@@ -2283,7 +2340,12 @@ function releaseClipEl(id) {
   const el = runtime.clipEls.get(id);
   if (el) { try { el.pause(); el.src = ""; } catch { } runtime.clipEls.delete(id); }
   const g = runtime.clipGain.get(id);
-  if (g) { try { g.disconnect(); } catch { } runtime.clipGain.delete(id); }
+  if (g) {
+    try { g.disconnect(); } catch {}
+    if (g._fcOut) { try { g._fcOut.disconnect(); } catch {} }
+    if (g._fcSplit) { try { g._fcSplit.disconnect(); } catch {} }
+    runtime.clipGain.delete(id);
+  }
 }
 function ensureAudio() {
   if (runtime.audio) return runtime.audio;
@@ -2317,9 +2379,23 @@ function hookAudio(c, el) {
   if (!runtime.audio || runtime.clipGain.has(c.id)) return;
   if (c.kind !== "video" && c.kind !== "audio") return;
   try {
-    const src = runtime.audio.ctx.createMediaElementSource(el);
-    const g = runtime.audio.ctx.createGain();
-    src.connect(g);
+    const ctx = runtime.audio.ctx;
+    const src = ctx.createMediaElementSource(el);
+    const g = ctx.createGain();
+    const ch = c.props?.audioChannel;
+    if (ch === 0 || ch === 1) {
+      // Isolate one stereo channel and place it on L or R of the track bus
+      const splitter = ctx.createChannelSplitter(2);
+      const merger = ctx.createChannelMerger(2);
+      src.connect(splitter);
+      splitter.connect(g, ch);
+      g.connect(merger, 0, ch);
+      g._fcSplit = splitter;
+      g._fcOut = merger;
+      g._fcChannel = ch;
+    } else {
+      src.connect(g);
+    }
     runtime.clipGain.set(c.id, g);
     routeClipGain(c);
   } catch {}
@@ -2329,10 +2405,11 @@ function routeClipGain(c) {
   const g = runtime.clipGain.get(c.id);
   if (!g || !runtime.audio) return;
   const bus = runtime.audio.trackBus[c.track] || runtime.audio.master;
-  if (g._fcBus === bus) return;
-  try { g.disconnect(); } catch {}
-  g.connect(bus);
-  g._fcBus = bus;
+  const out = g._fcOut || g;
+  if (out._fcBus === bus) return;
+  try { out.disconnect(); } catch {}
+  out.connect(bus);
+  out._fcBus = bus;
 }
 
 /* ── Per-track meters: RMS / LUFS-M / Peak (AudioWorklet) ── */
@@ -3765,7 +3842,17 @@ async function renderAudioMix(dur) {
     for (let i = 0; i < n; i++)
       curve[i] = clamp(evalProps(c, c.start + (i / (n - 1)) * c.duration).volume, 0, 4);
     g.gain.setValueCurveAtTime(curve, Math.max(0, c.start), Math.max(0.01, c.duration));
-    src.connect(g); g.connect(off.destination);
+    const ch = c.props?.audioChannel;
+    if (ch === 0 || ch === 1) {
+      const splitter = off.createChannelSplitter(2);
+      const merger = off.createChannelMerger(2);
+      src.connect(splitter);
+      splitter.connect(g, ch);
+      g.connect(merger, 0, ch);
+      merger.connect(off.destination);
+    } else {
+      src.connect(g); g.connect(off.destination);
+    }
     if (hasSpeedRamp(c)) {
       const rc = new Float32Array(n);
       for (let i = 0; i < n; i++)

--- a/app.js
+++ b/app.js
@@ -502,7 +502,8 @@ function getAudioBuffer(m) {
   return p;
 }
 function ensureWave(m) {
-  if (m.kind !== "audio" || runtime.wavePeaks.has(m.id)) return;
+  // Also decode peaks from video files when their audio is placed on an A track
+  if ((m.kind !== "audio" && m.kind !== "video") || runtime.wavePeaks.has(m.id)) return;
   runtime.wavePeaks.set(m.id, null); // pending
   getAudioBuffer(m).then((buf) => {
     const n = Math.max(1, Math.ceil(buf.duration * WAVE_PEAKS_PER_SEC));
@@ -767,6 +768,27 @@ function redo() {
 function defaultTrackFor(kind) {
   return kind === "audio" ? "A1" : kind === "svg" ? "V3" : "V1";
 }
+function linkedClip(c) {
+  return c?.linkedId ? getClip(c.linkedId) : null;
+}
+/* Expand a clip list so each AV-linked partner is included once. */
+function withLinked(clips) {
+  const out = new Map();
+  for (const c of clips) {
+    out.set(c.id, c);
+    const L = linkedClip(c);
+    if (L) out.set(L.id, L);
+  }
+  return [...out.values()];
+}
+function syncLinkedTiming(c) {
+  const L = linkedClip(c);
+  if (!L) return;
+  L.start = c.start;
+  L.in = c.in;
+  L.duration = c.duration;
+  if (c.props?.speed != null) L.props.speed = c.props.speed;
+}
 
 function addClipFromMedia(m, trackId, at) {
   pushUndo();
@@ -774,13 +796,29 @@ function addClipFromMedia(m, trackId, at) {
   trackId = trackId || defaultTrackFor(kind);
   const tr = TRACKS.find((t) => t.id === trackId);
   if (!tr || (kind === "audio") !== (tr.kind === "audio")) trackId = defaultTrackFor(kind);
+  const start = Math.max(0, at ?? state.time);
+  const duration = m.duration || 5;
+  const name = m.name.replace(/\.[^.]+$/, "");
   const c = {
     id: "c_" + uid(), mediaId: m.id, kind, track: trackId,
-    start: Math.max(0, at ?? state.time), in: 0,
-    duration: m.duration || 5, name: m.name.replace(/\.[^.]+$/, ""),
+    start, in: 0, duration, name,
     props: { ...DEFAULT_PROPS },
   };
   project.clips.push(c);
+  // Video+audio: put picture on a V track and a linked sound clip on A1.
+  // Mute the video clip so audio isn't doubled.
+  if (kind === "video") {
+    c.props.volume = 0;
+    const a = {
+      id: "c_" + uid(), mediaId: m.id, kind: "audio", track: "A1",
+      start, in: 0, duration, name,
+      props: { ...DEFAULT_PROPS },
+      linkedId: c.id,
+    };
+    c.linkedId = a.id;
+    project.clips.push(a);
+    ensureWave(m);
+  }
   selectClip(c.id); scheduleSave();
   return c;
 }
@@ -885,11 +923,12 @@ function addAdjust() {
   selectClip(c.id); scheduleSave();
 }
 function deleteSelected() {
-  const doomed = selectedClips();
+  let doomed = withLinked(selectedClips());
   if (!doomed.length) return;
   pushUndo();
+  const ids = new Set(doomed.map((c) => c.id));
   for (const c of doomed) releaseClipEl(c.id);
-  project.clips = project.clips.filter((x) => !state.selIds.has(x.id));
+  project.clips = project.clips.filter((x) => !ids.has(x.id));
   setSelection([]);
   scheduleSave(); renderInspector();
 }
@@ -1061,10 +1100,16 @@ function goToNextGap() {
 function splitAtPlayhead() {
   const t = state.time;
   let targets = state.selIds.size ? selectedClips() : project.clips;
-  targets = targets.filter((c) => t > c.start + MIN_DUR && t < clipEnd(c) - MIN_DUR);
+  targets = withLinked(targets.filter((c) => t > c.start + MIN_DUR && t < clipEnd(c) - MIN_DUR));
   if (!targets.length) return;
   pushUndo();
-  for (const c of targets) splitClipAt(c, t);
+  // Pair linked splits so the new right halves stay linked to each other
+  const newLink = new Map(); // oldClipId -> newRightId
+  for (const c of targets) {
+    const right = splitClipAt(c, t);
+    if (right) newLink.set(c.id, right);
+  }
+  relinkSplitRights(targets, newLink);
   scheduleSave();
 }
 /* Cut a clip at timeline time t (must fall strictly inside the clip). Leaves
@@ -1077,12 +1122,26 @@ function splitClipAt(c, t) {
     start: t, in: c.in + cut * clipSpeed(c), duration: clipEnd(c) - t,
     keyframes: shiftKF(c.keyframes, cut, clipEnd(c) - t),
     transitionIn: undefined,
+    linkedId: undefined,
   };
   c.duration = cut;
   c.keyframes = shiftKF(c.keyframes, 0, cut);
   c.transitionOut = undefined;
   project.clips.push(right);
   return right;
+}
+/* After splitting a set of clips, wire each new right half to its partner's right half. */
+function relinkSplitRights(targets, newLink) {
+  for (const c of targets) {
+    const right = newLink.get(c.id);
+    const partner = c.linkedId ? newLink.get(c.linkedId) : null;
+    if (right && partner) {
+      right.linkedId = partner.id;
+      partner.linkedId = right.id;
+    } else if (right) {
+      delete right.linkedId;
+    }
+  }
 }
 /* Split every enabled-track clip that crosses IN and/or OUT (no head/tail removal). */
 function splitAtWorkArea() {
@@ -1092,17 +1151,20 @@ function splitAtWorkArea() {
     return;
   }
   const onTrack = (c) => typeof isTrackEnabled !== "function" || isTrackEnabled(c.track);
-  const targets = project.clips.filter((c) =>
+  const targets = withLinked(project.clips.filter((c) =>
     onTrack(c) && cuts.some((t) => t > c.start + MIN_DUR && t < clipEnd(c) - MIN_DUR)
-  );
+  ));
   if (!targets.length) { toast("Nothing to split at IN/OUT"); return; }
   pushUndo();
   // Right-to-left so each successive cut still lands on the left-hand piece
-  for (const c of targets) {
-    const pts = cuts
-      .filter((t) => t > c.start + MIN_DUR && t < clipEnd(c) - MIN_DUR)
-      .sort((a, b) => b - a);
-    for (const t of pts) splitClipAt(c, t);
+  for (const t of cuts.slice().sort((a, b) => b - a)) {
+    const atT = targets.filter((c) => t > c.start + MIN_DUR && t < clipEnd(c) - MIN_DUR);
+    const newLink = new Map();
+    for (const c of atT) {
+      const right = splitClipAt(c, t);
+      if (right) newLink.set(c.id, right);
+    }
+    relinkSplitRights(atT, newLink);
   }
   scheduleSave();
 }
@@ -1118,6 +1180,7 @@ function trimToPlayhead(side) {
   } else if (side === "out" && t > c.start + MIN_DUR && t < clipEnd(c)) {
     c.duration = t - c.start;
   }
+  syncLinkedTiming(c);
   scheduleSave(); renderInspector();
 }
 /* Split at IN/OUT and discard clip heads before IN and tails after OUT.
@@ -1555,9 +1618,13 @@ function startClipGesture(e, c, mode, collapseOnClick) {
     start: c.start, in: c.in, duration: c.duration, track: c.track,
     keyframes: c.keyframes ? JSON.parse(JSON.stringify(c.keyframes)) : undefined,
   };
-  // moving a clip that belongs to a multi-selection drags the whole group
-  const group = mode === "move" && state.selIds.has(c.id) ? selectedClips() : [c];
-  const groupOrig = new Map(group.map((x) => [x.id, x.start]));
+  // moving a clip that belongs to a multi-selection drags the whole group;
+  // AV-linked partners (video+audio from one file) always move together
+  const group = withLinked(mode === "move" && state.selIds.has(c.id) ? selectedClips() : [c]);
+  const groupOrig = new Map(group.map((x) => [x.id, {
+    start: x.start, in: x.in, duration: x.duration,
+    keyframes: x.keyframes ? JSON.parse(JSON.stringify(x.keyframes)) : undefined,
+  }]));
   const groupIds = new Set(group.map((x) => x.id));
   const t0 = timeAtEvent(e);
   let moved = false;
@@ -1581,17 +1648,16 @@ function startClipGesture(e, c, mode, collapseOnClick) {
       else if (dStart > 0) ns = snapStart;
       // one time-delta for the whole group, clamped so nothing crosses 0
       let d = ns - orig.start;
-      d = Math.max(d, -Math.min(...group.map((x) => groupOrig.get(x.id))));
-      for (const x of group) x.start = groupOrig.get(x.id) + d;
-      if (group.length === 1) {
-        const tk = trackAtEvent(ev);
-        if (tk) {
-          const trk = TRACKS.find((t) => t.id === tk);
-          if (trk && (c.kind === "audio") === (trk.kind === "audio")) c.track = tk;
-        }
+      d = Math.max(d, -Math.min(...group.map((x) => groupOrig.get(x.id).start)));
+      for (const x of group) x.start = groupOrig.get(x.id).start + d;
+      // Dragged clip may change track; its AV-linked partner stays on its own lane
+      const tk = trackAtEvent(ev);
+      if (tk) {
+        const trk = TRACKS.find((t) => t.id === tk);
+        if (trk && (c.kind === "audio") === (trk.kind === "audio")) c.track = tk;
       }
     } else if (mode === "trim-l") {
-      let ns = snapTime(orig.start + dt, c.id);
+      let ns = snapTime(orig.start + dt, groupIds);
       const sp = clipSpeed(c);
       const maxShiftLeft = (c.kind === "video" || c.kind === "audio") ? orig.in / sp : 1e6;
       ns = clamp(ns, Math.max(0, orig.start - maxShiftLeft), orig.start + orig.duration - MIN_DUR);
@@ -1600,13 +1666,15 @@ function startClipGesture(e, c, mode, collapseOnClick) {
       c.in = (c.kind === "video" || c.kind === "audio") ? orig.in + d * sp : 0;
       c.duration = orig.duration - d;
       c.keyframes = shiftKF(orig.keyframes, d, c.duration);
+      syncLinkedTiming(c);
     } else { // trim-r
-      let ne = snapTime(orig.start + orig.duration + dt, c.id);
+      let ne = snapTime(orig.start + orig.duration + dt, groupIds);
       let maxDur = 1e6;
       if ((c.kind === "video" || c.kind === "audio") && media?.duration)
         maxDur = (media.duration - orig.in) / clipSpeed(c);
       c.duration = clamp(ne - orig.start, MIN_DUR, maxDur);
       c.keyframes = shiftKF(orig.keyframes, 0, c.duration);
+      syncLinkedTiming(c);
     }
     state.dirtyTimeline = true;
     renderInspector(true);

--- a/app.js
+++ b/app.js
@@ -2416,6 +2416,8 @@ function routeClipGain(c) {
 const METER_SEGS = 16;
 const METER_DB_MIN = -48;
 const METER_DB_MAX = 0;
+/** Scale tick marks shown beside the meter bars (dBFS). */
+const METER_DB_MARKS = [0, -6, -12, -24, -36, -48];
 const METER_MODES = ["rms", "lufs", "peak"];
 const METER_MODE_LABEL = { rms: "RMS", lufs: "LUFS", peak: "PEAK" };
 const meterState = {
@@ -2528,6 +2530,19 @@ function buildMeterDOM() {
 
   const row = document.createElement("div");
   row.className = "vu-channels";
+
+  const scale = document.createElement("div");
+  scale.className = "vu-scale";
+  const span = METER_DB_MAX - METER_DB_MIN;
+  for (const db of METER_DB_MARKS) {
+    const tick = document.createElement("span");
+    tick.className = "vu-scale-tick";
+    tick.textContent = db === 0 ? "0" : String(db);
+    tick.style.top = ((METER_DB_MAX - db) / span * 100) + "%";
+    scale.appendChild(tick);
+  }
+  row.appendChild(scale);
+
   meterState.segs = {};
   meterState.trackIds = tracks.map((t) => t.id);
   for (const t of tracks) {

--- a/app.js
+++ b/app.js
@@ -360,6 +360,8 @@ function applyProject(data) {
       if (Array.isArray(arr)) arr.sort((a, b) => a.t - b.t);
     if (c.kind === "text") ensureFont(c.props.font);
   }
+  // AV links aren't always on disk (older saves / agents) — rebuild from matching timing.
+  relinkClips();
   // reset runtime playback elements so they rebuild against new data
   for (const el of runtime.clipEls.values()) { try { el.pause(); el.src = ""; } catch { } }
   runtime.clipEls.clear(); runtime.clipGain.clear();
@@ -397,8 +399,12 @@ function projectJSON() {
     name, width, height, fps, background, revision,
     media: media.filter((m) => !m.transient).map(({ id, name, kind, src, duration, width, height }) =>
       ({ id, name, kind, src, duration, width, height })),
-    clips: clips.map(({ id, mediaId, kind, track, start, in: inn, duration, name, props, keyframes, transitionIn, transitionOut }) =>
-      ({ id, mediaId, kind, track, start, in: inn, duration, name, props, keyframes, transitionIn, transitionOut })),
+    clips: clips.map(({ id, mediaId, kind, track, start, in: inn, duration, name, props, keyframes, transitionIn, transitionOut, linkedId, linkGroup }) => {
+      const out = { id, mediaId, kind, track, start, in: inn, duration, name, props, keyframes, transitionIn, transitionOut };
+      if (linkGroup) out.linkGroup = linkGroup;
+      if (linkedId) out.linkedId = linkedId;
+      return out;
+    }),
     markers: (markers || []).map(({ t, label }) => (label ? { t, label } : { t })),
     inPoint: inPoint == null ? null : inPoint,
     outPoint: outPoint == null ? null : outPoint,
@@ -820,6 +826,36 @@ function syncLinkedTiming(c) {
     if (c.props?.speed != null) {
       L.props = L.props || {};
       L.props.speed = c.props.speed;
+    }
+  }
+}
+/* Rebuild AV linkGroups after load. Unlinking isn't supported, so any video +
+   audio clips that share mediaId and the same start/in/duration belong together
+   (e.g. picture + L/R stems from one file). Legacy pairwise linkedId is cleared
+   in favor of linkGroup. */
+function relinkClips() {
+  const near = (a, b) => Math.abs((+a || 0) - (+b || 0)) < 1e-3;
+  for (const c of project.clips) {
+    delete c.linkGroup;
+    delete c.linkedId;
+  }
+  const audios = project.clips.filter((c) => c.kind === "audio" && c.mediaId);
+  const used = new Set();
+  for (const v of project.clips) {
+    if (v.kind !== "video" || !v.mediaId) continue;
+    const partners = audios.filter((a) =>
+      !used.has(a.id) &&
+      a.mediaId === v.mediaId &&
+      near(a.start, v.start) &&
+      near(a.in, v.in) &&
+      near(a.duration, v.duration)
+    );
+    if (!partners.length) continue;
+    const lg = "lg_" + uid();
+    v.linkGroup = lg;
+    for (const a of partners) {
+      a.linkGroup = lg;
+      used.add(a.id);
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -77,10 +77,7 @@
           <div class="sa-ui-bottom"></div>
           <div class="sa-ui-right"></div>
         </div>
-        <div class="vu-meter" id="vuMeter" title="Master RMS" aria-hidden="true">
-          <div class="vu-channel" data-ch="0"><div class="vu-segs"></div><span class="vu-label">L</span></div>
-          <div class="vu-channel" data-ch="1"><div class="vu-segs"></div><span class="vu-label">R</span></div>
-        </div>
+        <div class="vu-meter" id="vuMeter" title="Click to switch RMS / LUFS / Peak"></div>
       </div>
       <div class="transport">
         <span class="timecode" id="tcCurrent">00:00:00</span>

--- a/index.html
+++ b/index.html
@@ -77,6 +77,10 @@
           <div class="sa-ui-bottom"></div>
           <div class="sa-ui-right"></div>
         </div>
+        <div class="vu-meter" id="vuMeter" title="Master RMS" aria-hidden="true">
+          <div class="vu-channel" data-ch="0"><div class="vu-segs"></div><span class="vu-label">L</span></div>
+          <div class="vu-channel" data-ch="1"><div class="vu-segs"></div><span class="vu-label">R</span></div>
+        </div>
       </div>
       <div class="transport">
         <span class="timecode" id="tcCurrent">00:00:00</span>

--- a/meter-worklet.js
+++ b/meter-worklet.js
@@ -1,67 +1,164 @@
-/* FableCut master-bus meter worklet.
-   Computes per-channel RMS (and peak) on the audio thread and posts
-   snapshots to the main thread. Passes audio through unchanged.
+/* FableCut per-track meter worklet.
+   Each input = one timeline audio track. Pass-through mix to stereo out.
+   Reports per-track: RMS, sample peak, and momentary LUFS (ITU-R BS.1770-4,
+   400 ms, K-weighted stereo). */
+function shelfCoeffs(fs) {
+  const f0 = 1681.974450955533;
+  const G = 3.999843853973347;
+  const Q = 0.7071752369554196;
+  const K = Math.tan(Math.PI * f0 / fs);
+  const Vh = Math.pow(10, G / 20);
+  const Vb = Math.pow(Vh, 0.5);
+  const a0 = 1 + K / Q + K * K;
+  return {
+    b0: (Vh + Vb * K / Q + K * K) / a0,
+    b1: 2 * (K * K - Vh) / a0,
+    b2: (Vh - Vb * K / Q + K * K) / a0,
+    a1: 2 * (K * K - 1) / a0,
+    a2: (1 - K / Q + K * K) / a0,
+  };
+}
+function hpfCoeffs(fs) {
+  const f0 = 38.13547087613982;
+  const Q = 0.5003270373238773;
+  const K = Math.tan(Math.PI * f0 / fs);
+  const a0 = 1 + K / Q + K * K;
+  return {
+    b0: 1 / a0,
+    b1: -2 / a0,
+    b2: 1 / a0,
+    a1: 2 * (K * K - 1) / a0,
+    a2: (1 - K / Q + K * K) / a0,
+  };
+}
+function makeBiquad(c) {
+  return { b0: c.b0, b1: c.b1, b2: c.b2, a1: c.a1, a2: c.a2, z1: 0, z2: 0 };
+}
+function biquadStep(f, x) {
+  const y = f.b0 * x + f.z1;
+  f.z1 = f.b1 * x - f.a1 * y + f.z2;
+  f.z2 = f.b2 * x - f.a2 * y;
+  return y;
+}
 
-   Layout is reserved for future LUFS (K-weighting + gated loudness):
-   keep the report payload stable and accumulate in process() only. */
 class FableCutMeterProcessor extends AudioWorkletProcessor {
   constructor(options) {
     super();
     const opts = (options && options.processorOptions) || {};
-    // How many render quanta to average before posting (~8 × 128 ≈ 23 ms @ 44.1k)
     this._hopBlocks = Math.max(1, opts.hopBlocks || 8);
+    this._nTracks = Math.max(1, opts.nTracks || 1);
+    this._ids = opts.trackIds || [];
     this._block = 0;
-    this._sumSq = [0, 0];
-    this._peak = [0, 0];
+    this._sumSq = new Float64Array(this._nTracks);
+    this._peak = new Float64Array(this._nTracks);
+    this._sumSqK = new Float64Array(this._nTracks);
     this._frames = 0;
-    // Future LUFS: mean-square of K-weighted signal, block energy ring, etc.
-    // this._kWeight = …; this._lufsBlocks = [];
+
+    const shelf = shelfCoeffs(sampleRate);
+    const hpf = hpfCoeffs(sampleRate);
+    this._shelfL = [];
+    this._hpfL = [];
+    this._shelfR = [];
+    this._hpfR = [];
+    for (let t = 0; t < this._nTracks; t++) {
+      this._shelfL.push(makeBiquad(shelf));
+      this._hpfL.push(makeBiquad(hpf));
+      this._shelfR.push(makeBiquad(shelf));
+      this._hpfR.push(makeBiquad(hpf));
+    }
+
+    // Momentary = 400 ms of block mean-squares (BS.1770)
+    const hopFrames = 128 * this._hopBlocks;
+    this._lufsLen = Math.max(1, Math.round(0.4 * sampleRate / hopFrames));
+    this._lufsRing = [];
+    this._lufsIdx = [];
+    this._lufsFilled = [];
+    for (let t = 0; t < this._nTracks; t++) {
+      this._lufsRing.push(new Float64Array(this._lufsLen));
+      this._lufsIdx.push(0);
+      this._lufsFilled.push(0);
+    }
   }
 
   process(inputs, outputs) {
-    const input = inputs[0];
     const output = outputs[0];
-    const chans = Math.max(output.length, input ? input.length : 0, 1);
+    const outL = output && output[0];
+    const outR = output && (output[1] || output[0]);
+    if (outL) outL.fill(0);
+    if (outR && outR !== outL) outR.fill(0);
 
-    for (let ch = 0; ch < output.length; ch++) {
-      const inp = input && input[Math.min(ch, input.length - 1)];
-      const out = output[ch];
-      if (!out) continue;
-      if (inp) {
-        out.set(inp);
-        let sum = this._sumSq[ch] || 0;
-        let peak = this._peak[ch] || 0;
-        for (let i = 0; i < inp.length; i++) {
-          const s = inp[i];
-          sum += s * s;
-          const a = s >= 0 ? s : -s;
-          if (a > peak) peak = a;
-        }
-        this._sumSq[ch] = sum;
-        this._peak[ch] = peak;
-      } else {
-        out.fill(0);
+    let frames = 0;
+    for (let t = 0; t < this._nTracks; t++) {
+      const chans = inputs[t];
+      const has = chans && chans[0];
+      const L = has ? chans[0] : null;
+      const R = has ? (chans[1] || chans[0]) : null;
+      const n = L ? L.length : (outL ? outL.length : 128);
+      frames = n;
+
+      let sum = this._sumSq[t];
+      let peak = this._peak[t];
+      let sumK = this._sumSqK[t];
+      const sL = this._shelfL[t], hL = this._hpfL[t];
+      const sR = this._shelfR[t], hR = this._hpfR[t];
+
+      for (let i = 0; i < n; i++) {
+        const l = L ? L[i] : 0;
+        const r = R ? R[i] : 0;
+        const mono = (l + r) * 0.5;
+        sum += mono * mono;
+        const aL = l >= 0 ? l : -l;
+        const aR = r >= 0 ? r : -r;
+        if (aL > peak) peak = aL;
+        if (aR > peak) peak = aR;
+
+        const fl = biquadStep(hL, biquadStep(sL, l));
+        const fr = biquadStep(hR, biquadStep(sR, r));
+        sumK += fl * fl + fr * fr;
+
+        if (outL) outL[i] += l;
+        if (outR && outR !== outL) outR[i] += r;
       }
+      this._sumSq[t] = sum;
+      this._peak[t] = peak;
+      this._sumSqK[t] = sumK;
     }
-    if (input && input[0]) this._frames += input[0].length;
+
+    if (frames) this._frames += frames;
     this._block++;
 
     if (this._block >= this._hopBlocks) {
       const n = Math.max(1, this._frames);
-      const rms = [];
-      const peak = [];
-      for (let ch = 0; ch < chans; ch++) {
-        rms[ch] = Math.sqrt((this._sumSq[ch] || 0) / n);
-        peak[ch] = this._peak[ch] || 0;
-        this._sumSq[ch] = 0;
-        this._peak[ch] = 0;
+      const rms = new Array(this._nTracks);
+      const peak = new Array(this._nTracks);
+      const lufs = new Array(this._nTracks);
+      for (let t = 0; t < this._nTracks; t++) {
+        rms[t] = Math.sqrt(this._sumSq[t] / n);
+        peak[t] = this._peak[t];
+
+        // Channel-weighted mean square for this hop (L+R, G=1 each)
+        const blockMs = this._sumSqK[t] / n;
+        const ring = this._lufsRing[t];
+        const idx = this._lufsIdx[t];
+        ring[idx] = blockMs;
+        this._lufsIdx[t] = (idx + 1) % this._lufsLen;
+        if (this._lufsFilled[t] < this._lufsLen) this._lufsFilled[t]++;
+        let acc = 0;
+        const filled = this._lufsFilled[t];
+        for (let i = 0; i < filled; i++) acc += ring[i];
+        const meanMs = acc / Math.max(1, filled);
+        lufs[t] = meanMs > 1e-12 ? -0.691 + 10 * Math.log10(meanMs) : -70;
+
+        this._sumSq[t] = 0;
+        this._peak[t] = 0;
+        this._sumSqK[t] = 0;
       }
       this.port.postMessage({
         type: "meter",
+        trackIds: this._ids,
         rms,
         peak,
-        // Placeholder for next step (momentary / short-term LUFS)
-        lufs: null,
+        lufs,
         frames: n,
       });
       this._block = 0;

--- a/meter-worklet.js
+++ b/meter-worklet.js
@@ -1,0 +1,74 @@
+/* FableCut master-bus meter worklet.
+   Computes per-channel RMS (and peak) on the audio thread and posts
+   snapshots to the main thread. Passes audio through unchanged.
+
+   Layout is reserved for future LUFS (K-weighting + gated loudness):
+   keep the report payload stable and accumulate in process() only. */
+class FableCutMeterProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+    const opts = (options && options.processorOptions) || {};
+    // How many render quanta to average before posting (~8 × 128 ≈ 23 ms @ 44.1k)
+    this._hopBlocks = Math.max(1, opts.hopBlocks || 8);
+    this._block = 0;
+    this._sumSq = [0, 0];
+    this._peak = [0, 0];
+    this._frames = 0;
+    // Future LUFS: mean-square of K-weighted signal, block energy ring, etc.
+    // this._kWeight = …; this._lufsBlocks = [];
+  }
+
+  process(inputs, outputs) {
+    const input = inputs[0];
+    const output = outputs[0];
+    const chans = Math.max(output.length, input ? input.length : 0, 1);
+
+    for (let ch = 0; ch < output.length; ch++) {
+      const inp = input && input[Math.min(ch, input.length - 1)];
+      const out = output[ch];
+      if (!out) continue;
+      if (inp) {
+        out.set(inp);
+        let sum = this._sumSq[ch] || 0;
+        let peak = this._peak[ch] || 0;
+        for (let i = 0; i < inp.length; i++) {
+          const s = inp[i];
+          sum += s * s;
+          const a = s >= 0 ? s : -s;
+          if (a > peak) peak = a;
+        }
+        this._sumSq[ch] = sum;
+        this._peak[ch] = peak;
+      } else {
+        out.fill(0);
+      }
+    }
+    if (input && input[0]) this._frames += input[0].length;
+    this._block++;
+
+    if (this._block >= this._hopBlocks) {
+      const n = Math.max(1, this._frames);
+      const rms = [];
+      const peak = [];
+      for (let ch = 0; ch < chans; ch++) {
+        rms[ch] = Math.sqrt((this._sumSq[ch] || 0) / n);
+        peak[ch] = this._peak[ch] || 0;
+        this._sumSq[ch] = 0;
+        this._peak[ch] = 0;
+      }
+      this.port.postMessage({
+        type: "meter",
+        rms,
+        peak,
+        // Placeholder for next step (momentary / short-term LUFS)
+        lufs: null,
+        frames: n,
+      });
+      this._block = 0;
+      this._frames = 0;
+    }
+    return true;
+  }
+}
+
+registerProcessor("fablecut-meter", FableCutMeterProcessor);

--- a/style.css
+++ b/style.css
@@ -564,7 +564,7 @@ body.track-size-s .clip.selected {
 /* ── Per-track VU (RMS / LUFS / Peak) ── */
 .vu-meter {
   position: absolute;
-  right: 10px;
+  right: 2px;
   bottom: 10px;
   display: flex;
   flex-direction: column;
@@ -593,8 +593,28 @@ body.track-size-s .clip.selected {
 .vu-mode:hover { opacity: 1; color: #fff; }
 .vu-channels {
   display: flex;
+  align-items: flex-start;
   gap: 4px;
 }
+.vu-scale {
+  position: relative;
+  /* Match .vu-segs height: 16×8px + 15×2px gap */
+  width: 16px;
+  height: 158px;
+  margin-right: 0px;
+  pointer-events: none;
+}
+.vu-scale-tick {
+  position: absolute;
+  right: 0;
+  transform: translateY(-50%);
+  font: 700 8px/1 ui-sans-serif, system-ui, sans-serif;
+  color: #8b8b93;
+  letter-spacing: .2px;
+  white-space: nowrap;
+}
+.vu-scale-tick:first-child { transform: translateY(0); }
+.vu-scale-tick:last-child { transform: translateY(-100%); }
 .vu-channel {
   display: flex;
   flex-direction: column;
@@ -608,7 +628,7 @@ body.track-size-s .clip.selected {
 }
 .vu-seg {
   width: 8px;
-  height: 8px;
+  height: 12px;
   border-radius: 1px;
   background: #2a2a33;
   box-shadow: inset 0 0 0 1px #0006;

--- a/style.css
+++ b/style.css
@@ -598,9 +598,9 @@ body.track-size-s .clip.selected {
 }
 .vu-scale {
   position: relative;
-  /* Match .vu-segs height: 16×8px + 15×2px gap */
+  /* Match .vu-segs height: 16×12px + 15×2px gap */
   width: 16px;
-  height: 158px;
+  height: 222px;
   margin-right: 0px;
   pointer-events: none;
 }

--- a/style.css
+++ b/style.css
@@ -199,7 +199,7 @@ body.resizing-panels * {
 
 body.track-size-s .clip .clip-label {
   font-size: 10px;
-  padding: 1px 6px;
+  padding: 0 6px;
 }
 
 body.track-size-s .clip .fade {
@@ -1092,9 +1092,12 @@ input[type=range] {
 .clip .clip-label {
   position: absolute;
   inset: 0;
-  padding: 3px 8px;
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
   font-size: 11px;
   font-weight: 600;
+  line-height: 1;
   color: #fff;
   text-shadow: 0 1px 2px #000c;
   white-space: nowrap;

--- a/style.css
+++ b/style.css
@@ -565,14 +565,12 @@ body.track-size-s .clip.selected {
 .vu-meter {
   position: absolute;
   right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
+  bottom: 10px;
   display: flex;
   gap: 5px;
   z-index: 4;
   pointer-events: none;
   padding: 6px 5px 4px;
-  border-radius: 6px;
   background: #000a;
 }
 .vu-channel {
@@ -587,8 +585,8 @@ body.track-size-s .clip.selected {
   gap: 2px;
 }
 .vu-seg {
-  width: 9px;
-  height: 5px;
+  width: 8px;
+  height: 8px;
   border-radius: 1px;
   background: #2a2a33;
   box-shadow: inset 0 0 0 1px #0006;

--- a/style.css
+++ b/style.css
@@ -1064,6 +1064,22 @@ input[type=range] {
   background-color: #7b6cff14;
 }
 
+/* Same-track audio overlap — hatched band over the shared time range */
+.track-overlap {
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  z-index: 2;
+  pointer-events: none;
+  border-radius: 3px;
+  background: repeating-linear-gradient(
+    -45deg,
+    transparent 0 3px,
+    #ff5a5a55 3px 6px
+  );
+  box-shadow: inset 0 0 0 1px #ff6b6bcc;
+}
+
 /* ── Clips ── */
 .clip {
   position: absolute;

--- a/style.css
+++ b/style.css
@@ -561,6 +561,49 @@ body.track-size-s .clip.selected {
   background: #000;
 }
 
+/* ── Master VU (segmented RMS) ── */
+.vu-meter {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  gap: 5px;
+  z-index: 4;
+  pointer-events: none;
+  padding: 6px 5px 4px;
+  border-radius: 6px;
+  background: #000a;
+}
+.vu-channel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+.vu-segs {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 2px;
+}
+.vu-seg {
+  width: 9px;
+  height: 5px;
+  border-radius: 1px;
+  background: #2a2a33;
+  box-shadow: inset 0 0 0 1px #0006;
+}
+.vu-seg.on.g { background: #3dd68c; box-shadow: none; }
+.vu-seg.on.y { background: #f0c14a; box-shadow: none; }
+.vu-seg.on.r { background: #e5484d; box-shadow: none; }
+.vu-label {
+  font-size: 9px;
+  font-weight: 700;
+  color: #8b8b93;
+  letter-spacing: .3px;
+  line-height: 1;
+}
+
 .head-select {
   background: var(--panel-2);
   border: 1px solid var(--border);

--- a/style.css
+++ b/style.css
@@ -561,17 +561,39 @@ body.track-size-s .clip.selected {
   background: #000;
 }
 
-/* ── Master VU (segmented RMS) ── */
+/* ── Per-track VU (RMS / LUFS / Peak) ── */
 .vu-meter {
   position: absolute;
   right: 10px;
   bottom: 10px;
   display: flex;
-  gap: 5px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
   z-index: 4;
-  pointer-events: none;
-  padding: 6px 5px 4px;
+  pointer-events: auto;
+  padding: 5px 5px 4px;
   background: #000a;
+  user-select: none;
+}
+.vu-mode {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 2px 0 2px;
+  border: 0;
+  background: transparent;
+  color: #c8c8d0;
+  font: 700 9px/1 ui-sans-serif, system-ui, sans-serif;
+  letter-spacing: .6px;
+  text-align: center;
+  cursor: pointer;
+  opacity: .85;
+}
+.vu-mode:hover { opacity: 1; color: #fff; }
+.vu-channels {
+  display: flex;
+  gap: 4px;
 }
 .vu-channel {
   display: flex;


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

This is just a proposal how video clips with audio tracks could be represented on the timeline. Audio tracks are separated yet linked to the video clip. 



## Type of change

- [ ] Bug fix
- [X] New feature (timeline display)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [ ] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [ ] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Program Monitor VU meter with click-to-switch between RMS, LUFS, and Peak, plus per-track stereo metering (Left/Right).
  * Improved timeline visuals: new audio A4 track, hatched bands for overlapping audio clips, and waveform previews that work with stereo audio placement.
  * Clip cards/inspector now reflect stereo channel placement with Left/Right labeling.
* **Bug Fixes**
  * AV-linked clips stay synchronized across project load/save and editing actions (move, split, trim, delete).
* **Documentation / UI**
  * Updated default track counts to 3 video tracks and 4 audio tracks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->