### PR TITLE
fix: syncMedia while playout is paused

### DIFF
--- a/app.js
+++ b/app.js
@@ -2237,6 +2237,12 @@ function syncMedia() {
       if (!el.paused) el.pause();
       const g = runtime.clipGain.get(c.id);
       if (g) g.gain.value = 0;
+      // Paused preview: keep decode head on the frame under the playhead.
+      // Needed when clips move/trim without setTime (drag does not scrub time).
+      if (!state.playing && enabled && c.kind === "video" && activeAt(c, t) &&
+          Math.abs(el.currentTime - mt) > 0.04) {
+        try { el.currentTime = mt; } catch {}
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

While paused, syncMedia() did not seek. Dragging a clip on the timeline did not update the preview.


## Type of change

- [X] Bug fix
- [ ] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paused video previews so displayed frames remain synchronized with the timeline after clips are moved or trimmed.
  * Video playback positions now automatically correct minor timing drift during preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->