### PR TITLE
Keyframe graphs and markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ same time.
 **Motion**
 
 - Keyframe animation on ~25 properties with easing
+- **Keyframe markers on clips** — diamonds on the clip body at each unique
+  keyframe time (tooltip lists channels; a count badge when several share a
+  time). <kbd>Ctrl/Cmd+←</kbd> / <kbd>Ctrl/Cmd+→</kbd> jumps the playhead to
+  the previous / next keyframe (selected clips first, else clips under the
+  playhead)
+- **Keyframe graphs** — toggle a property’s curve in the inspector to show an
+  interpolated value graph beside the program monitor; click the graph to seek
 - **Speed ramps** — keyframe `speed` and the engine time-remaps video *and* the
   export audio mix (the fast-into-slow-mo reel move)
 - **Camera shake** and **RGB-split/chromatic aberration**, both animatable

--- a/app.js
+++ b/app.js
@@ -160,6 +160,7 @@ const state = {
   binTab: "project",     // project | elements | sfx | svg
   disabledTracks: loadDisabledTracks(),
   transFocus: null,      // "in" | "out" — inspector transition row highlighted
+  kfGraphs: new Set(),   // animatable prop keys with open monitor graphs
 };
 function saveDisabledTracks() {
   try { localStorage.setItem(DISABLED_TRACKS_KEY, JSON.stringify([...state.disabledTracks])); } catch {}
@@ -213,7 +214,7 @@ const els = {
   exportTitle: $("exportTitle"), exportNote: $("exportNote"),
   projectName: $("projectName"), monitorRes: $("monitorRes"),
   aspectSel: $("aspectSel"), btnGuides: $("btnGuides"), safeOverlay: $("safeOverlay"),
-  monitorStage: $("monitorStage"),
+  monitorStage: $("monitorStage"), kfGraphs: $("kfGraphs"),
   exportSetup: $("exportSetup"), engineFast: $("engineFast"), engineRealtime: $("engineRealtime"),
 };
 const ctx2d = els.preview.getContext("2d");
@@ -1907,6 +1908,7 @@ function renderInspector(lite) {
   const c = getClip(state.selId);
   if (!c) {
     els.inspector.innerHTML = `<div class="inspector-empty">Select a clip to edit its<br>transform, effects &amp; audio.</div>`;
+    renderKfGraphsPanel();
     return;
   }
   if (lite) { // during gestures, just refresh timing numbers if present
@@ -1919,7 +1921,14 @@ function renderInspector(lite) {
   const kfCount = (k) => (c.keyframes && c.keyframes[k] ? c.keyframes[k].length : 0);
   const kfCtl = (k) => !ANIMATABLE.includes(k) ? "" :
     `<span class="kf-ctl"><button class="kf-btn${kfCount(k) ? " has" : ""}" data-kf="${k}" title="Set keyframe at playhead">◆${kfCount(k) || ""}</button>${kfCount(k) ? `<button class="kf-btn" data-kfclear="${k}" title="Clear keyframes">✕</button>` : ""}</span>`;
-  const row = (label, inner, k = "") => `<div class="insp-row"><label>${label}</label>${inner}${k ? kfCtl(k) : ""}</div>`;
+  const propLabel = (label, k = "") => {
+    if (!k || !ANIMATABLE.includes(k)) return `<label>${label}</label>`;
+    const on = state.kfGraphs.has(k) ? " on" : "";
+    const has = kfCount(k) ? " has-kf" : "";
+    return `<label class="kf-graph-toggle${on}${has}" data-kfgraph="${k}" title="Show / hide keyframe graph">${label}</label>`;
+  };
+  const row = (label, inner, k = "") =>
+    `<div class="insp-row">${propLabel(label, k)}${inner}${k ? kfCtl(k) : ""}</div>`;
   const slider = (k, min, max, step, val, unit = "") =>
     row(k[0].toUpperCase() + k.slice(1),
       `<input type="range" data-k="${k}" min="${min}" max="${max}" step="${step}" value="${val}">
@@ -2147,6 +2156,178 @@ function renderInspector(lite) {
     const k = state.transFocus === "in" ? "transIn" : "transOut";
     const row = els.inspector.querySelector(`[data-k="${k}"]`)?.closest(".insp-row");
     row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }
+  els.inspector.querySelectorAll("[data-kfgraph]").forEach((lab) => {
+    lab.addEventListener("click", (e) => {
+      e.preventDefault();
+      toggleKfGraph(lab.dataset.kfgraph);
+    });
+  });
+  renderKfGraphsPanel();
+}
+
+/* ── Keyframe graphs (program-monitor left gutter) ── */
+const KF_GRAPH_LABEL = {
+  x: "Pos X", y: "Pos Y", scale: "Scale", rotation: "Rotation", opacity: "Opacity",
+  volume: "Volume", speed: "Speed", brightness: "Bright", contrast: "Contrast",
+  saturation: "Sat", hue: "Hue", blur: "Blur", grayscale: "Gray", sepia: "Sepia",
+  invert: "Invert", temperature: "Temp", tint: "Tint", vignette: "Vignette",
+  cornerRadius: "Radius", shake: "Shake", rgbSplit: "RGB", grain: "Grain",
+  fontSize: "Size", letterSpacing: "Track", glow: "Glow",
+};
+function toggleKfGraph(key) {
+  if (!ANIMATABLE.includes(key)) return;
+  if (state.kfGraphs.has(key)) state.kfGraphs.delete(key);
+  else state.kfGraphs.add(key);
+  renderInspector(); // refresh label .on state + panel
+}
+function renderKfGraphsPanel() {
+  const root = els.kfGraphs;
+  if (!root) return;
+  const c = getClip(state.selId);
+  const keys = [...state.kfGraphs].filter((k) => ANIMATABLE.includes(k));
+  if (!c || !keys.length) {
+    root.innerHTML = "";
+    root.hidden = true;
+    return;
+  }
+  root.hidden = false;
+  root.innerHTML = keys.map((k) => {
+    const label = KF_GRAPH_LABEL[k] || k;
+    return `<div class="kf-graph" data-kfgraph-card="${k}">
+      <div class="kf-graph-head"><span>${label}</span>
+        <button type="button" data-kfgraph-close="${k}" title="Close graph">✕</button></div>
+      <canvas width="160" height="52"></canvas>
+    </div>`;
+  }).join("");
+  root.querySelectorAll("[data-kfgraph-close]").forEach((btn) => {
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      state.kfGraphs.delete(btn.dataset.kfgraphClose);
+      renderInspector();
+    });
+  });
+  root.querySelectorAll(".kf-graph canvas").forEach((cv) => {
+    const key = cv.closest("[data-kfgraph-card]")?.dataset.kfgraphCard;
+    cv.addEventListener("pointerdown", (e) => seekKfGraph(e, cv, key));
+  });
+  updateKfGraphs();
+}
+function seekKfGraph(e, cv, key) {
+  const c = getClip(state.selId);
+  if (!c || !key) return;
+  const { t0, t1 } = kfGraphRange(c, key);
+  const rect = cv.getBoundingClientRect();
+  const u = clamp((e.clientX - rect.left) / Math.max(1, rect.width), 0, 1);
+  setTime(c.start + t0 + u * Math.max(1e-6, t1 - t0));
+  updateKfGraphs();
+}
+/* Value + time window for a graph. When keyframes exist, zoom X to their span
+   (with padding) instead of the full clip duration. */
+function kfGraphRange(c, key) {
+  const fallback = +(c.props?.[key] ?? DEFAULT_PROPS[key] ?? 0);
+  const dur = Math.max(MIN_DUR, c.duration);
+  const kfs = Array.isArray(c.keyframes?.[key]) ? c.keyframes[key] : [];
+  const vals = kfs.length ? kfs.map((kf) => +kf.v) : [fallback];
+  let lo = Math.min(...vals), hi = Math.max(...vals);
+  if (!isFinite(lo) || !isFinite(hi)) { lo = 0; hi = 1; }
+  if (Math.abs(hi - lo) < 1e-6) {
+    const pad = Math.max(0.05, Math.abs(lo) * 0.1 || 0.5);
+    lo -= pad; hi += pad;
+  } else {
+    const pad = (hi - lo) * 0.12;
+    lo -= pad; hi += pad;
+  }
+
+  let t0 = 0, t1 = dur;
+  if (kfs.length === 1) {
+    const t = clamp(+kfs[0].t || 0, 0, dur);
+    const half = Math.max(0.15, dur * 0.08);
+    t0 = Math.max(0, t - half);
+    t1 = Math.min(dur, t + half);
+  } else if (kfs.length >= 2) {
+    const ts = kfs.map((kf) => +kf.t || 0);
+    const a = Math.min(...ts), b = Math.max(...ts);
+    const pad = Math.max(0.05, (b - a) * 0.1, dur * 0.02);
+    t0 = Math.max(0, a - pad);
+    t1 = Math.min(dur, b + pad);
+  }
+  if (t1 - t0 < 1e-3) { t0 = 0; t1 = dur; }
+  return { lo, hi, fallback, t0, t1, dur };
+}
+function updateKfGraphs() {
+  const root = els.kfGraphs;
+  if (!root || root.hidden) return;
+  const c = getClip(state.selId);
+  if (!c) return;
+  root.querySelectorAll(".kf-graph").forEach((card) => {
+    const key = card.dataset.kfgraphCard;
+    const cv = card.querySelector("canvas");
+    if (key && cv) drawKfGraph(cv, c, key);
+  });
+}
+function drawKfGraph(cv, c, key) {
+  const dpr = window.devicePixelRatio || 1;
+  const cssW = cv.clientWidth || 160, cssH = cv.clientHeight || 52;
+  if (cv.width !== Math.round(cssW * dpr) || cv.height !== Math.round(cssH * dpr)) {
+    cv.width = Math.round(cssW * dpr);
+    cv.height = Math.round(cssH * dpr);
+  }
+  const g = cv.getContext("2d");
+  g.setTransform(dpr, 0, 0, dpr, 0, 0);
+  const W = cssW, H = cssH;
+  g.clearRect(0, 0, W, H);
+  const { lo, hi, fallback, t0, t1 } = kfGraphRange(c, key);
+  const span = Math.max(1e-6, t1 - t0);
+  const yAt = (v) => H - 4 - ((v - lo) / (hi - lo)) * (H - 8);
+  const xAt = (t) => 3 + ((t - t0) / span) * (W - 6);
+
+  // mid / zero guide
+  g.strokeStyle = "#ffffff10";
+  g.lineWidth = 1;
+  g.beginPath();
+  const y0 = yAt(0);
+  if (y0 > 4 && y0 < H - 4) { g.moveTo(3, y0); g.lineTo(W - 3, y0); g.stroke(); }
+
+  // interpolated curve (only the zoomed window)
+  g.strokeStyle = "#7b6cff";
+  g.lineWidth = 1.5;
+  g.beginPath();
+  const steps = Math.max(24, Math.floor(W));
+  for (let i = 0; i <= steps; i++) {
+    const t = t0 + (i / steps) * span;
+    const v = kfChannel(c, key, t, fallback);
+    const x = xAt(t), y = yAt(v);
+    if (i === 0) g.moveTo(x, y); else g.lineTo(x, y);
+  }
+  g.stroke();
+
+  // keyframe diamonds
+  const kfs = c.keyframes?.[key];
+  if (Array.isArray(kfs)) {
+    g.fillStyle = "#ffd166";
+    for (const kf of kfs) {
+      const x = xAt(kf.t), y = yAt(kf.v);
+      g.beginPath();
+      g.moveTo(x, y - 3.5); g.lineTo(x + 3.5, y); g.lineTo(x, y + 3.5); g.lineTo(x - 3.5, y);
+      g.closePath(); g.fill();
+    }
+  }
+
+  // playhead (drawn only when inside the zoomed window)
+  const lt = state.time - c.start;
+  if (lt >= t0 - 1e-6 && lt <= t1 + 1e-6) {
+    const px = xAt(clamp(lt, t0, t1));
+    g.strokeStyle = "#ff4d6a";
+    g.lineWidth = 1;
+    g.beginPath();
+    g.moveTo(px, 1); g.lineTo(px, H - 1);
+    g.stroke();
+    const cur = kfChannel(c, key, clamp(lt, t0, t1), fallback);
+    g.fillStyle = "#ff4d6a";
+    g.beginPath();
+    g.arc(px, yAt(cur), 2.5, 0, Math.PI * 2);
+    g.fill();
   }
 }
 
@@ -3311,6 +3492,7 @@ function loop(ts) {
   els.playhead.style.left = state.time * state.pps + "px";
   drawRuler();
   updateSafeOverlay();
+  updateKfGraphs();
   els.tcCurrent.textContent = fmt(state.time);
   els.tcTotal.textContent = fmt(projDur());
   if (state.exporting && !state.rendering) {

--- a/app.js
+++ b/app.js
@@ -1286,34 +1286,36 @@ function transitionMarksHtml(c, trackH) {
   wedge(c.transitionOut, "out");
   return html;
 }
-/* Unique clip-local keyframe times (seconds), sorted. */
-function clipKeyframeLocalTimes(c) {
+/* Group keyframes by clip-local time → [{ t, keys: ["opacity","scale"] }, …]. */
+function clipKeyframeGroups(c) {
   if (!c?.keyframes) return [];
-  const seen = new Set();
-  const out = [];
-  for (const arr of Object.values(c.keyframes)) {
+  const byT = new Map();
+  for (const [channel, arr] of Object.entries(c.keyframes)) {
     if (!Array.isArray(arr)) continue;
     for (const kf of arr) {
       const t = +kf.t;
       if (!Number.isFinite(t)) continue;
       const key = t.toFixed(4);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push(t);
+      let g = byT.get(key);
+      if (!g) { g = { t, keys: [] }; byT.set(key, g); }
+      if (!g.keys.includes(channel)) g.keys.push(channel);
     }
   }
-  out.sort((a, b) => a - b);
-  return out;
+  return [...byT.values()].sort((a, b) => a.t - b.t);
 }
-/* Diamond marks on the clip body — one per unique keyframe time (all channels). */
+const clipKeyframeLocalTimes = (c) => clipKeyframeGroups(c).map((g) => g.t);
+/* Diamond marks on the clip body — one per unique time; count badge if multi-channel. */
 function clipKeyframesHtml(c) {
-  const times = clipKeyframeLocalTimes(c);
-  if (!times.length || !(c.duration > 0)) return "";
+  const groups = clipKeyframeGroups(c);
+  if (!groups.length || !(c.duration > 0)) return "";
   let html = `<div class="clip-kfs">`;
-  for (const t of times) {
+  for (const { t, keys } of groups) {
     if (t < -1e-6 || t > c.duration + 1e-6) continue;
     const pct = Math.max(0, Math.min(100, (t / c.duration) * 100));
-    html += `<div class="clip-kf" style="left:${pct}%" data-t="${t}" title="Keyframe @ ${fmt(c.start + t)}"></div>`;
+    const label = keys.join(", ") + " @ " + fmt(c.start + t);
+    const badge = keys.length > 1 ? `<span class="clip-kf-n">${keys.length}</span>` : "";
+    const multi = keys.length > 1 ? " multi" : "";
+    html += `<div class="clip-kf${multi}" style="left:${pct}%" data-t="${t}" title="${label}">${badge}</div>`;
   }
   return html + `</div>`;
 }

--- a/app.js
+++ b/app.js
@@ -1286,6 +1286,37 @@ function transitionMarksHtml(c, trackH) {
   wedge(c.transitionOut, "out");
   return html;
 }
+/* Unique clip-local keyframe times (seconds), sorted. */
+function clipKeyframeLocalTimes(c) {
+  if (!c?.keyframes) return [];
+  const seen = new Set();
+  const out = [];
+  for (const arr of Object.values(c.keyframes)) {
+    if (!Array.isArray(arr)) continue;
+    for (const kf of arr) {
+      const t = +kf.t;
+      if (!Number.isFinite(t)) continue;
+      const key = t.toFixed(4);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(t);
+    }
+  }
+  out.sort((a, b) => a - b);
+  return out;
+}
+/* Diamond marks on the clip body — one per unique keyframe time (all channels). */
+function clipKeyframesHtml(c) {
+  const times = clipKeyframeLocalTimes(c);
+  if (!times.length || !(c.duration > 0)) return "";
+  let html = `<div class="clip-kfs">`;
+  for (const t of times) {
+    if (t < -1e-6 || t > c.duration + 1e-6) continue;
+    const pct = Math.max(0, Math.min(100, (t / c.duration) * 100));
+    html += `<div class="clip-kf" style="left:${pct}%" data-t="${t}" title="Keyframe @ ${fmt(c.start + t)}"></div>`;
+  }
+  return html + `</div>`;
+}
 function rebuildClips() {
   const w = contentWidth();
   els.tracksContent.style.width = w + "px";
@@ -1307,10 +1338,10 @@ function rebuildClips() {
     }
     const hasWave = c.kind === "audio" && runtime.wavePeaks.get(c.mediaId) instanceof Float32Array;
     if (hasWave) body += `<canvas class="wave"></canvas>`;
-    const badge = c.keyframes && Object.keys(c.keyframes).length ? "◆ " : "";
     body += `<div class="fade"></div>
-      <div class="clip-label">${badge}${c.kind === "text" ? "T · " + (c.props.text || "").split("\n")[0]
+      <div class="clip-label">${c.kind === "text" ? "T · " + (c.props.text || "").split("\n")[0]
         : c.kind === "adjust" ? "FX · " + c.name : c.name}</div>`;
+    body += clipKeyframesHtml(c);
     let inner = `<div class="clip-body">${body}</div>`;
     inner += transitionMarksHtml(c, tr.h);
     inner += `<div class="handle l"></div><div class="handle r"></div>`;
@@ -1468,6 +1499,13 @@ els.tracksContent.addEventListener("pointerdown", (e) => {
   }
   const c = getClip(clipDiv.dataset.id);
   if (!c) return;
+  const kfMark = e.target.closest(".clip-kf");
+  if (kfMark) {
+    e.preventDefault();
+    selectClip(c.id);
+    setTime(c.start + (+kfMark.dataset.t || 0));
+    return;
+  }
   const transHandle = e.target.closest(".trans-dur-handle");
   if (transHandle) {
     const wrap = transHandle.closest(".trans-mark");
@@ -1700,6 +1738,47 @@ els.ruler.addEventListener("pointerdown", startScrub);
 function setTime(t) {
   state.time = clamp(t, 0, Math.max(projDur(), 0));
   seekMediaWhilePaused();
+}
+
+/* Absolute timeline times of every keyframe on the given clips (deduped). */
+function keyframeTimelineTimes(clips) {
+  const seen = new Set();
+  const out = [];
+  for (const c of clips) {
+    for (const local of clipKeyframeLocalTimes(c)) {
+      const t = +(c.start + local).toFixed(4);
+      if (seen.has(t)) continue;
+      seen.add(t);
+      out.push(t);
+    }
+  }
+  out.sort((a, b) => a - b);
+  return out;
+}
+/* Jump playhead to previous (−1) or next (+1) keyframe.
+   Prefers selected clips; falls back to clips under the playhead.
+   Keyboard counterpart to Avid’s Ctrl/Cmd-click snap-to-audio-keyframe. */
+function goToKeyframe(dir) {
+  let clips = state.selIds.size ? selectedClips() : [];
+  if (!clips.some((c) => clipKeyframeLocalTimes(c).length)) {
+    const t = state.time;
+    clips = project.clips.filter((c) =>
+      clipKeyframeLocalTimes(c).length &&
+      t >= c.start - 1e-6 && t <= c.start + c.duration + 1e-6);
+  }
+  const times = keyframeTimelineTimes(clips);
+  if (!times.length) { toast("No keyframes"); return; }
+  const eps = 0.5 / Math.max(1, project.fps || 30);
+  if (dir > 0) {
+    const next = times.find((t) => t > state.time + eps);
+    if (next == null) { toast("No next keyframe"); return; }
+    setTime(next);
+  } else {
+    let prev = null;
+    for (const t of times) if (t < state.time - eps) prev = t;
+    if (prev == null) { toast("No previous keyframe"); return; }
+    setTime(prev);
+  }
 }
 
 /* Add a marker at the playhead, or remove one already there (M key).
@@ -3842,6 +3921,10 @@ window.addEventListener("keydown", (e) => {
     e.shiftKey ? trimToWorkArea() : splitAtWorkArea();
   }
   else if (k === "Delete" || k === "Backspace") deleteSelected();
+  else if ((e.ctrlKey || e.metaKey) && !e.altKey && (k === "ArrowLeft" || k === "ArrowRight")) {
+    e.preventDefault();
+    goToKeyframe(k === "ArrowRight" ? 1 : -1);
+  }
   else if (k === "ArrowLeft") setTime(state.time - (e.shiftKey ? 1 : 1 / project.fps));
   else if (k === "ArrowRight") setTime(state.time + (e.shiftKey ? 1 : 1 / project.fps));
   else if (k === "Home") gotoHome();

--- a/index.html
+++ b/index.html
@@ -179,6 +179,7 @@
       <tr><td><kbd>Ctrl</kbd>+click clip</td><td>Add / remove a clip from the selection</td></tr>
       <tr><td><kbd>Ctrl</kbd>+<kbd>A</kbd> / <kbd>Esc</kbd></td><td>Select all clips / deselect</td></tr>
       <tr><td><kbd>←</kbd> <kbd>→</kbd></td><td>Step 1 frame (⇧ = 1 second)</td></tr>
+      <tr><td><kbd>Ctrl</kbd>+<kbd>←</kbd> / <kbd>Ctrl</kbd>+<kbd>→</kbd></td><td>Go to previous / next keyframe (selected clip, or clip under playhead)</td></tr>
       <tr><td><kbd>[</kbd> / <kbd>]</kbd></td><td>Trim selected clip's in / out to playhead</td></tr>
       <tr><td><kbd>Home</kbd> / <kbd>End</kbd></td><td>Jump to start / end</td></tr>
       <tr><td><kbd>M</kbd></td><td>Add / remove marker at playhead (tap on the beat while playing)</td></tr>

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
           <div class="sa-ui-bottom"></div>
           <div class="sa-ui-right"></div>
         </div>
+        <div class="kf-graphs" id="kfGraphs" hidden></div>
       </div>
       <div class="transport">
         <span class="timecode" id="tcCurrent">00:00:00</span>

--- a/style.css
+++ b/style.css
@@ -1073,6 +1073,32 @@ input[type=range] {
   z-index: 3;
 }
 
+/* Keyframe diamonds on the clip — same size/color as ruler beat markers */
+.clip .clip-kfs {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 1px;
+  height: 8px;
+  pointer-events: none;
+  z-index: 4;
+}
+.clip .clip-kf {
+  position: absolute;
+  top: 0;
+  /* rotated square → ~8×8 tip-to-tip, matching ruler markers */
+  width: 6px;
+  height: 6px;
+  margin-left: -3px;
+  background: #ffd166;
+  transform: rotate(45deg);
+  pointer-events: auto;
+  cursor: pointer;
+}
+.clip .clip-kf:hover {
+  background: #ffe28a;
+}
+
 /* transition wedges — width from transition duration × pps (see transitionMarksHtml) */
 .clip .trans-mark {
   position: absolute;

--- a/style.css
+++ b/style.css
@@ -561,6 +561,81 @@ body.track-size-s .clip.selected {
   background: #000;
 }
 
+/* ── Keyframe graphs (left gutter of program monitor) ── */
+.kf-graphs {
+  position: absolute;
+  left: 6px;
+  top: 6px;
+  bottom: 6px;
+  width: min(168px, 28%);
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  pointer-events: none;
+}
+.kf-graphs[hidden] { display: none; }
+.kf-graph {
+  pointer-events: auto;
+  flex: 0 0 auto;
+  background: #000a;
+  border: 1px solid #ffffff18;
+  border-radius: 4px;
+  padding: 4px 5px 3px;
+  user-select: none;
+}
+.kf-graph-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  margin-bottom: 2px;
+  font: 700 9px/1 ui-sans-serif, system-ui, sans-serif;
+  letter-spacing: .35px;
+  color: #c8c8d0;
+}
+.kf-graph-head button {
+  margin: 0;
+  padding: 0 3px;
+  border: 0;
+  background: transparent;
+  color: #8b8b93;
+  font: 700 11px/1 ui-sans-serif, system-ui, sans-serif;
+  cursor: pointer;
+  opacity: .75;
+}
+.kf-graph-head button:hover { color: #fff; opacity: 1; }
+.kf-graph canvas {
+  display: block;
+  width: 100%;
+  height: 52px;
+  cursor: crosshair;
+  border-radius: 2px;
+  background: #0a0a0ccc;
+}
+
+.insp-row label.kf-graph-toggle {
+  cursor: pointer;
+  border-radius: 3px;
+  margin: -1px -2px;
+  padding: 1px 2px;
+}
+.insp-row label.kf-graph-toggle:hover {
+  color: #cfc8ff;
+  background: #7b6cff22;
+}
+.insp-row label.kf-graph-toggle.on {
+  color: #b9baff;
+  background: #7b6cff33;
+}
+.insp-row label.kf-graph-toggle.has-kf::after {
+  content: " ◆";
+  font-size: 8px;
+  opacity: .7;
+}
+
 .head-select {
   background: var(--panel-2);
   border: 1px solid var(--border);

--- a/style.css
+++ b/style.css
@@ -1098,6 +1098,28 @@ input[type=range] {
 .clip .clip-kf:hover {
   background: #ffe28a;
 }
+/* Count badge when ≥2 channels share this time (diamond stays rotated; numeral counter-rotates) */
+.clip .clip-kf.multi {
+  width: 8px;
+  height: 8px;
+  margin-left: -4px;
+  top: -1px;
+}
+.clip .clip-kf-n {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: rotate(-45deg);
+  font: 700 7px/1 ui-sans-serif, system-ui, sans-serif;
+  color: #1a1a1e;
+  pointer-events: none;
+  user-select: none;
+}
+body.track-size-s .clip .clip-kf-n {
+  font-size: 6px;
+}
 
 /* transition wedges — width from transition duration × pps (see transitionMarksHtml) */
 .clip .trans-mark {


### PR DESCRIPTION
## What does this PR do?
<img width="459" height="888" alt="image" src="https://github.com/user-attachments/assets/70fb3c4b-c236-4ce1-982b-45d88be4147d" />

Visualizes keyframes. Keframes are displayed on a clip itself (with a counter if more than one effects is keyed at certain time point), and/or, when a property label is clicked, as a small overlay with a graph that is also clickable. <kbd>Ctrl</kbd>+<kbd>⇒/⇐</kbd> jumps between keyframes.

## Type of change

- [ ] Bug fix
- [X] New feature (UI)
- [X] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [X] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyframe diamond markers on timeline clips, including multi-channel indicators and keyboard navigation between keyframes.
  * Added keyframe graphs in the inspector with per-property show/hide toggles and click-to-seek, plus a playhead marker overlay.
* **Bug Fixes**
  * Keyframe graphs now refresh appropriately when clearing the current selection.
* **Documentation**
  * Updated the README to describe keyframe markers and keyframe graphs, and refreshed the shortcut help with Ctrl/Cmd + Left/Right.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->