### PR TITLE
Add luxury title style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,7 @@ dropdown + Shuffle), or reproduce it from an agent by writing the same props:
 | `serifDrop` | Abril Fatface | centered, `zoom-in` |
 | `subtitle` | Roboto | small, bottom, bg pill, `karaoke` |
 | `boldRise` | Archivo Black | uppercase, lower third, `rise-mask` |
+| `luxury` | Cinzel | uppercase, cream→gold gradient, wide `letterSpacing`, `clip-reveal` |
 
 **Rule for agents: vary the font per title — never reuse one font across a whole
 edit.** Any Google Font name auto-loads; the display faces above ship in

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ same time.
 **Text**
 
 - **Title styles** — one-tap cohesive looks (Impact, Elegant, Kinetic cut, Neon,
-  Handwritten, and more); new titles vary the font, placement and animation
+  Handwritten, Luxury, and more); new titles vary the font, placement and animation
   automatically instead of defaulting to one flat style
 - Kinetic captions: typewriter, word-pop, word-slide, karaoke, **letter-pop**,
   **wave**, **bounce**, **shake**, **clip-reveal**, **zoom-in**, **font-cut**

--- a/app.js
+++ b/app.js
@@ -110,8 +110,9 @@ const TITLE_STYLES = {
   serifDrop: { label: "Serif drop", place: "center", props: { font: "Abril Fatface", fontSize: 96, bold: false, color: "#ffffff", textShadow: 18, textAnim: "zoom-in" } },
   subtitle: { label: "Subtitle", place: "lower", props: { font: "Roboto", fontSize: 52, bold: false, color: "#ffffff", bgColor: "#000000", bgOpacity: 0.5, textAnim: "karaoke" } },
   boldRise: { label: "Bold rise", place: "lower", props: { font: "Archivo Black", fontSize: 92, bold: false, uppercase: true, color: "#ffffff", textAnim: "rise-mask" } },
+  luxury: { label: "Luxury", place: "center", props: { font: "Cinzel", fontSize: 88, bold: false, uppercase: true, color: "#faf0dc", color2: "#c9a227", letterSpacing: 6, textAnim: "clip-reveal" } },
 };
-const STYLE_CYCLE = ["impact", "elegant", "kinetic", "neon", "handwritten", "serifDrop", "boldRise"];
+const STYLE_CYCLE = ["impact", "elegant", "kinetic", "neon", "handwritten", "serifDrop", "boldRise", "luxury"];
 const AUDIO_EXT = /\.(mp3|wav|ogg|m4a|aac|flac|mpeg)$/i;
 const VIDEO_EXT = /\.(mp4|webm|mov|mkv|m4v)$/i;
 const IMAGE_EXT = /\.(png|jpe?g|gif|webp|avif)$/i;


### PR DESCRIPTION
## Summary
- Adds a **luxury** one-tap title style: Cinzel serif, uppercase, cream→gold gradient, wide letter spacing, `clip-reveal` animation
- Includes it in `STYLE_CYCLE` so new titles can rotate through the look
- Updates the title styles table in `CLAUDE.md` and the feature list in `README.md`

## Test plan
- [x] `node server.js` → http://localhost:7777
- [x] Title button → inspector style dropdown shows **Luxury**
- [x] Hover preview renders Cinzel with gold gradient

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Luxury** title style featuring an elegant serif font, uppercase gold-gradient text, wide spacing, and a reveal animation.
  * Included the Luxury style in automatic title style rotation.

* **Documentation**
  * Updated the title style documentation to list the new Luxury option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->