### PR TITLE
Add RTL support for titles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
 | `glowColor` | "" | glow color ("" = use the text color) |
 | `strokeWidth` `strokeColor` | 0, "#000" | text outline |
 | `bgColor` `bgOpacity` | "#000", 0 | rounded pill behind each line |
-| `textAnim` | "none" | typewriter · word-pop · word-slide · karaoke · **letter-pop** (per-character entrance) · **wave** (looping per-character ride) · **bounce** (looping per-word hop) · **shake** (looping jitter) · **clip-reveal** (wipe-mask sweep, per line) · **zoom-in** (scale + opacity settle) · **font-cut** (rhythmically swaps typeface, then settles — see `fontCutSet`) · **rise-mask** (line rises from behind its baseline, lower-third reveal) |
+| `textAnim` | "none" | typewriter · word-pop · word-slide · karaoke · **letter-pop** (per-character entrance; Arabic/Indic auto-fallback to per-word clusters so joined letters shape correctly) · **wave** (looping per-character ride; same shaping fallback) · **bounce** (looping per-word hop) · **shake** (looping jitter) · **clip-reveal** (wipe-mask sweep, per line) · **zoom-in** (scale + opacity settle) · **font-cut** (rhythmically swaps typeface, then settles — see `fontCutSet`) · **rise-mask** (line rises from behind its baseline, lower-third reveal) |
 | `wordRate` | 0.15 | seconds per word (typewriter: /4, letter-pop: /3 per character); also staggers `clip-reveal`/`zoom-in`/`rise-mask` per line |
 | `fontCutSet` | (curated) | array of font family names cycled by `font-cut`, e.g. `["Anton","Bebas Neue","Archivo Black","Oswald"]`; each is auto-loaded |
 
@@ -457,7 +457,9 @@ dims words until "spoken"; `typewriter` for terminal vibes.
 
 **RTL / Hebrew / Arabic caption**: omit `direction` (defaults to `"auto"`) or set
 `direction:"rtl"` explicitly; pick a font with the script's glyphs (Google Fonts
-work). Animations wipe and stagger in reading order automatically.
+work). Animations wipe and stagger in reading order automatically. `letter-pop` /
+`wave` animate whole words on Arabic/Indic lines (not isolated letters) so
+cursive joining stays correct.
 
 **Branded title**: `props: {font:"Bebas Neue", weight:700, letterSpacing:6,
 uppercase:true, color:"#ffffff", color2:"#7b6cff", textShadow:20}` — any Google

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,7 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
 | `bold` / `weight` | true / 0 | `weight` (300–900) overrides `bold` when non-zero |
 | `italic` `uppercase` | false | |
 | `align` | "center" | left · center · right (multi-line block alignment) |
+| `direction` | "auto" | auto · ltr · rtl — `auto` detects per line (Hebrew/Arabic → RTL); all `textAnim` modes honor reading direction (wipe, typewriter reveal, word/letter layout) |
 | `letterSpacing` | 0 | px |
 | `lineHeight` | 1.2 | multiplier |
 | `textShadow` | 12 | soft drop shadow amount, 0 = off |
@@ -453,6 +454,10 @@ font:"Bebas Neue", textAnim:"wave"}` on a dark shot.
 **Reel caption**: text clip with `props: {textAnim:"word-pop", wordRate:0.15,
 strokeWidth:6, bgColor:"#000000", bgOpacity:0.45, fontSize:88}`. `karaoke`
 dims words until "spoken"; `typewriter` for terminal vibes.
+
+**RTL / Hebrew / Arabic caption**: omit `direction` (defaults to `"auto"`) or set
+`direction:"rtl"` explicitly; pick a font with the script's glyphs (Google Fonts
+work). Animations wipe and stagger in reading order automatically.
 
 **Branded title**: `props: {font:"Bebas Neue", weight:700, letterSpacing:6,
 uppercase:true, color:"#ffffff", color2:"#7b6cff", textShadow:20}` — any Google

--- a/app.js
+++ b/app.js
@@ -2644,21 +2644,34 @@ function drawClip(c, W, H, t) {
   ctx2d.restore();
 }
 
-/* ── Text direction (LTR / RTL) — per-line when direction is "auto". ── */
+/* ── Text direction (LTR / RTL) — per-line when direction is "auto".
+   Auto-detect uses a DOM probe + getComputedStyle; cache by line text so
+   preview/export frames don't re-resolve style every tick. ── */
 let _textDirProbe;
+const _textDirCache = new Map(); // line text → "ltr" | "rtl"
+const TEXT_DIR_CACHE_MAX = 256;
 function detectTextDirection(text) {
+  const key = (text && String(text).trim()) ? String(text) : " ";
+  const hit = _textDirCache.get(key);
+  if (hit) return hit;
   if (!_textDirProbe) {
     _textDirProbe = document.createElement("p");
     _textDirProbe.style.cssText = "position:fixed;left:-9999px;visibility:hidden;white-space:nowrap";
     document.body.appendChild(_textDirProbe);
   }
   _textDirProbe.dir = "auto";
-  _textDirProbe.textContent = (text && String(text).trim()) ? text : " ";
-  return getComputedStyle(_textDirProbe).direction === "rtl" ? "rtl" : "ltr";
+  _textDirProbe.textContent = key;
+  const dir = getComputedStyle(_textDirProbe).direction === "rtl" ? "rtl" : "ltr";
+  if (_textDirCache.size >= TEXT_DIR_CACHE_MAX) _textDirCache.clear();
+  _textDirCache.set(key, dir);
+  return dir;
 }
 function lineDirections(p, lines) {
-  const forced = p.direction === "rtl" || p.direction === "ltr" ? p.direction : null;
-  return lines.map((ln) => forced || detectTextDirection(ln));
+  if (p.direction === "rtl" || p.direction === "ltr") {
+    const forced = p.direction;
+    return lines.map(() => forced);
+  }
+  return lines.map((ln) => detectTextDirection(ln));
 }
 function revealWipeRect(cx, w, lh, y, e, rtl, pad = 6) {
   const clipW = (w + pad * 2) * e;
@@ -2679,22 +2692,40 @@ function needsContextualShaping(text) {
   return SHAPING_SCRIPT_RE.test(text);
 }
 let _graphemeSeg;
+const _graphemeCache = new Map(); // line text → string[]
+const _letterAnimCache = new Map(); // line text → {text, animate}[]
+const TEXT_SEG_CACHE_MAX = 256;
 function graphemeSegments(text) {
+  const key = String(text ?? "");
+  const hit = _graphemeCache.get(key);
+  if (hit) return hit;
+  let segs;
   if (typeof Intl !== "undefined" && Intl.Segmenter) {
     if (!_graphemeSeg) _graphemeSeg = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-    return [..._graphemeSeg.segment(text)].map((s) => s.segment);
+    segs = [..._graphemeSeg.segment(key)].map((s) => s.segment);
+  } else {
+    segs = [...key];
   }
-  return [...text];
+  if (_graphemeCache.size >= TEXT_SEG_CACHE_MAX) _graphemeCache.clear();
+  _graphemeCache.set(key, segs);
+  return segs;
 }
 function letterAnimSegments(line) {
-  if (needsContextualShaping(line)) {
-    const out = [];
+  const key = String(line ?? "");
+  const hit = _letterAnimCache.get(key);
+  if (hit) return hit;
+  let segs;
+  if (needsContextualShaping(key)) {
+    segs = [];
     const re = /(\s+|[^\s]+)/g;
     let m;
-    while ((m = re.exec(line))) out.push({ text: m[0], animate: !!m[0].trim() });
-    return out;
+    while ((m = re.exec(key))) segs.push({ text: m[0], animate: !!m[0].trim() });
+  } else {
+    segs = graphemeSegments(key).map((text) => ({ text, animate: !!text.trim() }));
   }
-  return graphemeSegments(line).map((text) => ({ text, animate: !!text.trim() }));
+  if (_letterAnimCache.size >= TEXT_SEG_CACHE_MAX) _letterAnimCache.clear();
+  _letterAnimCache.set(key, segs);
+  return segs;
 }
 
 /* ── Text rendering: styling (stroke / background pill) + kinetic animations.
@@ -2850,11 +2881,12 @@ function drawText(c, p, local) {
     return;
   }
   if (anim === "typewriter") {
-    let budget = Math.floor(local / (rate / 4)); // rate/4 s per character
+    let budget = Math.floor(local / (rate / 4)); // rate/4 s per grapheme cluster
     rawLines.forEach((ln, i) => {
       const rtl = lineDirs[i] === "rtl";
-      const shown = ln.slice(0, Math.max(0, budget));
-      budget -= ln.length;
+      const graphemes = graphemeSegments(ln);
+      const shown = graphemes.slice(0, Math.max(0, budget)).join("");
+      budget -= graphemes.length;
       if (shown) {
         const shownW = ctx2d.measureText(shown).width;
         paint(shown, typewriterX(lineCx(i), lineWidths[i], shownW, rtl), y0 + i * lh, 1, rtl);

--- a/app.js
+++ b/app.js
@@ -52,7 +52,7 @@ const DEFAULT_PROPS = {
   bold: true, italic: false, weight: 0, align: "center",
   letterSpacing: 0, lineHeight: 1.2, uppercase: false, textShadow: 12,
   glow: 0, glowColor: "",                      // neon glow (glowColor defaults to fill)
-  textAnim: "none", wordRate: 0.15,
+  textAnim: "none", wordRate: 0.15, direction: "auto",
   strokeWidth: 0, strokeColor: "#000000", bgColor: "#000000", bgOpacity: 0,
 };
 const ANIMATABLE = ["x", "y", "scale", "rotation", "opacity", "volume", "speed",
@@ -1753,6 +1753,7 @@ function renderInspector(lite) {
                       <input type="color" data-k="color2" value="${p.color2 || p.color}" title="Gradient bottom color">
                       <button class="btn tiny${p.color2 ? "" : " toggle on"}" data-action="grad-off" title="Disable gradient">flat</button></span>`)}
       ${sel("Align", "align", ["left", "center", "right"], p.align)}
+      ${sel("Direction", "direction", ["auto", "ltr", "rtl"], p.direction || "auto")}
     </div>
     <div class="insp-section"><h3>Font</h3>
       ${row("Family", `<select data-k="font">
@@ -2643,6 +2644,35 @@ function drawClip(c, W, H, t) {
   ctx2d.restore();
 }
 
+/* ── Text direction (LTR / RTL) — per-line when direction is "auto". ── */
+let _textDirProbe;
+function detectTextDirection(text) {
+  if (!_textDirProbe) {
+    _textDirProbe = document.createElement("p");
+    _textDirProbe.style.cssText = "position:fixed;left:-9999px;visibility:hidden;white-space:nowrap";
+    document.body.appendChild(_textDirProbe);
+  }
+  _textDirProbe.dir = "auto";
+  _textDirProbe.textContent = (text && String(text).trim()) ? text : " ";
+  return getComputedStyle(_textDirProbe).direction === "rtl" ? "rtl" : "ltr";
+}
+function lineDirections(p, lines) {
+  const forced = p.direction === "rtl" || p.direction === "ltr" ? p.direction : null;
+  return lines.map((ln) => forced || detectTextDirection(ln));
+}
+function revealWipeRect(cx, w, lh, y, e, rtl, pad = 6) {
+  const clipW = (w + pad * 2) * e;
+  const x0 = rtl ? cx + w / 2 + pad - clipW : cx - w / 2 - pad;
+  ctx2d.rect(x0, y - lh / 2, clipW, lh);
+}
+function typewriterX(cx, fullW, shownW, rtl) {
+  const dx = (fullW - shownW) / 2;
+  return rtl ? cx + dx : cx - dx;
+}
+function runOrigin(cx, totalW, rtl) {
+  return rtl ? cx + totalW / 2 : cx - totalW / 2;
+}
+
 /* ── Text rendering: styling (stroke / background pill) + kinetic animations.
    `local` is clip-local time in seconds. Word timing: word i enters at
    i * wordRate; each entrance animation lasts ~0.25 s. ── */
@@ -2666,6 +2696,7 @@ function drawText(c, p, local) {
   const align = p.align === "left" || p.align === "right" ? p.align : "center";
   const lineWidths = rawLines.map((ln) => ctx2d.measureText(ln).width);
   const blockW = Math.max(1, ...lineWidths);
+  const lineDirs = lineDirections(p, rawLines);
   // anchor x of each line's center, honoring block alignment
   const lineCx = (i) => align === "left" ? -blockW / 2 + lineWidths[i] / 2
     : align === "right" ? blockW / 2 - lineWidths[i] / 2 : 0;
@@ -2692,10 +2723,13 @@ function drawText(c, p, local) {
     g.addColorStop(1, p.color2);
     return g;
   };
-  const paint = (str, x, y, alpha = 1) => {
+  const paint = (str, x, y, alpha = 1, rtl = false) => {
     if (alpha <= 0) return;
     const keep = ctx2d.globalAlpha;
+    const prevDir = ctx2d.direction;
     ctx2d.globalAlpha = keep * clamp(alpha, 0, 1);
+    ctx2d.direction = rtl ? "rtl" : "ltr";
+    ctx2d.textAlign = "center";
     if (p.strokeWidth > 0) {
       ctx2d.shadowColor = "transparent";
       ctx2d.lineJoin = "round"; ctx2d.miterLimit = 2;
@@ -2718,67 +2752,66 @@ function drawText(c, p, local) {
       ctx2d.fillText(str, x, y);
     }
     ctx2d.shadowColor = "transparent"; ctx2d.shadowBlur = 0; ctx2d.shadowOffsetY = 0;
+    ctx2d.direction = prevDir;
     ctx2d.globalAlpha = keep;
   };
 
   if (anim === "none") {
-    ctx2d.textAlign = "center";
-    rawLines.forEach((ln, i) => paint(ln, lineCx(i), y0 + i * lh));
+    rawLines.forEach((ln, i) => paint(ln, lineCx(i), y0 + i * lh, 1, lineDirs[i] === "rtl"));
     return;
   }
-  // clip-reveal: a wipe mask sweeps each line into view, left to right
+  // clip-reveal: wipe mask sweeps each line in reading direction
   if (anim === "clip-reveal") {
-    ctx2d.textAlign = "center";
     rawLines.forEach((ln, i) => {
       if (!ln.trim()) return;
       const u = clamp((local - i * rate) / 0.5, 0, 1);
       if (u <= 0) return;
       const e = EASE["ease-out"](u), w = lineWidths[i], cx = lineCx(i), y = y0 + i * lh;
+      const rtl = lineDirs[i] === "rtl";
       ctx2d.save();
       ctx2d.beginPath();
-      ctx2d.rect(cx - w / 2 - 6, y - lh / 2, (w + 12) * e, lh);
+      revealWipeRect(cx, w, lh, y, e, rtl);
       ctx2d.clip();
-      paint(ln, cx, y);
+      paint(ln, cx, y, 1, rtl);
       ctx2d.restore();
     });
     return;
   }
   // zoom-in: text scales down into place with an opacity settle
   if (anim === "zoom-in") {
-    ctx2d.textAlign = "center";
     rawLines.forEach((ln, i) => {
       if (!ln.trim()) return;
       const u = clamp((local - i * rate) / 0.45, 0, 1);
       if (u <= 0) return;
       const e = EASE["ease-out"](u), s = 1.35 - 0.35 * e;
+      const rtl = lineDirs[i] === "rtl";
       ctx2d.save();
       ctx2d.translate(lineCx(i), y0 + i * lh);
       ctx2d.scale(s, s);
-      paint(ln, 0, 0, Math.min(1, u * 1.6));
+      paint(ln, 0, 0, Math.min(1, u * 1.6), rtl);
       ctx2d.restore();
     });
     return;
   }
   // rise-mask: each line rises from behind its own baseline (lower-third reveal)
   if (anim === "rise-mask") {
-    ctx2d.textAlign = "center";
     rawLines.forEach((ln, i) => {
       if (!ln.trim()) return;
       const u = clamp((local - i * rate) / 0.5, 0, 1);
       if (u <= 0) return;
       const e = EASE["ease-out"](u), cx = lineCx(i), y = y0 + i * lh;
+      const rtl = lineDirs[i] === "rtl";
       ctx2d.save();
       ctx2d.beginPath();
       ctx2d.rect(cx - blockW / 2 - 24, y - lh / 2, blockW + 48, lh);
       ctx2d.clip();
-      paint(ln, cx, y + (1 - e) * lh);
+      paint(ln, cx, y + (1 - e) * lh, 1, rtl);
       ctx2d.restore();
     });
     return;
   }
   // font-cut: rhythmically swap the typeface, then settle (speed cuts)
   if (anim === "font-cut") {
-    ctx2d.textAlign = "center";
     const setF = (Array.isArray(p.fontCutSet) && p.fontCutSet.length) ? p.fontCutSet : FONT_CUT_DEFAULT;
     setF.forEach(ensureFont);
     const cutDur = 0.6, interval = 0.06;
@@ -2788,32 +2821,36 @@ function drawText(c, p, local) {
     const lw = rawLines.map((ln) => ctx2d.measureText(ln).width);
     const bw = Math.max(1, ...lw);
     const lcx = (i) => align === "left" ? -bw / 2 + lw[i] / 2
-      : align === "right" ? bw / 2 - lw[i] / 2 : 0;
-    rawLines.forEach((ln, i) => { if (ln.trim()) paint(ln, lcx(i), y0 + i * lh); });
+                     : align === "right" ? bw / 2 - lw[i] / 2 : 0;
+    rawLines.forEach((ln, i) => { if (ln.trim()) paint(ln, lcx(i), y0 + i * lh, 1, lineDirs[i] === "rtl"); });
     return;
   }
   if (anim === "typewriter") {
-    ctx2d.textAlign = "center";
     let budget = Math.floor(local / (rate / 4)); // rate/4 s per character
     rawLines.forEach((ln, i) => {
+      const rtl = lineDirs[i] === "rtl";
       const shown = ln.slice(0, Math.max(0, budget));
       budget -= ln.length;
-      if (shown) paint(shown, lineCx(i) - (lineWidths[i] - ctx2d.measureText(shown).width) / 2, y0 + i * lh);
+      if (shown) {
+        const shownW = ctx2d.measureText(shown).width;
+        paint(shown, typewriterX(lineCx(i), lineWidths[i], shownW, rtl), y0 + i * lh, 1, rtl);
+      }
     });
     return;
   }
   // per-character animations (TikTok style)
   if (anim === "letter-pop" || anim === "wave") {
-    ctx2d.textAlign = "center";
     let ci = 0;
     rawLines.forEach((ln, i) => {
       const y = y0 + i * lh;
+      const rtl = lineDirs[i] === "rtl";
       const chars = [...ln];
       const widths = chars.map((ch) => ctx2d.measureText(ch).width);
       const total = widths.reduce((a, b) => a + b, 0);
-      let x = lineCx(i) - total / 2;
+      let x = runOrigin(lineCx(i), total, rtl);
       chars.forEach((ch, j) => {
-        const cx = x + widths[j] / 2;
+        const w = widths[j];
+        const cx = rtl ? x - w / 2 : x + w / 2;
         if (ch.trim()) {
           if (anim === "letter-pop") {
             const u = clamp((local - ci * rate / 3) / 0.18, 0, 1);
@@ -2822,31 +2859,32 @@ function drawText(c, p, local) {
               ctx2d.translate(cx, y);
               const s = Math.max(0.001, backOut(u));
               ctx2d.scale(s, s);
-              paint(ch, 0, 0, Math.min(1, u * 2.5));
+              paint(ch, 0, 0, Math.min(1, u * 2.5), rtl);
               ctx2d.restore();
             }
           } else { // wave: continuous per-character sine ride
-            paint(ch, cx, y + Math.sin(local * 4 + ci * 0.55) * size * 0.12);
+            paint(ch, cx, y + Math.sin(local * 4 + ci * 0.55) * size * 0.12, 1, rtl);
           }
           ci++;
         }
-        x += widths[j];
+        x += rtl ? -w : w;
       });
     });
     return;
   }
-  // word-based animations: lay words out manually, per-line, honoring alignment
-  ctx2d.textAlign = "center";
+  // word-based animations: lay words out manually, per-line, honoring alignment + direction
   const spaceW = ctx2d.measureText(" ").width;
   let wi = 0;
   rawLines.forEach((ln, i) => {
     const y = y0 + i * lh;
+    const rtl = lineDirs[i] === "rtl";
     const words = ln.split(/\s+/).filter(Boolean);
     const widths = words.map((w) => ctx2d.measureText(w).width);
     const total = widths.reduce((a, b) => a + b, 0) + spaceW * Math.max(0, words.length - 1);
-    let x = lineCx(i) - total / 2;
+    let x = runOrigin(lineCx(i), total, rtl);
     words.forEach((word, j) => {
-      const cx = x + widths[j] / 2;
+      const w = widths[j];
+      const cx = rtl ? x - w / 2 : x + w / 2;
       const u = clamp((local - wi * rate) / 0.25, 0, 1);
       if (anim === "word-pop") {
         if (u > 0) {
@@ -2854,20 +2892,20 @@ function drawText(c, p, local) {
           ctx2d.translate(cx, y);
           const s = Math.max(0.001, backOut(u));
           ctx2d.scale(s, s);
-          paint(word, 0, 0, Math.min(1, u * 2.5));
+          paint(word, 0, 0, Math.min(1, u * 2.5), rtl);
           ctx2d.restore();
         }
       } else if (anim === "word-slide") {
-        if (u > 0) paint(word, cx, y + (1 - EASE["ease-out"](u)) * size * 0.7, u);
+        if (u > 0) paint(word, cx, y + (1 - EASE["ease-out"](u)) * size * 0.7, u, rtl);
       } else if (anim === "bounce") { // continuous per-word hop
-        paint(word, cx, y - Math.abs(Math.sin(local * 3.2 + wi * 0.9)) * size * 0.18);
+        paint(word, cx, y - Math.abs(Math.sin(local * 3.2 + wi * 0.9)) * size * 0.18, 1, rtl);
       } else if (anim === "shake") { // continuous nervous jitter
         paint(word, cx + Math.sin(local * 31 + wi * 7.3) * size * 0.035,
-          y + Math.cos(local * 27 + wi * 3.1) * size * 0.035);
+                    y + Math.cos(local * 27 + wi * 3.1) * size * 0.035, 1, rtl);
       } else { // karaoke: everything visible dim, spoken words at full strength
-        paint(word, cx, y, u >= 1 ? 1 : 0.3 + u * 0.7);
+        paint(word, cx, y, u >= 1 ? 1 : 0.3 + u * 0.7, rtl);
       }
-      x += widths[j] + spaceW;
+      x += rtl ? -(w + spaceW) : (w + spaceW);
       wi++;
     });
   });

--- a/app.js
+++ b/app.js
@@ -2672,6 +2672,30 @@ function typewriterX(cx, fullW, shownW, rtl) {
 function runOrigin(cx, totalW, rtl) {
   return rtl ? cx + totalW / 2 : cx - totalW / 2;
 }
+// Arabic/Indic letters change shape when drawn in isolation — letter-pop/wave must
+// paint shaped clusters (whole words), not individual code points.
+const SHAPING_SCRIPT_RE = /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF\u0900-\u097F\u0980-\u09FF\u0A00-\u0A7F\u0A80-\u0AFF\u0B00-\u0B7F\u0B80-\u0BFF\u0C00-\u0C7F\u0C80-\u0CFF\u0D00-\u0D7F]/;
+function needsContextualShaping(text) {
+  return SHAPING_SCRIPT_RE.test(text);
+}
+let _graphemeSeg;
+function graphemeSegments(text) {
+  if (typeof Intl !== "undefined" && Intl.Segmenter) {
+    if (!_graphemeSeg) _graphemeSeg = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+    return [..._graphemeSeg.segment(text)].map((s) => s.segment);
+  }
+  return [...text];
+}
+function letterAnimSegments(line) {
+  if (needsContextualShaping(line)) {
+    const out = [];
+    const re = /(\s+|[^\s]+)/g;
+    let m;
+    while ((m = re.exec(line))) out.push({ text: m[0], animate: !!m[0].trim() });
+    return out;
+  }
+  return graphemeSegments(line).map((text) => ({ text, animate: !!text.trim() }));
+}
 
 /* ── Text rendering: styling (stroke / background pill) + kinetic animations.
    `local` is clip-local time in seconds. Word timing: word i enters at
@@ -2838,32 +2862,34 @@ function drawText(c, p, local) {
     });
     return;
   }
-  // per-character animations (TikTok style)
+  // per-character animations (TikTok style); Arabic/Indic fall back to word clusters
   if (anim === "letter-pop" || anim === "wave") {
     let ci = 0;
     rawLines.forEach((ln, i) => {
       const y = y0 + i * lh;
       const rtl = lineDirs[i] === "rtl";
-      const chars = [...ln];
-      const widths = chars.map((ch) => ctx2d.measureText(ch).width);
+      const shaped = needsContextualShaping(ln);
+      const segs = letterAnimSegments(ln);
+      const stagger = shaped ? rate : rate / 3;
+      const widths = segs.map((s) => ctx2d.measureText(s.text).width);
       const total = widths.reduce((a, b) => a + b, 0);
       let x = runOrigin(lineCx(i), total, rtl);
-      chars.forEach((ch, j) => {
+      segs.forEach((seg, j) => {
         const w = widths[j];
         const cx = rtl ? x - w / 2 : x + w / 2;
-        if (ch.trim()) {
+        if (seg.animate) {
           if (anim === "letter-pop") {
-            const u = clamp((local - ci * rate / 3) / 0.18, 0, 1);
+            const u = clamp((local - ci * stagger) / 0.18, 0, 1);
             if (u > 0) {
               ctx2d.save();
               ctx2d.translate(cx, y);
               const s = Math.max(0.001, backOut(u));
               ctx2d.scale(s, s);
-              paint(ch, 0, 0, Math.min(1, u * 2.5), rtl);
+              paint(seg.text, 0, 0, Math.min(1, u * 2.5), rtl);
               ctx2d.restore();
             }
-          } else { // wave: continuous per-character sine ride
-            paint(ch, cx, y + Math.sin(local * 4 + ci * 0.55) * size * 0.12, 1, rtl);
+          } else { // wave: continuous per-segment sine ride
+            paint(seg.text, cx, y + Math.sin(local * 4 + ci * 0.55) * size * 0.12, 1, rtl);
           }
           ci++;
         }


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

Adds support for RTL scripts in titles. Before, only LRT scripts were supported. Now the direction is auto-discovered (best-effort) and the directional effects (such as _clip-reveal_) are applied according to the direction discovered. For letter-level effects, like _letter-pop_ word level effects are applied as a fallback. This is especially important for Arabic, Urdu and Indic scripts (or others with contextual shaping if such exist), where splitting words into letters would be difficult without a dedicated text shaper, so it is a reasonable compromise.

## Type of change

- [ ] Bug fix
- [X] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [X] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text direction controls with Auto, Left-to-Right, and Right-to-Left options.
  * Improved rendering and animation behavior for Arabic, Indic, and other joined-letter scripts.
  * Updated text effects to respect reading direction, with word-based animation where needed to preserve shaping.
* **Documentation**
  * Added guidance and examples for configuring RTL captions, selecting fonts, and understanding direction-aware animation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->