### PR TITLE
Add sunset and midnight filter presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
 **Filter / color** (video/image/svg):
 | prop | default | notes |
 |---|---|---|
-| `filterPreset` | "none" | one of: cinematic · teal-orange · noir · vintage · faded · warm · cold · pop · dreamy · retro · bw-soft · cyberpunk. Combines non-destructively with the sliders below. |
+| `filterPreset` | "none" | one of: cinematic · teal-orange · noir · vintage · faded · warm · cold · pop · dreamy · retro · bw-soft · cyberpunk · sunset · midnight. Combines non-destructively with the sliders below. |
 | `brightness` `contrast` `saturation` | 100 | % (100 = neutral) |
 | `hue` | 0 | degrees |
 | `temperature` | 0 | −100 (cool blue) … +100 (warm orange) |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ same time.
 
 **Look**
 
-- 12 one-click filter presets (cinematic, teal-orange, noir, vintage, cyberpunk…)
+- 14 one-click filter presets (cinematic, teal-orange, noir, vintage, cyberpunk, sunset, midnight…)
 - **Adjustment layers** — one clip grades everything below it, Premiere-style
 - Full grade controls: brightness/contrast/saturation/hue, **temperature & tint**,
   blur, grayscale/sepia/invert, **vignette**, animated **film grain**

--- a/app.js
+++ b/app.js
@@ -84,6 +84,8 @@ const FILTER_PRESETS = {
   retro: { saturation: 130, hue: -6, contrast: 106, sepia: 15 },
   "bw-soft": { grayscale: 100, contrast: 95, brightness: 108 },
   cyberpunk: { saturation: 140, hue: 12, contrast: 118, temperature: -15, vignette: 25 },
+  sunset: { temperature: 24, tint: 6, brightness: 105, saturation: 116, contrast: 104, vignette: 20 },
+  midnight: { temperature: -24, brightness: 88, contrast: 122, saturation: 94, vignette: 38 },
 };
 const SYSTEM_FONTS = ["Segoe UI", "Arial", "Georgia", "Impact", "Courier New",
   "Trebuchet MS", "Verdana", "Times New Roman", "Comic Sans MS", "Consolas"];


### PR DESCRIPTION
## What does this PR do?

Adds two new one-tap color grades to `FILTER_PRESETS` in `app.js`:

- **`sunset`** - warm golden-hour glow: lifted temperature/tint, slight brightness + saturation boost, soft vignette.
- **`midnight`** - cool, moody night look: cooler temperature, darker, higher contrast, stronger vignette.

Both use only existing, already-rendered grade props, so they combine non-destructively with the sliders just like the other presets. The inspector dropdown builds itself from `Object.keys(FILTER_PRESETS)`, so they appear automatically with no extra wiring.

Closes #26

## Type of change

- [ ] Bug fix
- [x] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [x] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [x] Opened the editor and confirmed both presets appear in the inspector's Filter/Color dropdown and apply to a clip with no console errors
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [x] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

<sub>Note: the presets only set existing grade props (temperature, tint, brightness, saturation, contrast, vignette) that already flow through the single shared compositor, so preview and export render identically by construction.</sub>

## Checklist

- [x] No new runtime dependencies added
- [x] Preview and export render identically (single compositor)
- [x] Commits are focused and messages are descriptive
