### PR TITLE
Export frame

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,10 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
 ```jsonc
 {
   "name": "My Edit",
-  "width": 1280, "height": 720, "fps": 30,   // timeline + export rate (UI: Program Monitor FPS select)
+  "width": 1280, "height": 720, "fps": 30,   // composition canvas + timeline/export rate (UI: FPS select)
+  "exportFrame": { "x": 420, "y": 0, "w": 1080, "h": 1920 },  // optional delivery crop
+  // ^ omit = export the full canvas. Preview dims outside this rect; Fast export crops
+  // JPEGs to w×h. Clip x/y/scale stay relative to the composition center, not the frame.
   "background": "#000000",                    // canvas color behind all clips (optional)
   "revision": 7,                              // bump on every write!
   "markers": [ { "t": 2.5 }, { "t": 5.0, "label": "drop" } ],
@@ -519,6 +522,12 @@ to them (the UI also snaps drags to markers).
 or simply `transitionOut: {type:"fade", duration:3}`.
 
 **Pulse / emphasis**: `keyframes: { scale:[{t:0,v:1},{t:0.3,v:1.12},{t:0.6,v:1}] }`.
+
+**Reframe horizontal → vertical**: keep a wide composition canvas and crop for
+delivery — e.g. `width:1920, height:1080` with
+`exportFrame:{x:656,y:0,w:608,h:1080}` (9:16 fitted to canvas height). Position
+footage with clip `x`/`y`/`scale`; the export frame can be dragged in the UI.
+Omit `exportFrame` to export the full canvas.
 
 **Vertical reel**: set project `width:1080, height:1920`; use the UI's safe-area
 guides (▦) to keep captions out of platform UI zones.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
 {
   "name": "My Edit",
   "width": 1280, "height": 720, "fps": 30,   // composition canvas + timeline/export rate (UI: FPS select)
-  "exportFrame": { "x": 420, "y": 0, "w": 1080, "h": 1920 },  // optional delivery crop
+  "exportFrame": { "x": 405, "y": 0, "w": 405, "h": 720 },  // optional delivery crop
   // ^ omit = export the full canvas. Preview dims outside this rect; Fast export crops
   // JPEGs to w×h. Clip x/y/scale stay relative to the composition center, not the frame.
   "background": "#000000",                    // canvas color behind all clips (optional)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,10 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
 {
   "name": "My Edit",
   "width": 1280, "height": 720, "fps": 30,   // composition canvas + timeline/export rate (UI: FPS select)
-  "exportFrame": { "x": 405, "y": 0, "w": 405, "h": 720 },  // optional delivery crop
+  "exportFrame": { "x": 438, "y": 0, "w": 404, "h": 720 },  // optional delivery crop (even w/h for H.264)
   // ^ omit = export the full canvas. Preview dims outside this rect; Fast export crops
   // JPEGs to w×h. Clip x/y/scale stay relative to the composition center, not the frame.
+  // Frame size is always even (yuv420p / libx264); 9:16 on 1280×720 → 404×720, not 405.
   "background": "#000000",                    // canvas color behind all clips (optional)
   "revision": 7,                              // bump on every write!
   "markers": [ { "t": 2.5 }, { "t": 5.0, "label": "drop" } ],

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ same time.
   turns it off.
 - Canvas aspect presets (16:9, 9:16 reels, 4:5, 1:1) + project FPS select
   (24 / 25 / 30 / 50 / 60; non-preset rates show as Custom) + safe-area guides
+- **Export frame / reframing** — composition canvas can be larger than the delivery
+  crop (`exportFrame` in `project.json`). Preview dims the overscan; drag the
+  **Export frame** handle to reframe (e.g. 16:9 canvas → 9:16 export). Fast export
+  crops to the frame; Realtime export is disabled while a frame is set
 - **Program Monitor zoom** — mouse-wheel over the preview zooms the composition
   toward the cursor (fit → up to **2 screen pixels per canvas pixel**). Magnified
   view uses **native scrollbars** so overflow stays reachable; middle-click or

--- a/app.js
+++ b/app.js
@@ -5902,6 +5902,7 @@ els.monitorScroll.addEventListener("pointercancel", endViewPan);
 els.monitorScroll.addEventListener("auxclick", (e) => { if (e.button === 1) e.preventDefault(); });
 els.monitorScroll.addEventListener("scroll", () => {
   if (state.guides) updateSafeOverlay();
+  if (state.exportFrameView && getExportFrame()) updateExportFrameOverlay();
   scheduleMonitorView();
 });
 if (typeof ResizeObserver !== "undefined") {
@@ -5909,6 +5910,7 @@ if (typeof ResizeObserver !== "undefined") {
     if (state.viewZoom <= 1.001) {
       monitorFitCache = null;
       if (state.guides) updateSafeOverlay();
+      if (state.exportFrameView && getExportFrame()) updateExportFrameOverlay();
       return;
     }
     const scroll = els.monitorScroll;
@@ -5933,6 +5935,13 @@ function updateSafeOverlay() {
   els.safeOverlay.classList.toggle("vertical", project.height > project.width);
 }
 /* Dimmed overscan outside the delivery export frame (preview-only overlay). */
+const EF_EDGE = 10;
+function layoutExportFrameOverlayPart(el, left, top, w, h) {
+  el.style.left = left + "px";
+  el.style.top = top + "px";
+  el.style.width = w + "px";
+  el.style.height = h + "px";
+}
 function updateExportFrameOverlay() {
   const ov = els.exportFrameOverlay;
   if (!ov) return;
@@ -5950,19 +5959,23 @@ function updateExportFrameOverlay() {
   const sy = cv.offsetHeight / project.height;
   const hole = ov.querySelector(".ef-shade");
   const handle = ov.querySelector(".ef-handle");
+  const edgeT = ov.querySelector(".ef-edge-t");
+  const edgeB = ov.querySelector(".ef-edge-b");
+  const edgeL = ov.querySelector(".ef-edge-l");
+  const edgeR = ov.querySelector(".ef-edge-r");
   if (!hole) return;
   const left = ef.x * sx, top = ef.y * sy, w = ef.w * sx, h = ef.h * sy;
-  hole.style.left = left + "px";
-  hole.style.top = top + "px";
-  hole.style.width = w + "px";
-  hole.style.height = h + "px";
-  if (handle) {
-    handle.style.left = left + "px";
-    handle.style.top = top + "px";
-    handle.style.width = w + "px";
-  }
+  layoutExportFrameOverlayPart(hole, left, top, w, h);
+  if (handle) layoutExportFrameOverlayPart(handle, left + 6, top + 6, Math.min(w - 12, 120), 22);
+  if (edgeT) layoutExportFrameOverlayPart(edgeT, left, top, w, EF_EDGE);
+  if (edgeB) layoutExportFrameOverlayPart(edgeB, left, top + h - EF_EDGE, w, EF_EDGE);
+  if (edgeL) layoutExportFrameOverlayPart(edgeL, left, top + EF_EDGE, EF_EDGE, Math.max(0, h - EF_EDGE * 2));
+  if (edgeR) layoutExportFrameOverlayPart(edgeR, left + w - EF_EDGE, top + EF_EDGE, EF_EDGE, Math.max(0, h - EF_EDGE * 2));
 }
 let exportFrameDrag = null;
+function exportFrameDragTarget(e) {
+  return e.target.closest(".ef-handle, .ef-edge-t, .ef-edge-b, .ef-edge-l, .ef-edge-r");
+}
 function exportFrameDragMove(e) {
   if (!exportFrameDrag) return;
   const cv = els.preview;
@@ -5977,23 +5990,30 @@ function exportFrameDragMove(e) {
   }, project.width, project.height);
   updateExportFrameOverlay();
 }
-function exportFrameDragEnd() {
+function exportFrameDragEnd(e) {
   if (!exportFrameDrag) return;
   exportFrameDrag = null;
+  els.exportFrameOverlay?.classList.remove("is-dragging");
   syncExportFrameSel();
   updateMonitorRes();
   scheduleSave();
   document.removeEventListener("pointermove", exportFrameDragMove);
   document.removeEventListener("pointerup", exportFrameDragEnd, true);
+  document.removeEventListener("pointercancel", exportFrameDragEnd, true);
+  try { els.exportFrameOverlay?.releasePointerCapture(e.pointerId); } catch { }
 }
 els.exportFrameOverlay?.addEventListener("pointerdown", (e) => {
-  if (!e.target.closest(".ef-handle")) return;
+  if (!exportFrameDragTarget(e)) return;
   const ef = getExportFrame();
   if (!ef) return;
   e.preventDefault();
+  e.stopPropagation();
+  els.exportFrameOverlay?.classList.add("is-dragging");
   exportFrameDrag = { startX: e.clientX, startY: e.clientY, ox: ef.x, oy: ef.y };
+  try { els.exportFrameOverlay.setPointerCapture(e.pointerId); } catch { }
   document.addEventListener("pointermove", exportFrameDragMove);
   document.addEventListener("pointerup", exportFrameDragEnd, true);
+  document.addEventListener("pointercancel", exportFrameDragEnd, true);
 });
 
 window.addEventListener("keydown", (e) => {

--- a/app.js
+++ b/app.js
@@ -5743,7 +5743,6 @@ els.btnExportFrame?.addEventListener("click", () => {
     updateMonitorRes();
     scheduleSave();
   } else if (state.exportFrameView) {
-    project.exportFrame = null;
     state.exportFrameView = false;
     syncExportFrameSel();
     updateMonitorRes();
@@ -6013,6 +6012,30 @@ function exportFrameDragEnd(e) {
   document.removeEventListener("pointercancel", exportFrameDragEnd, true);
   try { els.exportFrameOverlay?.releasePointerCapture(e.pointerId); } catch { }
 }
+const EF_NUDGE_PX = 1;
+const EF_NUDGE_SHIFT_PX = 10;
+function nudgeExportFrame(dx, dy) {
+  const ef = getExportFrame();
+  if (!ef) return;
+  project.exportFrame = normalizeExportFrame({
+    x: ef.x + dx, y: ef.y + dy, w: ef.w, h: ef.h,
+  }, project.width, project.height);
+  updateExportFrameOverlay();
+  syncExportFrameSel();
+  updateMonitorRes();
+  scheduleSave();
+}
+function exportFrameHandleKeydown(e) {
+  const k = e.key;
+  if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(k)) return;
+  e.preventDefault();
+  e.stopPropagation();
+  const step = e.shiftKey ? EF_NUDGE_SHIFT_PX : EF_NUDGE_PX;
+  nudgeExportFrame(
+    k === "ArrowLeft" ? -step : k === "ArrowRight" ? step : 0,
+    k === "ArrowUp" ? -step : k === "ArrowDown" ? step : 0,
+  );
+}
 els.exportFrameOverlay?.addEventListener("pointerdown", (e) => {
   if (!exportFrameDragTarget(e)) return;
   const ef = getExportFrame();
@@ -6026,6 +6049,7 @@ els.exportFrameOverlay?.addEventListener("pointerdown", (e) => {
   document.addEventListener("pointerup", exportFrameDragEnd, true);
   document.addEventListener("pointercancel", exportFrameDragEnd, true);
 });
+els.exportFrameOverlay?.querySelector(".ef-handle")?.addEventListener("keydown", exportFrameHandleKeydown);
 
 window.addEventListener("keydown", (e) => {
   const k = e.key;

--- a/app.js
+++ b/app.js
@@ -590,12 +590,17 @@ function startFolderRename(folderId) {
     if (e.key === "Escape") { e.preventDefault(); row.textContent = getFolder(folderId)?.name || "Folder"; row.blur(); }
   });
 }
+/** Floor to even ≥ 8 — required for libx264 + yuv420p (chroma 2×2). */
+function evenFloor(n) {
+  return Math.max(8, Math.floor(n / 2) * 2);
+}
 function normalizeExportFrame(raw, canvasW, canvasH) {
   if (!raw || typeof raw !== "object") return null;
   let w = Math.round(+raw.w), h = Math.round(+raw.h);
   if (!w || !h || w < 8 || h < 8) return null;
   let x = Math.round(+raw.x || 0), y = Math.round(+raw.y || 0);
-  w = Math.min(w, canvasW); h = Math.min(h, canvasH);
+  w = evenFloor(Math.min(w, canvasW));
+  h = evenFloor(Math.min(h, canvasH));
   x = clamp(x, 0, Math.max(0, canvasW - w));
   y = clamp(y, 0, Math.max(0, canvasH - h));
   if (w >= canvasW && h >= canvasH) return null;
@@ -604,13 +609,15 @@ function normalizeExportFrame(raw, canvasW, canvasH) {
 function getExportFrame() {
   return normalizeExportFrame(project.exportFrame, project.width, project.height);
 }
-/** Largest axis-aligned rect of aspect aw×ah that fits inside the canvas. */
+/** Largest axis-aligned rect of aspect aw×ah that fits inside the canvas.
+ *  Width/height are snapped even so Fast export (H.264 yuv420p) can encode. */
 function fitExportFrameAspect(aw, ah, canvasW = project.width, canvasH = project.height) {
   const target = aw / ah, canvas = canvasW / canvasH;
   let w, h;
   if (target > canvas) { w = canvasW; h = Math.round(canvasW / target); }
   else { h = canvasH; w = Math.round(canvasH * target); }
-  w = clamp(w, 8, canvasW); h = clamp(h, 8, canvasH);
+  w = evenFloor(Math.min(w, canvasW));
+  h = evenFloor(Math.min(h, canvasH));
   return {
     x: Math.round((canvasW - w) / 2),
     y: Math.round((canvasH - h) / 2),
@@ -5293,23 +5300,31 @@ function openExportSetup() {
   if (!project.clips.length) { alert("Timeline is empty — add some clips first."); return; }
   const ef = getExportFrame();
   const fastOk = state.connected && state.ffmpeg;
+  const rtOk = !ef; // realtime cannot crop to the delivery frame
   els.engineFast.disabled = !fastOk;
-  els.engineRealtime.disabled = false;
-  if (ef && fastOk) {
+  els.engineRealtime.disabled = !rtOk;
+  if (fastOk) {
     els.engineFast.checked = true;
     els.engineRealtime.checked = false;
+  } else if (rtOk) {
+    els.engineFast.checked = false;
+    els.engineRealtime.checked = true;
   } else {
-    els.engineFast.checked = fastOk;
-    els.engineRealtime.checked = !fastOk;
+    // Frame set but no ffmpeg — neither engine can run; prefer Fast in the UI.
+    els.engineFast.checked = true;
+    els.engineRealtime.checked = false;
   }
-  if (ef) els.engineRealtime.disabled = true;
   $("engineFastNote").textContent = fastOk
     ? (ef ? "Exports the " + ef.w + "×" + ef.h + " delivery frame (cropped). Keeps rendering if you switch tabs."
       : "Frame-accurate ffmpeg encode. Keeps rendering if you switch tabs.")
-    : "Needs the server + ffmpeg on PATH.";
+    : (ef
+      ? "Needs the server + ffmpeg on PATH to export a cropped delivery frame."
+      : "Needs the server + ffmpeg on PATH.");
   const rtNote = $("engineRealtime")?.closest(".engine-opt")?.querySelector(".dim");
   if (rtNote) rtNote.textContent = ef
-    ? "Unavailable while an export frame is set — use Fast export."
+    ? (fastOk
+      ? "Unavailable while an export frame is set — use Fast export."
+      : "Unavailable while an export frame is set. Install ffmpeg, or clear the export frame to use Realtime.")
     : "Plays the timeline once and records it. Keep the tab focused.";
   const warn = $("exportTrackWarn");
   const disabled = TRACKS.filter((t) =>
@@ -5328,8 +5343,19 @@ function openExportSetup() {
   els.exportSetup.classList.remove("hidden");
 }
 function startChosenExport() {
+  const useFast = els.engineFast.checked && !els.engineFast.disabled;
+  const useRt = els.engineRealtime.checked && !els.engineRealtime.disabled;
+  if (!useFast && !useRt) {
+    const ef = getExportFrame();
+    if (ef && !(state.connected && state.ffmpeg)) {
+      alert("Export frame cropping needs Fast export (server + ffmpeg). Clear the export frame, or install ffmpeg and try again.");
+      return;
+    }
+    alert("No export engine is available.");
+    return;
+  }
   els.exportSetup.classList.add("hidden");
-  if (els.engineFast.checked && !els.engineFast.disabled) fastExport();
+  if (useFast) fastExport();
   else startExport();
 }
 

--- a/app.js
+++ b/app.js
@@ -133,6 +133,14 @@ const ASPECT_PRESETS = [
   { label: "1:1 · 1080×1080", w: 1080, h: 1080 },
 ];
 const FPS_PRESETS = [24, 25, 30, 50, 60];
+/** Delivery-aspect presets fitted inside the composition canvas (export crop). */
+const EXPORT_FRAME_ASPECTS = [
+  { label: "Full canvas", w: 0, h: 0 },
+  { label: "9:16 Reel", w: 9, h: 16 },
+  { label: "16:9", w: 16, h: 9 },
+  { label: "4:5 IG", w: 4, h: 5 },
+  { label: "1:1 Square", w: 1, h: 1 },
+];
 const WAVE_PEAKS_PER_SEC = 50;
 const TRACK_IDS = new Set(TRACKS.map((t) => t.id));
 // Audio lanes available for a video's per-channel linked audio (index = props.audioChannel).
@@ -237,6 +245,7 @@ const project = {
   inPoint: null,  // timeline work-area IN (seconds), or null
   outPoint: null, // timeline work-area OUT (seconds), or null
   disabledTracks: [], // track ids (V4…A3) hidden from preview/export when listed
+  exportFrame: null, // optional {x,y,w,h} delivery crop inside width×height canvas
 };
 const state = {
   time: 0, playing: false, pps: 60, snap: true,
@@ -247,6 +256,7 @@ const state = {
   connected: false, exporting: false,
   rendering: false,      // fast (server/ffmpeg) export in progress
   guides: false,         // safe-area overlay on the monitor
+  exportFrameView: true, // dimmed overscan + export frame overlay
   viewZoom: 1,           // program-monitor display zoom (1 = fit stage)
   audioHold: false,      // while paused, loop one frame of audio at the playhead
   ffmpeg: false,         // server reports ffmpeg available
@@ -321,8 +331,11 @@ const els = {
   btnAudioHold: $("btnAudioHold"),
   exportOverlay: $("exportOverlay"), exportProgress: $("exportProgress"),
   exportTitle: $("exportTitle"), exportNote: $("exportNote"),
-  projectName: $("projectName"),
-  aspectSel: $("aspectSel"), fpsSel: $("fpsSel"), btnGuides: $("btnGuides"), btnZoom100: $("btnZoom100"),
+  projectName: $("projectName"), monitorRes: $("monitorRes"),
+  aspectSel: $("aspectSel"), fpsSel: $("fpsSel"),
+  btnGuides: $("btnGuides"), btnExportFrame: $("btnExportFrame"),
+  exportFrameSel: $("exportFrameSel"), exportFrameOverlay: $("exportFrameOverlay"),
+  btnZoom100: $("btnZoom100"),
   safeOverlay: $("safeOverlay"), btnSpeed: $("btnSpeed"),
   monitorStage: $("monitorStage"), monitorScroll: $("monitorScroll"),
   monitorZoomInner: $("monitorZoomInner"), kfGraphs: $("kfGraphs"),
@@ -577,6 +590,62 @@ function startFolderRename(folderId) {
     if (e.key === "Escape") { e.preventDefault(); row.textContent = getFolder(folderId)?.name || "Folder"; row.blur(); }
   });
 }
+function normalizeExportFrame(raw, canvasW, canvasH) {
+  if (!raw || typeof raw !== "object") return null;
+  let w = Math.round(+raw.w), h = Math.round(+raw.h);
+  if (!w || !h || w < 8 || h < 8) return null;
+  let x = Math.round(+raw.x || 0), y = Math.round(+raw.y || 0);
+  w = Math.min(w, canvasW); h = Math.min(h, canvasH);
+  x = clamp(x, 0, Math.max(0, canvasW - w));
+  y = clamp(y, 0, Math.max(0, canvasH - h));
+  if (w >= canvasW && h >= canvasH) return null;
+  return { x, y, w, h };
+}
+function getExportFrame() {
+  return normalizeExportFrame(project.exportFrame, project.width, project.height);
+}
+/** Largest axis-aligned rect of aspect aw×ah that fits inside the canvas. */
+function fitExportFrameAspect(aw, ah, canvasW = project.width, canvasH = project.height) {
+  const target = aw / ah, canvas = canvasW / canvasH;
+  let w, h;
+  if (target > canvas) { w = canvasW; h = Math.round(canvasW / target); }
+  else { h = canvasH; w = Math.round(canvasH * target); }
+  w = clamp(w, 8, canvasW); h = clamp(h, 8, canvasH);
+  return {
+    x: Math.round((canvasW - w) / 2),
+    y: Math.round((canvasH - h) / 2),
+    w, h,
+  };
+}
+function exportFrameAspectIndex(ef) {
+  if (!ef) return 0;
+  const r = ef.w / ef.h;
+  for (let i = 1; i < EXPORT_FRAME_ASPECTS.length; i++) {
+    const a = EXPORT_FRAME_ASPECTS[i];
+    const ar = a.w / a.h;
+    if (Math.abs(r - ar) < 0.02) return i;
+  }
+  return -1;
+}
+function updateMonitorRes() {
+  if (!els.monitorRes) return;
+  const ef = getExportFrame();
+  els.monitorRes.textContent = ef
+    ? `${project.width}×${project.height} canvas → ${ef.w}×${ef.h} export · ${project.fps}fps`
+    : `${project.width} × ${project.height} · ${project.fps}fps`;
+}
+function syncExportFrameSel() {
+  if (!els.exportFrameSel) return;
+  const ef = getExportFrame();
+  const i = exportFrameAspectIndex(ef);
+  let html = EXPORT_FRAME_ASPECTS.map((a, j) => {
+    const sel = ef ? (i === j) : (j === 0);
+    return `<option value="${j}" ${sel ? "selected" : ""}>${a.label}</option>`;
+  }).join("");
+  if (ef && i < 0)
+    html += `<option value="custom" selected>Custom · ${ef.w}×${ef.h}</option>`;
+  els.exportFrameSel.innerHTML = html;
+}
 function applyProject(data) {
   const wa = normalizeWorkArea(data.inPoint, data.outPoint);
   const disabledTracks = normalizeDisabledTracks(data.disabledTracks);
@@ -592,6 +661,7 @@ function applyProject(data) {
     inPoint: wa.inPoint,
     outPoint: wa.outPoint,
     disabledTracks,
+    exportFrame: normalizeExportFrame(data.exportFrame, data.width || 1280, data.height || 720),
   });
   const folderIds = new Set(project.folders.map((f) => f.id));
   for (const m of project.media) {
@@ -621,8 +691,12 @@ function applyProject(data) {
   for (const el of runtime.clipEls.values()) { try { el.pause(); el.src = ""; } catch { } }
   runtime.clipEls.clear(); runtime.clipGain.clear();
   els.preview.width = project.width; els.preview.height = project.height;
+  updateMonitorRes();
   syncAspectSel();
   syncFpsSel();
+  syncExportFrameSel();
+  updateExportFrameOverlay();
+  els.btnExportFrame?.classList.toggle("on", state.exportFrameView && !!getExportFrame());
   pruneSelection(); // keep the selection across external reloads where possible
   state.dirtyTimeline = true;
   renderBin(); renderInspector();
@@ -649,8 +723,8 @@ function scheduleSave() {
   }, 400);
 }
 function projectJSON() {
-  const { name, width, height, fps, background, revision, folders, media, clips, markers, inPoint, outPoint, disabledTracks } = project;
-  return {
+  const { name, width, height, fps, background, revision, folders, media, clips, markers, inPoint, outPoint, disabledTracks, exportFrame } = project;
+  const out = {
     name, width, height, fps, background, revision,
     folders: (folders || []).map(({ id, name, parentId, open }) =>
       ({ id, name, parentId: parentId || null, open: open !== false })),
@@ -667,6 +741,9 @@ function projectJSON() {
     outPoint: outPoint == null ? null : outPoint,
     disabledTracks: normalizeDisabledTracks(disabledTracks),
   };
+  const ef = getExportFrame();
+  if (ef) out.exportFrame = ef;
+  return out;
 }
 function listenSSE() {
   const es = new EventSource("/api/events");
@@ -5214,13 +5291,21 @@ function loop(ts) {
 function openExportSetup() {
   if (state.exporting) return;
   if (!project.clips.length) { alert("Timeline is empty — add some clips first."); return; }
+  const ef = getExportFrame();
   const fastOk = state.connected && state.ffmpeg;
   els.engineFast.disabled = !fastOk;
   els.engineFast.checked = fastOk;
-  els.engineRealtime.checked = !fastOk;
+  els.engineRealtime.disabled = !!ef;
+  els.engineRealtime.checked = !fastOk && !ef;
+  if (ef && fastOk) els.engineFast.checked = true;
   $("engineFastNote").textContent = fastOk
-    ? "Frame-accurate ffmpeg encode. Keeps rendering if you switch tabs."
+    ? (ef ? "Exports the " + ef.w + "×" + ef.h + " delivery frame (cropped). Keeps rendering if you switch tabs."
+      : "Frame-accurate ffmpeg encode. Keeps rendering if you switch tabs.")
     : "Needs the server + ffmpeg on PATH.";
+  const rtNote = $("engineRealtime")?.closest(".engine-opt")?.querySelector(".dim");
+  if (rtNote) rtNote.textContent = ef
+    ? "Unavailable while an export frame is set — use Fast export."
+    : "Plays the timeline once and records it. Keep the tab focused.";
   const warn = $("exportTrackWarn");
   const disabled = TRACKS.filter((t) =>
     !isTrackEnabled(t.id) && project.clips.some((c) => c.track === t.id)
@@ -5245,6 +5330,17 @@ function startChosenExport() {
 
 /* ── Fast export ── */
 let renderCancelled = false;
+let exportCropCanvas = null;
+function previewToExportBlob(quality = 0.95) {
+  const ef = getExportFrame();
+  if (!ef) return new Promise((res) => els.preview.toBlob(res, "image/jpeg", quality));
+  if (!exportCropCanvas) exportCropCanvas = document.createElement("canvas");
+  exportCropCanvas.width = ef.w;
+  exportCropCanvas.height = ef.h;
+  exportCropCanvas.getContext("2d").drawImage(
+    els.preview, ef.x, ef.y, ef.w, ef.h, 0, 0, ef.w, ef.h);
+  return new Promise((res) => exportCropCanvas.toBlob(res, "image/jpeg", quality));
+}
 function seekVideosTo(t) {
   const waits = [];
   for (const c of project.clips) {
@@ -5363,7 +5459,7 @@ async function fastExport() {
       await seekVideosTo(t);
       await prepareFrameAssets(t);       // exact SVG frames + AI masks
       drawFrame(t);
-      const blob = await new Promise((res) => els.preview.toBlob(res, "image/jpeg", 0.95));
+      const blob = await previewToExportBlob(0.95);
       const r = await fetch("/api/export/frame?id=" + sessId, { method: "POST", body: blob });
       if (!r.ok) throw new Error((await r.json()).error || "frame upload failed");
       const pct = ((f + 1) / frames) * 100;
@@ -5600,7 +5696,12 @@ els.aspectSel.addEventListener("change", () => {
   if (!a) return;
   project.width = a.w; project.height = a.h;
   els.preview.width = a.w; els.preview.height = a.h;
+  if (project.exportFrame)
+    project.exportFrame = normalizeExportFrame(project.exportFrame, a.w, a.h);
+  updateMonitorRes();
   syncAspectSel();
+  syncExportFrameSel();
+  updateExportFrameOverlay();
   seekMediaWhilePaused();
   scheduleSave();
 });
@@ -5609,9 +5710,38 @@ els.fpsSel?.addEventListener("change", () => {
   if (!(v > 0)) return;
   project.fps = v;
   syncFpsSel();
+  updateMonitorRes();
   state.dirtyTimeline = true;
   seekMediaWhilePaused();
   scheduleSave();
+});
+els.exportFrameSel?.addEventListener("change", () => {
+  const v = els.exportFrameSel.value;
+  if (v === "custom") return;
+  const preset = EXPORT_FRAME_ASPECTS[+v];
+  if (!preset) return;
+  if (!preset.w) project.exportFrame = null;
+  else project.exportFrame = fitExportFrameAspect(preset.w, preset.h);
+  state.exportFrameView = !!getExportFrame();
+  els.btnExportFrame?.classList.toggle("on", state.exportFrameView && !!getExportFrame());
+  updateMonitorRes();
+  syncExportFrameSel();
+  updateExportFrameOverlay();
+  scheduleSave();
+});
+els.btnExportFrame?.addEventListener("click", () => {
+  if (!getExportFrame()) {
+    const preset = EXPORT_FRAME_ASPECTS[1]; // 9:16 — common reframe default
+    project.exportFrame = fitExportFrameAspect(preset.w, preset.h);
+    state.exportFrameView = true;
+    syncExportFrameSel();
+    updateMonitorRes();
+    scheduleSave();
+  } else {
+    state.exportFrameView = !state.exportFrameView;
+  }
+  els.btnExportFrame.classList.toggle("on", state.exportFrameView && !!getExportFrame());
+  updateExportFrameOverlay();
 });
 els.btnGuides.addEventListener("click", () => {
   state.guides = !state.guides;
@@ -5679,6 +5809,7 @@ function applyMonitorView() {
   els.btnZoom100.classList.toggle("hidden", !zoomed);
   scroll.classList.toggle("is-zoomed", zoomed);
   updateSafeOverlay();
+  updateExportFrameOverlay();
 }
 let monitorViewRaf = 0;
 let monitorViewAfter = null;
@@ -5801,6 +5932,69 @@ function updateSafeOverlay() {
   o.height = cv.offsetHeight + "px";
   els.safeOverlay.classList.toggle("vertical", project.height > project.width);
 }
+/* Dimmed overscan outside the delivery export frame (preview-only overlay). */
+function updateExportFrameOverlay() {
+  const ov = els.exportFrameOverlay;
+  if (!ov) return;
+  const ef = getExportFrame();
+  const show = state.exportFrameView && ef;
+  ov.classList.toggle("hidden", !show);
+  if (!show) return;
+  const cv = els.preview;
+  const root = ov.style;
+  root.left = cv.offsetLeft + "px";
+  root.top = cv.offsetTop + "px";
+  root.width = cv.offsetWidth + "px";
+  root.height = cv.offsetHeight + "px";
+  const sx = cv.offsetWidth / project.width;
+  const sy = cv.offsetHeight / project.height;
+  const hole = ov.querySelector(".ef-shade");
+  const handle = ov.querySelector(".ef-handle");
+  if (!hole) return;
+  const left = ef.x * sx, top = ef.y * sy, w = ef.w * sx, h = ef.h * sy;
+  hole.style.left = left + "px";
+  hole.style.top = top + "px";
+  hole.style.width = w + "px";
+  hole.style.height = h + "px";
+  if (handle) {
+    handle.style.left = left + "px";
+    handle.style.top = top + "px";
+    handle.style.width = w + "px";
+  }
+}
+let exportFrameDrag = null;
+function exportFrameDragMove(e) {
+  if (!exportFrameDrag) return;
+  const cv = els.preview;
+  const sx = project.width / cv.offsetWidth;
+  const sy = project.height / cv.offsetHeight;
+  const ef = getExportFrame();
+  if (!ef) return;
+  project.exportFrame = normalizeExportFrame({
+    x: exportFrameDrag.ox + (e.clientX - exportFrameDrag.startX) * sx,
+    y: exportFrameDrag.oy + (e.clientY - exportFrameDrag.startY) * sy,
+    w: ef.w, h: ef.h,
+  }, project.width, project.height);
+  updateExportFrameOverlay();
+}
+function exportFrameDragEnd() {
+  if (!exportFrameDrag) return;
+  exportFrameDrag = null;
+  syncExportFrameSel();
+  updateMonitorRes();
+  scheduleSave();
+  document.removeEventListener("pointermove", exportFrameDragMove);
+  document.removeEventListener("pointerup", exportFrameDragEnd, true);
+}
+els.exportFrameOverlay?.addEventListener("pointerdown", (e) => {
+  if (!e.target.closest(".ef-handle")) return;
+  const ef = getExportFrame();
+  if (!ef) return;
+  e.preventDefault();
+  exportFrameDrag = { startX: e.clientX, startY: e.clientY, ox: ef.x, oy: ef.y };
+  document.addEventListener("pointermove", exportFrameDragMove);
+  document.addEventListener("pointerup", exportFrameDragEnd, true);
+});
 
 window.addEventListener("keydown", (e) => {
   const k = e.key;

--- a/app.js
+++ b/app.js
@@ -5294,10 +5294,15 @@ function openExportSetup() {
   const ef = getExportFrame();
   const fastOk = state.connected && state.ffmpeg;
   els.engineFast.disabled = !fastOk;
-  els.engineFast.checked = fastOk;
-  els.engineRealtime.disabled = !!ef;
-  els.engineRealtime.checked = !fastOk && !ef;
-  if (ef && fastOk) els.engineFast.checked = true;
+  els.engineRealtime.disabled = false;
+  if (ef && fastOk) {
+    els.engineFast.checked = true;
+    els.engineRealtime.checked = false;
+  } else {
+    els.engineFast.checked = fastOk;
+    els.engineRealtime.checked = !fastOk;
+  }
+  if (ef) els.engineRealtime.disabled = true;
   $("engineFastNote").textContent = fastOk
     ? (ef ? "Exports the " + ef.w + "×" + ef.h + " delivery frame (cropped). Keeps rendering if you switch tabs."
       : "Frame-accurate ffmpeg encode. Keeps rendering if you switch tabs.")
@@ -5737,8 +5742,14 @@ els.btnExportFrame?.addEventListener("click", () => {
     syncExportFrameSel();
     updateMonitorRes();
     scheduleSave();
+  } else if (state.exportFrameView) {
+    project.exportFrame = null;
+    state.exportFrameView = false;
+    syncExportFrameSel();
+    updateMonitorRes();
+    scheduleSave();
   } else {
-    state.exportFrameView = !state.exportFrameView;
+    state.exportFrameView = true;
   }
   els.btnExportFrame.classList.toggle("on", state.exportFrameView && !!getExportFrame());
   updateExportFrameOverlay();

--- a/index.html
+++ b/index.html
@@ -75,7 +75,10 @@
         <span class="panel-head-actions">
           <select id="aspectSel" class="head-select" title="Canvas aspect preset"></select>
           <select id="fpsSel" class="head-select" title="Project frame rate"></select>
+          <select id="exportFrameSel" class="head-select" title="Delivery export frame — crop inside the canvas for reframing"></select>
+          <button class="btn tiny toggle" id="btnExportFrame" title="Toggle export frame overlay (drag handle to reframe)">⬒ Frame</button>
           <button class="btn tiny toggle" id="btnGuides" title="Toggle safe-area guides">▦ Safe</button>
+          <span class="dim" id="monitorRes">1280 × 720 · 30fps</span>
         </span>
       </div>
       <div class="monitor-stage" id="monitorStage">
@@ -87,6 +90,10 @@
               <div class="sa-title"></div>
               <div class="sa-ui-bottom"></div>
               <div class="sa-ui-right"></div>
+            </div>
+            <div id="exportFrameOverlay" class="hidden">
+              <div class="ef-shade"></div>
+              <div class="ef-handle" title="Drag to reposition export frame">Export frame</div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -94,6 +94,10 @@
             <div id="exportFrameOverlay" class="hidden">
               <div class="ef-shade"></div>
               <div class="ef-handle" title="Drag to reposition export frame">Export frame</div>
+              <div class="ef-edge ef-edge-t" title="Drag to reposition export frame"></div>
+              <div class="ef-edge ef-edge-b" title="Drag to reposition export frame"></div>
+              <div class="ef-edge ef-edge-l" title="Drag to reposition export frame"></div>
+              <div class="ef-edge ef-edge-r" title="Drag to reposition export frame"></div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -93,11 +93,12 @@
             </div>
             <div id="exportFrameOverlay" class="hidden">
               <div class="ef-shade"></div>
-              <div class="ef-handle" title="Drag to reposition export frame">Export frame</div>
-              <div class="ef-edge ef-edge-t" title="Drag to reposition export frame"></div>
-              <div class="ef-edge ef-edge-b" title="Drag to reposition export frame"></div>
-              <div class="ef-edge ef-edge-l" title="Drag to reposition export frame"></div>
-              <div class="ef-edge ef-edge-r" title="Drag to reposition export frame"></div>
+              <button type="button" class="ef-handle"
+                aria-label="Export frame — drag or arrow keys to reposition (Shift for 10px steps)">Export frame</button>
+              <div class="ef-edge ef-edge-t" title="Drag to reposition export frame" aria-hidden="true"></div>
+              <div class="ef-edge ef-edge-b" title="Drag to reposition export frame" aria-hidden="true"></div>
+              <div class="ef-edge ef-edge-l" title="Drag to reposition export frame" aria-hidden="true"></div>
+              <div class="ef-edge ef-edge-r" title="Drag to reposition export frame" aria-hidden="true"></div>
             </div>
           </div>
         </div>

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -298,7 +298,7 @@ async function callTool(name, args) {
             break;
           }
           case "setProject": {
-            const allowed = ["name", "width", "height", "fps", "background", "markers", "disabledTracks"];
+            const allowed = ["name", "width", "height", "fps", "background", "markers", "disabledTracks", "exportFrame"];
             for (const [k, v] of Object.entries(op.set || {})) {
               if (!allowed.includes(k)) throw new Error(`setProject: '${k}' not settable (allowed: ${allowed.join(", ")})`);
               if (v === null) delete proj[k]; else proj[k] = v;

--- a/style.css
+++ b/style.css
@@ -988,8 +988,10 @@ body.track-size-s .clip.selected {
   justify-content: flex-start;
   height: 22px;
   box-sizing: border-box;
+  margin: 0;
   padding: 0 8px;
   font: 600 10px/1 "Segoe UI", sans-serif;
+  font-family: inherit;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: #fff;
@@ -1002,6 +1004,12 @@ body.track-size-s .clip.selected {
   white-space: nowrap;
   user-select: none;
   transition: background 0.12s ease;
+  appearance: none;
+  -webkit-appearance: none;
+}
+#exportFrameOverlay .ef-handle:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
 }
 #exportFrameOverlay .ef-handle:hover {
   background: rgba(79, 140, 255, 1);

--- a/style.css
+++ b/style.css
@@ -973,7 +973,6 @@ body.track-size-s .clip.selected {
   position: absolute;
   pointer-events: none;
   z-index: 6;
-  overflow: hidden;
 }
 #exportFrameOverlay .ef-shade {
   position: absolute;
@@ -984,21 +983,47 @@ body.track-size-s .clip.selected {
 }
 #exportFrameOverlay .ef-handle {
   position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
   height: 22px;
   box-sizing: border-box;
-  padding: 2px 8px;
-  font: 600 10px/18px "Segoe UI", sans-serif;
+  padding: 0 8px;
+  font: 600 10px/1 "Segoe UI", sans-serif;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: #fff;
-  background: rgba(79, 140, 255, 0.92);
+  background: rgba(79, 140, 255, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.35);
-  border-radius: 4px 4px 0 0;
+  border-radius: 4px;
   cursor: move;
   pointer-events: auto;
+  touch-action: none;
   white-space: nowrap;
-  transform: translateY(-100%);
   user-select: none;
+  transition: background 0.12s ease;
+}
+#exportFrameOverlay .ef-handle:hover {
+  background: rgba(79, 140, 255, 1);
+}
+#exportFrameOverlay.is-dragging .ef-handle,
+#exportFrameOverlay .ef-handle:active {
+  background: rgba(79, 140, 255, 0.9);
+}
+#exportFrameOverlay .ef-edge {
+  position: absolute;
+  pointer-events: auto;
+  touch-action: none;
+  cursor: move;
+  user-select: none;
+}
+#exportFrameOverlay .ef-edge-t,
+#exportFrameOverlay .ef-edge-b {
+  height: 10px;
+}
+#exportFrameOverlay .ef-edge-l,
+#exportFrameOverlay .ef-edge-r {
+  width: 10px;
 }
 
 .transport {

--- a/style.css
+++ b/style.css
@@ -968,6 +968,39 @@ body.track-size-s .clip.selected {
   border-left: 1px dashed #ff4d6a80;
 }
 
+/* ── Export frame overlay (dimmed overscan, preview-only) ── */
+#exportFrameOverlay {
+  position: absolute;
+  pointer-events: none;
+  z-index: 6;
+  overflow: hidden;
+}
+#exportFrameOverlay .ef-shade {
+  position: absolute;
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.58);
+  border: 2px solid rgba(255, 255, 255, 0.88);
+  box-sizing: border-box;
+  pointer-events: none;
+}
+#exportFrameOverlay .ef-handle {
+  position: absolute;
+  height: 22px;
+  box-sizing: border-box;
+  padding: 2px 8px;
+  font: 600 10px/18px "Segoe UI", sans-serif;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #fff;
+  background: rgba(79, 140, 255, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 4px 4px 0 0;
+  cursor: move;
+  pointer-events: auto;
+  white-space: nowrap;
+  transform: translateY(-100%);
+  user-select: none;
+}
+
 .transport {
   display: flex;
   align-items: center;


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## What does this PR do?

<img width="1251" height="634" alt="image" src="https://github.com/user-attachments/assets/0eac1b98-8a42-4f4b-b2f0-6ecd0bb1666c" />

This is a proposal, as rendering is affected (the one called "realtime" - it is disabled while **frame** is active).

 Quite often the footage is, for example, horizontal, but a vertical reel must be produced. Abstracting out the video reframing done externally, for the manual process now one can set a project to 16x9, with a cropping frame 9x16. On ffmpeg export, this will be preserved. While making a composition (by a human), it is quite easy to manualy frame the source horizontal video, as it is visible, but dimmed ouside the **frame** area.

## Type of change

- [ ] Bug fix
- [X] New feature (GUI/composition)
- [X] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [X] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [ ] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project frame-rate selection with preset and custom-rate options.
  * Added export-frame controls for reframing compositions to different delivery aspect ratios, including draggable overlays and presets.
  * Preview shows overscan outside the selected export area; settings persist per project.
  * Fast exports are cropped to the selected frame, while realtime export is unavailable when an export frame is active.
* **Documentation**
  * Added guidance and a recipe for reframing horizontal compositions for vertical delivery.
  * Expanded setup and MCP configuration instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->