### PR TITLE
feat: gui only - linked selection project-timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ same time.
 **Editing**
 
 - 3 video tracks + 4 audio tracks, drag/trim/split/snap, undo/redo
+- **Settings** (cog in the top bar) — optional prefs stored in this browser via
+  `localStorage`. Enable **Link timeline and Project bin selection** so picking a
+  timeline clip highlights its media in Project, and clicking a Project item
+  selects every timeline clip that uses it (off by default).
 - **Direct manipulation on the monitor** — click a clip or title on the preview to
   move, resize (corner handles), or rotate (top handle, Shift-snap) it directly
 - **Timeline multi-select** — rubber-band marquee (drag on empty track area),

--- a/app.js
+++ b/app.js
@@ -4429,13 +4429,39 @@ $("btnBack").addEventListener("click", () => setTime(state.time - 1 / project.fp
 $("btnFwd").addEventListener("click", () => setTime(state.time + 1 / project.fps));
 $("btnHelp").addEventListener("click", () => $("helpOverlay").classList.remove("hidden"));
 $("btnCloseHelp").addEventListener("click", () => $("helpOverlay").classList.add("hidden"));
+function settingsFocusables() {
+  const root = $("settingsDialog");
+  if (!root) return [];
+  return [...root.querySelectorAll("button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])")]
+    .filter((el) => !el.disabled && el.getClientRects().length);
+}
+function onSettingsTabTrap(e) {
+  if (e.key !== "Tab") return;
+  const list = settingsFocusables();
+  if (!list.length) return;
+  const first = list[0], last = list[list.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
 function openSettings() {
   const cb = $("setLinkSelect");
   if (cb) cb.checked = !!getSetting("linkSelect");
-  $("settingsOverlay").classList.remove("hidden");
+  const overlay = $("settingsOverlay");
+  overlay.classList.remove("hidden");
+  overlay.addEventListener("keydown", onSettingsTabTrap);
+  const dialog = $("settingsDialog");
+  (cb || dialog)?.focus();
 }
 function closeSettings() {
-  $("settingsOverlay").classList.add("hidden");
+  const overlay = $("settingsOverlay");
+  overlay.removeEventListener("keydown", onSettingsTabTrap);
+  overlay.classList.add("hidden");
+  $("btnSettings")?.focus();
 }
 $("btnSettings").addEventListener("click", openSettings);
 $("btnCloseSettings").addEventListener("click", closeSettings);

--- a/app.js
+++ b/app.js
@@ -131,6 +131,37 @@ const ASPECT_PRESETS = [
 const WAVE_PEAKS_PER_SEC = 50;
 const TRACK_IDS = new Set(TRACKS.map((t) => t.id));
 
+/* ── User settings (localStorage; optional behavior toggles) ── */
+const SETTINGS_KEY = "fablecut-settings";
+const DEFAULT_SETTINGS = {
+  linkSelect: false, // timeline ↔ project bin selection sync
+};
+let settings = { ...DEFAULT_SETTINGS };
+function loadSettings() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(SETTINGS_KEY) || "null");
+    if (!raw || typeof raw !== "object") { settings = { ...DEFAULT_SETTINGS }; return; }
+    const next = { ...DEFAULT_SETTINGS };
+    for (const k of Object.keys(DEFAULT_SETTINGS)) {
+      if (Object.hasOwn(raw, k)) next[k] = raw[k];
+    }
+    settings = next;
+  } catch {
+    settings = { ...DEFAULT_SETTINGS };
+  }
+}
+function saveSettings() {
+  try { localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings)); } catch { }
+}
+function getSetting(key) {
+  return settings[key];
+}
+function setSetting(key, value) {
+  if (!Object.hasOwn(DEFAULT_SETTINGS, key)) return;
+  settings[key] = value;
+  saveSettings();
+}
+
 /* ── State ─────────────────────────────────────────────────────────────── */
 const project = {
   name: "Untitled Project",
@@ -624,6 +655,7 @@ function renderBin() {
   for (const m of project.media) {
     const item = document.createElement("div");
     item.className = "bin-item"; item.draggable = true;
+    item.dataset.mediaId = m.id;
     const aux = runtime.mediaAux.get(m.id) || {};
     const icon = m.kind === "audio" ? "🎵" : m.kind === "image" ? "🖼" : m.kind === "svg" ? "✨" : "🎞";
     const thumbSrc = aux.thumb || (m.kind === "image" || m.kind === "svg" ? m.src : null);
@@ -638,6 +670,13 @@ function renderBin() {
       e.dataTransfer.setData("text/fablecut-media", m.id);
       e.dataTransfer.effectAllowed = "copy";
     });
+    item.addEventListener("click", (e) => {
+      if (e.target.closest(".bin-del")) return;
+      if (e.ctrlKey || e.metaKey) return; // reserved for import
+      if (!getSetting("linkSelect")) return;
+      e.preventDefault();
+      selectClipsByMediaId(m.id);
+    });
     item.addEventListener("dblclick", () => addClipFromMedia(m, null, state.time));
     item.querySelector(".bin-del").addEventListener("click", () => {
       pushUndo();
@@ -647,6 +686,7 @@ function renderBin() {
     });
     els.binList.appendChild(item);
   }
+  syncBinSelectionFromTimeline();
 }
 
 /* Open the native file dialog. Windows anchors it to the <input>'s screen
@@ -1705,6 +1745,7 @@ els.tracksContent.addEventListener("pointerdown", (e) => {
     selectClip(c.id);
   } else if (state.selId !== c.id) {
     // grabbing inside an existing multi-selection: keep the group, retarget the inspector
+    // (bin link-select unchanged — same media set)
     state.selId = c.id;
     state.dirtyTimeline = true;
     renderInspector();
@@ -1900,6 +1941,7 @@ function startMarquee(e) {
       if (!state.selIds.has(state.selId)) state.selId = [...state.selIds].pop() ?? null;
       state.dirtyTimeline = true;
       renderInspector();
+      syncBinSelectionFromTimeline();
     }
     if (runtime.pendingSync) syncFromServer();
   };
@@ -2103,12 +2145,47 @@ els.timelineScroll.addEventListener("wheel", (e) => {
 }, { passive: false });
 
 /* ═══════════════════════════ SELECTION & INSPECTOR ═══════════════════════ */
+function selectedMediaIds() {
+  const ids = new Set();
+  for (const c of selectedClips()) {
+    if (c.mediaId) ids.add(c.mediaId);
+  }
+  return ids;
+}
+/** Clear Project-bin link-select highlights (used when the setting turns off). */
+function clearBinSelectionHighlight() {
+  if (!els.binList) return;
+  for (const item of els.binList.querySelectorAll(".bin-item.selected"))
+    item.classList.remove("selected");
+}
+/** Highlight Project-bin items that match the timeline selection (when linkSelect is on). */
+function syncBinSelectionFromTimeline() {
+  if (!els.binList || !getSetting("linkSelect")) return; // no-op when off — avoids DOM work on every selection
+  const mediaIds = selectedMediaIds();
+  for (const item of els.binList.querySelectorAll(".bin-item[data-media-id]")) {
+    item.classList.toggle("selected", mediaIds.has(item.dataset.mediaId));
+  }
+}
+/** Select every timeline clip that uses this media (video primary when present). */
+function selectClipsByMediaId(mediaId) {
+  const clips = project.clips.filter((c) => c.mediaId === mediaId);
+  if (!clips.length) {
+    setSelection([]);
+    toast("No clips on the timeline use this media");
+    return;
+  }
+  clips.sort((a, b) => a.start - b.start || String(a.id).localeCompare(String(b.id)));
+  const primary = clips.find((c) => c.kind === "video") || clips[0];
+  if (state.binTab !== "project") setBinTab("project");
+  setSelection(clips.map((c) => c.id), primary.id);
+}
 function setSelection(ids, primary) {
   state.selIds = new Set(ids);
   state.selId = primary !== undefined ? primary : ([...state.selIds].pop() ?? null);
   if (state.selId && !state.selIds.has(state.selId)) state.selIds.add(state.selId);
   state.dirtyTimeline = true;
   renderInspector();
+  syncBinSelectionFromTimeline();
 }
 /* Plain call replaces the selection; {toggle:true} (ctrl/cmd/shift+click)
    adds/removes the clip from it. */
@@ -2129,6 +2206,7 @@ function selectClip(id, opts) {
 function pruneSelection() {
   state.selIds = new Set([...state.selIds].filter((id) => getClip(id)));
   if (!state.selIds.has(state.selId)) state.selId = [...state.selIds].pop() ?? null;
+  syncBinSelectionFromTimeline();
 }
 const selectedClips = () => project.clips.filter((c) => state.selIds.has(c.id));
 function renderInspector(lite) {
@@ -4351,6 +4429,28 @@ $("btnBack").addEventListener("click", () => setTime(state.time - 1 / project.fp
 $("btnFwd").addEventListener("click", () => setTime(state.time + 1 / project.fps));
 $("btnHelp").addEventListener("click", () => $("helpOverlay").classList.remove("hidden"));
 $("btnCloseHelp").addEventListener("click", () => $("helpOverlay").classList.add("hidden"));
+function openSettings() {
+  const cb = $("setLinkSelect");
+  if (cb) cb.checked = !!getSetting("linkSelect");
+  $("settingsOverlay").classList.remove("hidden");
+}
+function closeSettings() {
+  $("settingsOverlay").classList.add("hidden");
+}
+$("btnSettings").addEventListener("click", openSettings);
+$("btnCloseSettings").addEventListener("click", closeSettings);
+$("settingsOverlay").addEventListener("click", (e) => {
+  if (e.target === $("settingsOverlay")) closeSettings();
+});
+$("setLinkSelect").addEventListener("change", (e) => {
+  setSetting("linkSelect", !!e.target.checked);
+  if (!getSetting("linkSelect")) {
+    clearBinSelectionHighlight();
+    return;
+  }
+  if (selectedMediaIds().size && state.binTab !== "project") setBinTab("project");
+  syncBinSelectionFromTimeline();
+});
 els.btnSnap.addEventListener("click", () => {
   state.snap = !state.snap;
   els.btnSnap.classList.toggle("on", state.snap);
@@ -4451,7 +4551,17 @@ window.addEventListener("keydown", (e) => {
     e.shiftKey ? clearOutPoint() : setOutPoint();
   }
   else if (k === "n" || k === "N") els.btnSnap.click();
-  else if (k === "Escape") selectClip(null);
+  else if (k === "Escape") {
+    if (!$("settingsOverlay").classList.contains("hidden")) {
+      e.preventDefault();
+      closeSettings();
+    } else if (!$("helpOverlay").classList.contains("hidden")) {
+      e.preventDefault();
+      $("helpOverlay").classList.add("hidden");
+    } else {
+      selectClip(null);
+    }
+  }
   else if ((e.ctrlKey || e.metaKey) && (k === "a" || k === "A")) {
     e.preventDefault();
     setSelection(project.clips.map((c) => c.id));
@@ -4587,6 +4697,7 @@ function initPanelSplit() {
 }
 
 /* ── Boot ── */
+loadSettings();
 initPanelSplit();
 buildTrackDOM();
 rebuildClips();

--- a/index.html
+++ b/index.html
@@ -25,6 +25,11 @@
           <button type="button" class="btn tiny" data-track-size="l" title="Large tracks">L</button>
         </span>
       </span>
+      <button class="btn ghost" id="btnSettings" title="Settings" aria-label="Settings">
+        <svg class="ico" viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+          <path fill="currentColor" fill-rule="evenodd" d="M6.71 2.81L6.88.94L9.12.94L9.29 2.81L10.76 3.41L12.2 2.22L13.78 3.8L12.59 5.24L13.19 6.71L15.06 6.88L15.06 9.12L13.19 9.29L12.59 10.76L13.78 12.2L12.2 13.78L10.76 12.59L9.29 13.19L9.12 15.06L6.88 15.06L6.71 13.19L5.24 12.59L3.8 13.78L2.22 12.2L3.41 10.76L2.81 9.29L.94 9.12L.94 6.88L2.81 6.71L3.41 5.24L2.22 3.8L3.8 2.22L5.24 3.41Z M5.15 8a2.85 2.85 0 1 0 5.7 0a2.85 2.85 0 1 0-5.7 0"/>
+        </svg>
+      </button>
       <button class="btn ghost" id="btnHelp" title="Keyboard shortcuts">?</button>
       <button class="btn primary" id="btnExport">⬇ Export</button>
     </div>
@@ -161,6 +166,25 @@
     <p class="dim" id="exportNote">Rendering your sequence in real time. Keep this tab focused.</p>
     <div class="progress"><div class="progress-fill" id="exportProgress"></div></div>
     <div class="dialog-actions"><button class="btn" id="btnCancelExport">Cancel</button></div>
+  </div>
+</div>
+
+<!-- ══════════ SETTINGS OVERLAY ══════════ -->
+<div class="overlay hidden" id="settingsOverlay">
+  <div class="dialog settings" role="dialog" aria-labelledby="settingsTitle">
+    <h2 id="settingsTitle">Settings</h2>
+    <p class="dim settings-intro">Preferences are stored in this browser only.</p>
+    <div class="settings-section">
+      <h3>Selection</h3>
+      <label class="settings-row">
+        <input type="checkbox" id="setLinkSelect">
+        <span>
+          <span class="settings-label">Link timeline and Project bin selection</span>
+          <span class="settings-hint">Selecting a timeline clip highlights its media in Project, and the reverse. Off by default.</span>
+        </span>
+      </label>
+    </div>
+    <div class="dialog-actions"><button class="btn primary" id="btnCloseSettings">Close</button></div>
   </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
 
 <!-- ══════════ SETTINGS OVERLAY ══════════ -->
 <div class="overlay hidden" id="settingsOverlay">
-  <div class="dialog settings" role="dialog" aria-labelledby="settingsTitle">
+  <div class="dialog settings" id="settingsDialog" role="dialog" aria-modal="true" aria-labelledby="settingsTitle" tabindex="-1">
     <h2 id="settingsTitle">Settings</h2>
     <p class="dim settings-intro">Preferences are stored in this browser only.</p>
     <div class="settings-section">

--- a/style.css
+++ b/style.css
@@ -481,6 +481,12 @@ body.track-size-s .clip.selected {
   border-color: #454552;
 }
 
+.bin-item.selected {
+  border-color: var(--accent);
+  background: #7b6cff18;
+  box-shadow: inset 0 0 0 1px #7b6cff44;
+}
+
 .bin-item:active {
   cursor: grabbing;
 }
@@ -1420,6 +1426,73 @@ input[type=range] {
   width: min(820px, 94vw);
   max-height: min(90vh, 640px);
   overflow: auto;
+}
+
+.dialog.settings {
+  width: min(440px, 92vw);
+}
+
+.dialog.settings .settings-intro {
+  margin-bottom: 14px;
+  font-size: 12px;
+}
+
+.dialog.settings .settings-section h3 {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .4px;
+  text-transform: uppercase;
+  color: var(--dim);
+  margin: 0 0 8px;
+}
+
+.settings-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--panel-2);
+}
+
+.settings-row:hover {
+  border-color: #454552;
+}
+
+.settings-row input {
+  margin-top: 2px;
+  flex: none;
+}
+
+.settings-label {
+  display: block;
+  color: #e8e8ec;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.settings-hint {
+  display: block;
+  font-size: 12px;
+  color: var(--dim);
+  line-height: 1.35;
+}
+
+#btnSettings {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  padding: 6px 0;
+}
+
+#btnSettings .ico {
+  margin: 0;
+  vertical-align: 0;
 }
 
 .dialog.help .keys-cols {


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

Implemented "Settings" dialog. Settings are stored in localStorage. The first setting is 'selection linking'. A clip selected in project gets selected in the timeline and vice-versa.

## Type of change

- [ ] Bug fix
- [X] New feature (GUI)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [X] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings panel via the top-bar gear icon.
  * Introduced an optional “link timeline selection with Project bin media” preference (off by default).
  * Saved preferences persist in the browser for future sessions.
* **Accessibility & Usability**
  * Settings overlay includes accessible dialog semantics and a dedicated Close action.
  * Pressing Escape now closes Settings first, then Help, before clearing timeline selection.
* **Visual Updates**
  * Media bin items can now show a “selected/linked” highlight state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->