### PR TITLE
Transition overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://trendshift.io/repositories/77702?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-77702" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/77702/daily?language=JavaScript" alt="ronak-create%2FFableCut | Trendshift" width="250" height="55"/></a>
 
-https://github.com/user-attachments/assets/2430b854-168b-4a9a-af2e-489e5efa7543
+<https://github.com/user-attachments/assets/2430b854-168b-4a9a-af2e-489e5efa7543>
 
 FableCut is a Premiere-style non-linear video editor that runs entirely in your
 browser — and exposes its whole timeline as one JSON document. Edit it by hand,
@@ -28,6 +28,7 @@ same time.
 ## Features
 
 **Editing**
+
 - 4 video tracks + 3 audio tracks, drag/trim/split/snap, undo/redo
 - **Direct manipulation on the monitor** — click a clip or title on the preview to
   move, resize (corner handles), or rotate (top handle, Shift-snap) it directly
@@ -37,6 +38,7 @@ same time.
   whole group; <kbd>Delete</kbd> removes all selected; <kbd>S</kbd> splits all
   selected at the playhead. Inspector shows an "N clips selected" banner.
 - Beat & cue markers (tap <kbd>⇧m</kbd> on the beat during playback) with edge snapping
+- Press <kbd>Alt+t</kbd> to add an in/out transition based on the playhead position over the selected clip. The last used transition is remembered as the default. Drag the overlay triangle to adjust duration; <kbd>Delete</kbd> clears the focused transition.
 - Real decoded audio waveforms on clips
 - Canvas aspect presets (16:9, 9:16 reels, 4:5, 1:1) + safe-area guides
 - Resizable workspace: drag the divider between monitor and timeline (double-click resets), plus S/M/L timeline track-density presets (S hides thumbnails for compact tracks)
@@ -44,6 +46,7 @@ same time.
 - **IN/OUT work area** — set markers with <kbd>i</kbd> and <kbd>o</kbd> (<kbd>⇧I</kbd> / <kbd>⇧O</kbd> to clear). Enabling **Limit** constrains playback to the marked range and maps <kbd>Home</kbd> / <kbd>End</kbd> to the IN and OUT positions rather than the full timeline. <kbd>t</kbd> splits clips at the markers; <kbd>⇧t</kbd> trims clips to the work (between marker in and marker out) area.
 
 **Look**
+
 - 12 one-click filter presets (cinematic, teal-orange, noir, vintage, cyberpunk…)
 - **Adjustment layers** — one clip grades everything below it, Premiere-style
 - Full grade controls: brightness/contrast/saturation/hue, **temperature & tint**,
@@ -54,6 +57,7 @@ same time.
 - **AI background removal** (person cut-out, in-browser via MediaPipe)
 
 **Motion**
+
 - Keyframe animation on ~25 properties with easing
 - **Speed ramps** — keyframe `speed` and the engine time-remaps video *and* the
   export audio mix (the fast-into-slow-mo reel move)
@@ -62,6 +66,7 @@ same time.
   whip-pan, **glitch**, **pop**
 
 **Text**
+
 - **Title styles** — one-tap cohesive looks (Impact, Elegant, Kinetic cut, Neon,
   Handwritten, and more); new titles vary the font, placement and animation
   automatically instead of defaulting to one flat style
@@ -75,12 +80,14 @@ same time.
   weights, italic, uppercase, alignment, soft shadows
 
 **Animated SVG clips**
+
 - A first-class `svg` clip kind: CSS-`@keyframes`-animated SVGs render
   **frame-accurately** in preview and export (the compositor freezes the
   animation at any time). Agents can author their own vector overlays —
   lower-thirds, confetti, sparkles — as plain `.svg` files. Starters included.
 
 **Remake a reference video**
+
 - Give it a reference edit (a reel you like) and get back an **edit blueprint**:
   shot boundaries, music beats + BPM, a loudness curve, per-shot energy, the
   drop — plus the reference's **music track extracted** into your media, ready
@@ -90,10 +97,12 @@ same time.
   `fablecut_analyze_reference` MCP tool.
 
 **Asset library**
+
 - `library/` folders surface as tabs in the UI: **Elements** (overlay art),
   **Sound FX**, **SVG** — drop files in, the open editor refreshes live
 
 **Export**
+
 - Fast export: browser renders every frame + an offline audio mix, ffmpeg
   encodes a frame-accurate CRF-18 MP4 (keeps rendering if you switch tabs)
 - Realtime MediaRecorder fallback when ffmpeg isn't available
@@ -126,9 +135,11 @@ Three equivalent control surfaces:
 
 1. **MCP** (best for Claude Code / Claude Desktop) — register the bundled
    zero-dependency MCP server once:
+
    ```bash
    claude mcp add -s user fablecut -- node "<path-to>/fablecut/mcp-server.js"
    ```
+
    Tools: `fablecut_status` (auto-starts the editor), `fablecut_docs`,
    `fablecut_get_project`, `fablecut_set_project`, `fablecut_patch_project`,
    `fablecut_import_media`, `fablecut_analyze_reference`.

--- a/app.js
+++ b/app.js
@@ -1733,11 +1733,9 @@ function selectClip(id, opts) {
     else { s.add(id); setSelection([...s], id); }
     return;
   }
-  const focus = opts?.transFocus ?? null;
-  if (id == null) state.transFocus = null;
-  else if (focus) state.transFocus = focus;
-  else state.transFocus = null;
-  if (state.selId === id && state.selIds.size <= 1 && focus === state.transFocus && focus == null) return;
+  const nextFocus = id == null ? null : (opts?.transFocus ?? null);
+  if (state.selId === id && state.selIds.size <= 1 && nextFocus === state.transFocus) return;
+  state.transFocus = nextFocus;
   setSelection(id == null ? [] : [id], id ?? null);
 }
 /* Drop selected ids whose clips no longer exist (undo/redo, external reload) */
@@ -3374,7 +3372,7 @@ function updateSafeOverlay() {
 window.addEventListener("keydown", (e) => {
   const k = e.key;
   if (k === "Delete" || k === "Backspace") {
-    if (clearFocusedTransition()) {
+    if (!isTypingTarget(document.activeElement) && clearFocusedTransition()) {
       e.preventDefault();
       return;
     }

--- a/app.js
+++ b/app.js
@@ -24,6 +24,8 @@ const TRACK_SIZE_PRESETS = {
   l: { thumbs: true, h: { V4: 44, V3: 44, V2: 58, V1: 58, A1: 42, A2: 42, A3: 42 } },
 };
 const TRACK_SIZE_KEY = "fablecut-track-size";
+const LAST_TRANS_KEY = { in: "fablecut-last-trans-in", out: "fablecut-last-trans-out" };
+const DEFAULT_LAST_TRANS = { type: "fade", duration: 1 };
 const RULER_H = 26;
 const SNAP_PX = 8;
 const MIN_DUR = 0.05;
@@ -892,6 +894,41 @@ function clearFocusedTransition() {
   renderInspector();
   return true;
 }
+function loadLastTransition(side) {
+  try {
+    const raw = JSON.parse(localStorage.getItem(LAST_TRANS_KEY[side]) || "null");
+    if (raw?.type && raw.type !== "none" && TRANSITIONS.includes(raw.type)) {
+      const dur = +raw.duration;
+      return { type: raw.type, duration: isFinite(dur) && dur >= MIN_TRANS_DUR ? dur : 1 };
+    }
+  } catch {}
+  return { ...DEFAULT_LAST_TRANS };
+}
+function saveLastTransition(side, tr) {
+  if (!tr?.type || tr.type === "none") return;
+  try {
+    localStorage.setItem(LAST_TRANS_KEY[side], JSON.stringify({
+      type: tr.type,
+      duration: Math.max(MIN_TRANS_DUR, +tr.duration || 1),
+    }));
+  } catch {}
+}
+function addTransitionAtPlayhead() {
+  const c = getClip(state.selId);
+  if (!c) { toast("Select a clip first"); return; }
+  const t = state.time;
+  if (t < c.start || t >= clipEnd(c)) { toast("Move playhead over the selected clip"); return; }
+  const side = (t - c.start) / c.duration < 0.5 ? "in" : "out";
+  const key = side === "in" ? "transitionIn" : "transitionOut";
+  const preset = loadLastTransition(side);
+  const dur = Math.min(Math.max(MIN_TRANS_DUR, preset.duration), c.duration);
+  pushUndo();
+  c[key] = { type: preset.type, duration: +dur.toFixed(3) };
+  saveLastTransition(side, c[key]);
+  state.dirtyTimeline = true;
+  selectClip(c.id, { transFocus: side });
+  scheduleSave();
+}
 function splitAtPlayhead() {
   const t = state.time;
   let targets = state.selIds.size ? selectedClips() : project.clips;
@@ -1371,7 +1408,10 @@ function startTransDurGesture(e, c, side) {
     window.removeEventListener("pointermove", onMove);
     window.removeEventListener("pointerup", onUp);
     state.gesture = false;
-    if (moved) scheduleSave();
+    if (moved) {
+      scheduleSave();
+      saveLastTransition(side, c[key]);
+    }
     renderInspector();
   };
   window.addEventListener("pointermove", onMove);
@@ -1907,14 +1947,18 @@ function renderInspector(lite) {
       else if (k === "duration") { c.duration = Math.max(MIN_DUR, +v || MIN_DUR); state.dirtyTimeline = true; }
       else if (k === "transIn" || k === "transOut") {
         const key = k === "transIn" ? "transitionIn" : "transitionOut";
-        const dur = Math.max(0.1, parseFloat(els.inspector.querySelector(`[data-k="${k}Dur"]`)?.value) || 1);
+        const side = k === "transIn" ? "in" : "out";
+        const dur = Math.max(MIN_TRANS_DUR, parseFloat(els.inspector.querySelector(`[data-k="${k}Dur"]`)?.value) || 1);
         c[key] = v === "none" ? undefined : { type: String(v), duration: dur };
+        if (c[key]) saveLastTransition(side, c[key]);
         state.dirtyTimeline = true;
       }
       else if (k === "transInDur" || k === "transOutDur") {
         const key = k === "transInDur" ? "transitionIn" : "transitionOut";
+        const side = k === "transInDur" ? "in" : "out";
         if (c[key]) {
-          c[key].duration = Math.max(0.1, +v || 1);
+          c[key].duration = Math.max(MIN_TRANS_DUR, +v || 1);
+          saveLastTransition(side, c[key]);
           state.dirtyTimeline = true;
         }
       }
@@ -3380,6 +3424,10 @@ window.addEventListener("keydown", (e) => {
   if (isTypingTarget(document.activeElement)) return;
   if (k === " ") { e.preventDefault(); state.playing ? pause() : play(); }
   else if (k === "s" || k === "S") splitAtPlayhead();
+  else if (e.altKey && !e.ctrlKey && !e.metaKey && (k === "t" || k === "T")) {
+    e.preventDefault();
+    addTransitionAtPlayhead();
+  }
   else if ((k === "t" || k === "T") && !e.ctrlKey && !e.metaKey && !e.altKey) {
     e.preventDefault();
     e.shiftKey ? trimToWorkArea() : splitAtWorkArea();

--- a/app.js
+++ b/app.js
@@ -1100,12 +1100,15 @@ function transitionMarksHtml(c, trackH) {
     const bot = clipH - r;
     const focused = state.selId === c.id && state.transFocus === side ? " focused" : "";
     if (side === "in") {
-      // top edge (0,0)→(w,0); bottom vertex on left edge, y inset for corner radius
-      html += `<svg class="trans-mark in${focused}" style="width:${w}px" viewBox="0 0 ${w} ${clipH}" preserveAspectRatio="none" aria-hidden="true" title="Edit transition in">` +
-        `<polygon points="0,0 ${w},0 0,${bot}"/></svg>`;
+      html += `<div class="trans-mark in${focused}" style="width:${w}px" data-side="in">` +
+        `<svg viewBox="0 0 ${w} ${clipH}" preserveAspectRatio="none" aria-hidden="true">` +
+        `<polygon points="0,0 ${w},0 0,${bot}"/></svg>` +
+        `<div class="trans-dur-handle" title="Drag to adjust duration"></div></div>`;
     } else {
-      html += `<svg class="trans-mark out${focused}" style="width:${w}px" viewBox="0 0 ${w} ${clipH}" preserveAspectRatio="none" aria-hidden="true" title="Edit transition out">` +
-        `<polygon points="0,0 ${w},0 ${w},${bot}"/></svg>`;
+      html += `<div class="trans-mark out${focused}" style="width:${w}px" data-side="out">` +
+        `<svg viewBox="0 0 ${w} ${clipH}" preserveAspectRatio="none" aria-hidden="true">` +
+        `<polygon points="0,0 ${w},0 ${w},${bot}"/></svg>` +
+        `<div class="trans-dur-handle" title="Drag to adjust duration"></div></div>`;
     }
   };
   wedge(c.transitionIn, "in");
@@ -1294,6 +1297,12 @@ els.tracksContent.addEventListener("pointerdown", (e) => {
   }
   const c = getClip(clipDiv.dataset.id);
   if (!c) return;
+  const transHandle = e.target.closest(".trans-dur-handle");
+  if (transHandle) {
+    const wrap = transHandle.closest(".trans-mark");
+    startTransDurGesture(e, c, wrap?.classList.contains("out") ? "out" : "in");
+    return;
+  }
   const transMark = e.target.closest(".trans-mark");
   if (transMark) {
     e.preventDefault();
@@ -1317,6 +1326,43 @@ els.tracksContent.addEventListener("pointerdown", (e) => {
   // a plain click (no drag) on a multi-selection collapses it to that clip on release
   startClipGesture(e, c, mode, !additive && state.selIds.size > 1);
 });
+
+const MIN_TRANS_DUR = 0.1;
+function startTransDurGesture(e, c, side) {
+  e.preventDefault();
+  const key = side === "in" ? "transitionIn" : "transitionOut";
+  const tr = c[key];
+  if (!tr) return;
+  selectClip(c.id, { transFocus: side });
+  state.gesture = true;
+  const origDur = tr.duration;
+  const x0 = e.clientX;
+  let moved = false;
+  pushUndo();
+
+  const onMove = (ev) => {
+    const dx = ev.clientX - x0;
+    if (Math.abs(dx) < 2 && !moved) return;
+    moved = true;
+    const sign = side === "in" ? 1 : -1;
+    const dur = clamp(origDur + sign * dx / state.pps, MIN_TRANS_DUR, c.duration);
+    tr.duration = +dur.toFixed(3);
+    state.dirtyTimeline = true;
+    rebuildClips();
+    const durK = side === "in" ? "transInDur" : "transOutDur";
+    const inp = els.inspector.querySelector(`[data-k="${durK}"]`);
+    if (inp) inp.value = tr.duration;
+  };
+  const onUp = () => {
+    window.removeEventListener("pointermove", onMove);
+    window.removeEventListener("pointerup", onUp);
+    state.gesture = false;
+    if (moved) scheduleSave();
+    renderInspector();
+  };
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp);
+}
 
 function startClipGesture(e, c, mode, collapseOnClick) {
   e.preventDefault();

--- a/app.js
+++ b/app.js
@@ -878,6 +878,20 @@ function deleteSelected() {
   setSelection([]);
   scheduleSave(); renderInspector();
 }
+function clearFocusedTransition() {
+  if (!state.transFocus || !state.selId) return false;
+  const c = getClip(state.selId);
+  if (!c) return false;
+  const key = state.transFocus === "in" ? "transitionIn" : "transitionOut";
+  if (!c[key]) return false;
+  pushUndo();
+  c[key] = undefined;
+  state.transFocus = null;
+  state.dirtyTimeline = true;
+  scheduleSave();
+  renderInspector();
+  return true;
+}
 function splitAtPlayhead() {
   const t = state.time;
   let targets = state.selIds.size ? selectedClips() : project.clips;
@@ -1971,7 +1985,6 @@ function renderInspector(lite) {
     const k = state.transFocus === "in" ? "transIn" : "transOut";
     const row = els.inspector.querySelector(`[data-k="${k}"]`)?.closest(".insp-row");
     row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-    requestAnimationFrame(() => els.inspector.querySelector(`[data-k="${k}"]`)?.focus());
   }
 }
 
@@ -3293,7 +3306,9 @@ $("btnWorkAreaPlay").addEventListener("click", () => {
   state.workAreaPlay = !state.workAreaPlay;
   syncTrimIOButton();
 });
-$("btnDelete").addEventListener("click", deleteSelected);
+$("btnDelete").addEventListener("click", () => {
+  if (!clearFocusedTransition()) deleteSelected();
+});
 $("btnExport").addEventListener("click", openExportSetup);
 $("btnStartExport").addEventListener("click", startChosenExport);
 $("btnCancelSetup").addEventListener("click", () => els.exportSetup.classList.add("hidden"));
@@ -3357,8 +3372,14 @@ function updateSafeOverlay() {
 }
 
 window.addEventListener("keydown", (e) => {
-  if (isTypingTarget(document.activeElement)) return;
   const k = e.key;
+  if (k === "Delete" || k === "Backspace") {
+    if (clearFocusedTransition()) {
+      e.preventDefault();
+      return;
+    }
+  }
+  if (isTypingTarget(document.activeElement)) return;
   if (k === " ") { e.preventDefault(); state.playing ? pause() : play(); }
   else if (k === "s" || k === "S") splitAtPlayhead();
   else if ((k === "t" || k === "T") && !e.ctrlKey && !e.metaKey && !e.altKey) {

--- a/app.js
+++ b/app.js
@@ -1079,6 +1079,37 @@ function contentWidth() {
   const minSec = (els.timelineScroll.clientWidth || 800) / state.pps;
   return Math.max(projDur() + TIMELINE_PAD_SEC, minSec) * state.pps;
 }
+function clipTransitionDur(tr) {
+  if (!tr || tr.type === "none") return 0;
+  const d = +tr.duration;
+  return isFinite(d) && d > 0 ? d : 0;
+}
+function clipBorderRadius() {
+  return state.trackSize === "s" ? 2 : 5;
+}
+/* Top-edge SVG wedges — width from transition duration × pps. */
+function transitionMarksHtml(c, trackH) {
+  let html = "";
+  const clipH = Math.max(8, trackH - 6);
+  const r = clipBorderRadius();
+  const wedge = (tr, side) => {
+    const dur = clipTransitionDur(tr);
+    if (!dur) return;
+    const w = Math.max(4, Math.min(dur, c.duration) * state.pps);
+    const bot = clipH - r;
+    if (side === "in") {
+      // top edge (0,0)→(w,0); bottom vertex on left edge, y inset for corner radius
+      html += `<svg class="trans-mark in" style="width:${w}px" viewBox="0 0 ${w} ${clipH}" preserveAspectRatio="none" aria-hidden="true">` +
+        `<polygon points="0,0 ${w},0 0,${bot}"/></svg>`;
+    } else {
+      html += `<svg class="trans-mark out" style="width:${w}px" viewBox="0 0 ${w} ${clipH}" preserveAspectRatio="none" aria-hidden="true">` +
+        `<polygon points="0,0 ${w},0 ${w},${bot}"/></svg>`;
+    }
+  };
+  wedge(c.transitionIn, "in");
+  wedge(c.transitionOut, "out");
+  return html;
+}
 function rebuildClips() {
   const w = contentWidth();
   els.tracksContent.style.width = w + "px";
@@ -1093,19 +1124,20 @@ function rebuildClips() {
     div.dataset.id = c.id;
     div.style.left = c.start * state.pps + "px";
     div.style.width = Math.max(8, c.duration * state.pps) + "px";
-    let inner = "";
+    let body = "";
     if (c.kind === "video" && trackSizeShowsThumbs()) {
       const thumb = runtime.mediaAux.get(c.mediaId)?.thumb;
-      if (thumb) inner += `<div class="thumbs" style="background-image:url('${thumb}')"></div>`;
+      if (thumb) body += `<div class="thumbs" style="background-image:url('${thumb}')"></div>`;
     }
     const hasWave = c.kind === "audio" && runtime.wavePeaks.get(c.mediaId) instanceof Float32Array;
-    if (hasWave) inner += `<canvas class="wave"></canvas>`;
-    const badge = (c.keyframes && Object.keys(c.keyframes).length ? "◆ " : "") +
-      (c.transitionIn || c.transitionOut ? "⇄ " : "");
-    inner += `<div class="fade"></div>
+    if (hasWave) body += `<canvas class="wave"></canvas>`;
+    const badge = c.keyframes && Object.keys(c.keyframes).length ? "◆ " : "";
+    body += `<div class="fade"></div>
       <div class="clip-label">${badge}${c.kind === "text" ? "T · " + (c.props.text || "").split("\n")[0]
-        : c.kind === "adjust" ? "FX · " + c.name : c.name}</div>
-      <div class="handle l"></div><div class="handle r"></div>`;
+        : c.kind === "adjust" ? "FX · " + c.name : c.name}</div>`;
+    let inner = `<div class="clip-body">${body}</div>`;
+    inner += transitionMarksHtml(c, tr.h);
+    inner += `<div class="handle l"></div><div class="handle r"></div>`;
     div.innerHTML = inner;
     if (hasWave) div.classList.add("has-wave");
     row.appendChild(div);
@@ -1807,7 +1839,10 @@ function renderInspector(lite) {
       }
       else if (k === "transInDur" || k === "transOutDur") {
         const key = k === "transInDur" ? "transitionIn" : "transitionOut";
-        if (c[key]) c[key].duration = Math.max(0.1, +v || 1);
+        if (c[key]) {
+          c[key].duration = Math.max(0.1, +v || 1);
+          state.dirtyTimeline = true;
+        }
       }
       else { c.props[k] = v; if (k === "text") state.dirtyTimeline = true; }
       const valEl = els.inspector.querySelector(`[data-val="${k}"]`);

--- a/app.js
+++ b/app.js
@@ -154,6 +154,7 @@ const state = {
   workAreaPlay: false,   // when true, play + Home/End stay inside IN/OUT
   binTab: "project",     // project | elements | sfx | svg
   disabledTracks: loadDisabledTracks(),
+  transFocus: null,      // "in" | "out" — inspector transition row highlighted
 };
 function saveDisabledTracks() {
   try { localStorage.setItem(DISABLED_TRACKS_KEY, JSON.stringify([...state.disabledTracks])); } catch {}
@@ -1097,12 +1098,13 @@ function transitionMarksHtml(c, trackH) {
     if (!dur) return;
     const w = Math.max(4, Math.min(dur, c.duration) * state.pps);
     const bot = clipH - r;
+    const focused = state.selId === c.id && state.transFocus === side ? " focused" : "";
     if (side === "in") {
       // top edge (0,0)→(w,0); bottom vertex on left edge, y inset for corner radius
-      html += `<svg class="trans-mark in" style="width:${w}px" viewBox="0 0 ${w} ${clipH}" preserveAspectRatio="none" aria-hidden="true">` +
+      html += `<svg class="trans-mark in${focused}" style="width:${w}px" viewBox="0 0 ${w} ${clipH}" preserveAspectRatio="none" aria-hidden="true" title="Edit transition in">` +
         `<polygon points="0,0 ${w},0 0,${bot}"/></svg>`;
     } else {
-      html += `<svg class="trans-mark out" style="width:${w}px" viewBox="0 0 ${w} ${clipH}" preserveAspectRatio="none" aria-hidden="true">` +
+      html += `<svg class="trans-mark out${focused}" style="width:${w}px" viewBox="0 0 ${w} ${clipH}" preserveAspectRatio="none" aria-hidden="true" title="Edit transition out">` +
         `<polygon points="0,0 ${w},0 ${w},${bot}"/></svg>`;
     }
   };
@@ -1292,6 +1294,12 @@ els.tracksContent.addEventListener("pointerdown", (e) => {
   }
   const c = getClip(clipDiv.dataset.id);
   if (!c) return;
+  const transMark = e.target.closest(".trans-mark");
+  if (transMark) {
+    e.preventDefault();
+    selectClip(c.id, { transFocus: transMark.classList.contains("out") ? "out" : "in" });
+    return;
+  }
   const additive = e.ctrlKey || e.metaKey || e.shiftKey;
   if (additive) {
     selectClip(c.id, { toggle: true });
@@ -1660,11 +1668,16 @@ function setSelection(ids, primary) {
 function selectClip(id, opts) {
   if (opts && opts.toggle && id != null) {
     const s = new Set(state.selIds);
+    state.transFocus = null;
     if (s.has(id)) { s.delete(id); setSelection([...s]); }
     else { s.add(id); setSelection([...s], id); }
     return;
   }
-  if (state.selId === id && state.selIds.size <= 1) return;
+  const focus = opts?.transFocus ?? null;
+  if (id == null) state.transFocus = null;
+  else if (focus) state.transFocus = focus;
+  else state.transFocus = null;
+  if (state.selId === id && state.selIds.size <= 1 && focus === state.transFocus && focus == null) return;
   setSelection(id == null ? [] : [id], id ?? null);
 }
 /* Drop selected ids whose clips no longer exist (undo/redo, external reload) */
@@ -1767,9 +1780,12 @@ function renderInspector(lite) {
       ${slider("speed", 0.25, 4, 0.05, p.speed, "×")}
     </div>`;
   }
-  const tsel = (label, key, tr) => row(label,
-    `<span class="insp-ctrls"><select data-k="${key}">${TRANSITIONS.map((x) => `<option ${x === (tr?.type || "none") ? "selected" : ""}>${x}</option>`).join("")}</select>
-     <input type="number" class="insp-dur" data-k="${key}Dur" step="0.1" min="0.1" value="${tr?.duration ?? 1}"></span>`);
+  const tsel = (label, key, tr) => {
+    const active = state.transFocus === (key === "transIn" ? "in" : "out");
+    return `<div class="insp-row${active ? " trans-active" : ""}"><label>${label}</label>
+      <span class="insp-ctrls"><select data-k="${key}">${TRANSITIONS.map((x) => `<option ${x === (tr?.type || "none") ? "selected" : ""}>${x}</option>`).join("")}</select>
+       <input type="number" class="insp-dur" data-k="${key}Dur" step="0.1" min="0.1" value="${tr?.duration ?? 1}"></span></div>`;
+  };
   html += `<div class="insp-section"><h3>Transition</h3>
     ${tsel("In", "transIn", c.transitionIn)}
     ${tsel("Out", "transOut", c.transitionOut)}
@@ -1905,6 +1921,12 @@ function renderInspector(lite) {
       scheduleSave(); renderInspector();
     });
   });
+  if (state.transFocus) {
+    const k = state.transFocus === "in" ? "transIn" : "transOut";
+    const row = els.inspector.querySelector(`[data-k="${k}"]`)?.closest(".insp-row");
+    row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    requestAnimationFrame(() => els.inspector.querySelector(`[data-k="${k}"]`)?.focus());
+  }
 }
 
 /* ═══════════════════════════ PLAYBACK ENGINE ═══════════════════════════ */

--- a/index.html
+++ b/index.html
@@ -167,7 +167,8 @@
     <table class="keys">
       <tr><td><kbd>Space</kbd></td><td>Play / pause</td></tr>
       <tr><td><kbd>S</kbd></td><td>Split clip(s) at playhead</td></tr>
-      <tr><td><kbd>Del</kbd></td><td>Delete selected clip(s)</td></tr>
+      <tr><td><kbd>Alt</kbd>+<kbd>T</kbd></td><td>Add transition at playhead (first half → in, second half → out)</td></tr>
+      <tr><td><kbd>Del</kbd></td><td>Delete selected clip(s), or clear focused transition</td></tr>
       <tr><td>Drag empty area</td><td>Marquee-select clips (drag a box around them)</td></tr>
       <tr><td><kbd>Ctrl</kbd>+click bin</td><td>Import media files</td></tr>
       <tr><td><kbd>Ctrl</kbd>+click clip</td><td>Add / remove a clip from the selection</td></tr>

--- a/style.css
+++ b/style.css
@@ -1004,8 +1004,7 @@ input[type=range] {
   top: 0;
   bottom: 0;
   height: auto;
-  pointer-events: auto;
-  cursor: pointer;
+  pointer-events: none;
   z-index: 2;
   overflow: hidden;
 }
@@ -1030,6 +1029,8 @@ input[type=range] {
   stroke: #ffffffcc;
   stroke-width: 1;
   vector-effect: non-scaling-stroke;
+  pointer-events: auto;
+  cursor: pointer;
 }
 .clip .trans-mark.focused polygon {
   fill: #7b6cff88;
@@ -1043,6 +1044,7 @@ input[type=range] {
   bottom: 0;
   width: 10px;
   cursor: ew-resize;
+  pointer-events: auto;
   z-index: 3;
 }
 .clip .trans-mark.in .trans-dur-handle {

--- a/style.css
+++ b/style.css
@@ -206,7 +206,7 @@ body.track-size-s .clip .fade {
   display: none;
 }
 
-body.track-size-s .clip.c-audio::after {
+body.track-size-s .clip.c-audio .clip-body::after {
   height: 12px;
 }
 
@@ -944,11 +944,19 @@ input[type=range] {
   top: 3px;
   bottom: 3px;
   border-radius: 5px;
-  overflow: hidden;
+  overflow: visible;
   border: 1px solid #0007;
   cursor: grab;
   min-width: 8px;
   box-shadow: 0 1px 3px #0006;
+}
+
+/* rounded clip content — trans wedges sit outside this so corners stay sharp */
+.clip-body {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  overflow: hidden;
 }
 
 .clip:active {
@@ -987,6 +995,34 @@ input[type=range] {
   overflow: hidden;
   text-overflow: ellipsis;
   pointer-events: none;
+  z-index: 3;
+}
+
+/* transition wedges — SVG width from transition duration × pps (see transitionMarksHtml) */
+.clip .trans-mark {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  height: auto;
+  pointer-events: none;
+  z-index: 2;
+  overflow: hidden;
+}
+.clip .trans-mark.in {
+  left: 0;
+  border-top-left-radius: inherit;
+  border-bottom-left-radius: inherit;
+}
+.clip .trans-mark.out {
+  right: 0;
+  border-top-right-radius: inherit;
+  border-bottom-right-radius: inherit;
+}
+.clip .trans-mark polygon {
+  fill: #ffffff55;
+  stroke: #ffffffcc;
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
 }
 
 .clip .fade {
@@ -994,6 +1030,7 @@ input[type=range] {
   inset: 0;
   background: linear-gradient(180deg, #ffffff1f, transparent 40%);
   pointer-events: none;
+  z-index: 0;
 }
 
 .clip .handle {
@@ -1002,7 +1039,7 @@ input[type=range] {
   bottom: 0;
   width: 8px;
   cursor: ew-resize;
-  z-index: 2;
+  z-index: 4;
 }
 
 .clip .handle.l {
@@ -1015,7 +1052,7 @@ input[type=range] {
   border-right: 3px solid #ffffff55;
 }
 
-.clip.c-video {
+.clip.c-video .clip-body {
   background: linear-gradient(180deg, #4c66ff33, #4c66ff11), #273575;
 }
 
@@ -1028,15 +1065,15 @@ input[type=range] {
   pointer-events: none;
 }
 
-.clip.c-image {
+.clip.c-image .clip-body {
   background: linear-gradient(180deg, #2dbd8533, #2dbd8511), #1d5b45;
 }
 
-.clip.c-audio {
+.clip.c-audio .clip-body {
   background: linear-gradient(180deg, #7ec24933, #7ec24911), #33531f;
 }
 
-.clip.c-audio::after {
+.clip.c-audio .clip-body::after {
   content: "";
   position: absolute;
   left: 0;
@@ -1050,7 +1087,7 @@ input[type=range] {
   pointer-events: none;
 }
 
-.clip.c-audio.has-wave::after {
+.clip.c-audio.has-wave .clip-body::after {
   display: none;
 }
 
@@ -1063,15 +1100,15 @@ input[type=range] {
   pointer-events: none;
 }
 
-.clip.c-text {
+.clip.c-text .clip-body {
   background: linear-gradient(180deg, #ff7ac833, #ff7ac811), #6b2a53;
 }
 
-.clip.c-svg {
+.clip.c-svg .clip-body {
   background: linear-gradient(180deg, #ffd16633, #ffd16611), #6b5420;
 }
 
-.clip.c-adjust {
+.clip.c-adjust .clip-body {
   background: repeating-linear-gradient(135deg, #38bdf822 0 10px, transparent 10px 20px), #155e75;
 }
 

--- a/style.css
+++ b/style.css
@@ -1004,7 +1004,8 @@ input[type=range] {
   top: 0;
   bottom: 0;
   height: auto;
-  pointer-events: none;
+  pointer-events: auto;
+  cursor: pointer;
   z-index: 2;
   overflow: hidden;
 }
@@ -1023,6 +1024,18 @@ input[type=range] {
   stroke: #ffffffcc;
   stroke-width: 1;
   vector-effect: non-scaling-stroke;
+}
+.clip .trans-mark.focused polygon {
+  fill: #7b6cff88;
+  stroke: #cfc8ff;
+  stroke-width: 1.5;
+}
+
+.insp-row.trans-active {
+  background: #7b6cff18;
+  border-radius: 6px;
+  margin: 0 -6px;
+  padding: 2px 6px;
 }
 
 .clip .fade {

--- a/style.css
+++ b/style.css
@@ -998,7 +998,7 @@ input[type=range] {
   z-index: 3;
 }
 
-/* transition wedges — SVG width from transition duration × pps (see transitionMarksHtml) */
+/* transition wedges — width from transition duration × pps (see transitionMarksHtml) */
 .clip .trans-mark {
   position: absolute;
   top: 0;
@@ -1008,6 +1008,12 @@ input[type=range] {
   cursor: pointer;
   z-index: 2;
   overflow: hidden;
+}
+.clip .trans-mark svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 }
 .clip .trans-mark.in {
   left: 0;
@@ -1029,6 +1035,21 @@ input[type=range] {
   fill: #7b6cff88;
   stroke: #cfc8ff;
   stroke-width: 1.5;
+}
+/* duration handle — invisible drag strip at the wedge edge */
+.clip .trans-dur-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 10px;
+  cursor: ew-resize;
+  z-index: 3;
+}
+.clip .trans-mark.in .trans-dur-handle {
+  right: 0;
+}
+.clip .trans-mark.out .trans-dur-handle {
+  left: 0;
 }
 
 .insp-row.trans-active {


### PR DESCRIPTION
<img width="418" height="358" alt="image" src="https://github.com/user-attachments/assets/7dec1632-4243-4054-a7b0-9809d549b26e" />

## What does this PR do?

Adds transitionIn/transitionOut overlays over the clip. The overlays are focusable and duration can be changed by dragging one of the triangle vertexes with a mouse. Focused transition can be deleted (set to _none_ in inspector) via Del key.

Closes #

## Type of change

- [ ] Bug fix
- [X] New feature (UI)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timeline wedge/handle controls to resize transition durations with live inspector updates, clamped minimums, undo, and persistence.
  * Introduced focused transition handling (in/out) with timeline + inspector highlighting and auto-scrolling.
  * Added **Alt+T** to create a transition at the playhead, using the last selected settings per side.
* **Bug Fixes**
  * Improved clip/transition layering so transition controls consistently appear above fade overlays.
* **Documentation**
  * Updated shortcut help and feature notes, including that Delete clears a focused transition before deleting a clip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->