### PR TITLE
feat: use monochrome icons only

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,8 +106,8 @@
   <section class="panel timeline-panel" id="timelinePanel">
     <div class="timeline-toolbar">
       <button class="btn tiny" id="btnSplit" title="Split at playhead (S)">✂ Split</button>
-      <button class="btn tiny" id="btnDelete" title="Delete selected (Del)">🗑 Delete</button>
-      <button class="btn tiny toggle on" id="btnSnap" title="Toggle snapping (N)">🧲 Snap</button>
+      <button class="btn tiny" id="btnDelete" title="Delete selected (Del)"><svg class="ico" viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"><path fill="currentColor" d="M5.5 1.5h5v1.25H14v1.5H2v-1.5h3.5V1.5zM3.75 5.5h8.5v8.25a1.5 1.5 0 0 1-1.5 1.5h-5.5a1.5 1.5 0 0 1-1.5-1.5V5.5zm2 2v5h1.25v-5H5.75zm3.25 0v5H10.25v-5H9z"/></svg> Delete</button>
+      <button class="btn tiny toggle on" id="btnSnap" title="Toggle snapping (N)"><svg class="ico" viewBox="0 0 16 14" width="14" height="12" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="3.25" stroke-linecap="butt" d="M4 10.25V7a4 4 0 0 1 8 0v3.25"/><path fill="currentColor" d="M2.375 10.75h3.25v2.5h-3.25zm8 0h3.25v2.5h-3.25z"/></svg> Snap</button>
       <span class="flex-spacer"></span>
       <span class="dim tiny-label">Zoom</span>
       <input type="range" id="zoomSlider" min="1" max="300" value="60">

--- a/style.css
+++ b/style.css
@@ -305,6 +305,11 @@ body.track-size-s .clip.selected {
   font-size: 12px;
   border-radius: 5px;
 }
+.btn .ico {
+  display: inline-block;
+  vertical-align: -2px;
+  margin-right: 2px;
+}
 
 .btn.tiny.accent {
   border-color: var(--accent);


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

Replaced trashcan and magnet icons with simpler monochrome SVG icons to keep the look of interface consistent.
<img width="334" height="47" alt="image" src="https://github.com/user-attachments/assets/ba8559c3-9c01-474a-8e87-27172a5787ed" />


## Type of change

- [ ] Bug fix
- [X] New feature (monochrome icons)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Delete and Snap toolbar controls with cleaner inline icons.
  * Improved icon alignment and spacing alongside button text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->