### PR TITLE
feat: restyle the 'play' button to be more visible

### DIFF
--- a/app.js
+++ b/app.js
@@ -2208,10 +2208,12 @@ function play() {
   }
   state.playing = true;
   els.btnPlay.textContent = "⏸";
+  els.btnPlay.classList.add("on");
 }
 function pause() {
   state.playing = false;
   els.btnPlay.textContent = "▶";
+  els.btnPlay.classList.remove("on");
   for (const el of runtime.clipEls.values()) { if (!el.paused) el.pause(); }
   if (state.exporting) finishExport(false);
 }
@@ -3546,6 +3548,7 @@ async function startExport() {
   recorder.start(250);
   state.playing = true;
   els.btnPlay.textContent = "⏸";
+  els.btnPlay.classList.add("on");
 }
 function finishExport(keep) {
   if (!state.exporting) return;
@@ -3554,6 +3557,7 @@ function finishExport(keep) {
   recDiscard = !keep;
   state.playing = false;
   els.btnPlay.textContent = "▶";
+  els.btnPlay.classList.remove("on");
   for (const el of runtime.clipEls.values()) { if (!el.paused) el.pause(); }
   if (recorder && recorder.state !== "inactive") recorder.stop();
   else els.exportOverlay.classList.add("hidden");

--- a/style.css
+++ b/style.css
@@ -627,13 +627,48 @@ body.track-size-s .clip.selected {
 
 .transport-btns {
   display: flex;
-  gap: 6px;
+  align-items: center;
+  gap: 4px;
+}
+
+.transport-btns .btn.icon {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  font-size: 11px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.transport-btns .btn.icon.big {
+  width: 40px;
+  height: 34px;
+  font-size: 16px;
+}
+
+#btnPlay.on {
+  background: #7b6cff;
+  border-color: #9a8fff;
+  color: #fff;
+  font-size: 19.2px; /* 16px × 1.2 — pause glyph reads smaller than ▶ */
+  /* ⏸ sits low in the em-box; padding shifts the flex content up to optical center */
+  padding-bottom: 3px;
+}
+
+#btnPlay.on:hover {
+  background: #8d80ff;
+  border-color: #b0a6ff;
 }
 
 .timecode {
   font: 600 14px/1 "Consolas", monospace;
   color: #b9b3ff;
   min-width: 86px;
+  height: 14px;
+  line-height: 14px;
+  align-self: center;
 }
 
 .timecode.dim {


### PR DESCRIPTION
## What does this PR do?
<img width="434" height="345" alt="image" src="https://github.com/user-attachments/assets/561af4ec-f220-498a-bf30-accceb9c030b" />

The 'play/pause' button size is increased and while playing, its background color is set to the accent color; also, the 'pause' icon is bigger now.

## Type of change

- [ ] Bug fix
- [X] New feature (UI)
- [ ] Docs
- [X] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear visual feedback for active playback and realtime export states.
  * Improved play button styling and hover behavior.

* **Style**
  * Refined transport controls with tighter spacing and consistent icon sizing.
  * Improved timecode alignment and vertical sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->