### PR TITLE
feat: add ffmpeg encoding profiles for 'fast' export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,7 +430,9 @@ obvious cuts were missed, raise it if motion is being misread as cuts.
 - `POST /api/analyze` — body `{src:"/media/ref.mp4", threshold?, music?}`: analyze a
   reference video into an edit blueprint (see "Remake a reference video"); extracts
   its music into ./media. `GET /api/analyze?src=…` returns the cached blueprint.
-- `GET  /api/events`  — SSE, emits `change` when project.json, ./media or ./library changes
+- `GET  /api/events`  — SSE: named event `change` when project.json, ./media or
+  ./library changes; named event `profiles` when `encoding-profiles.json` changes
+  (UI refreshes the export-profile list only — no project reload)
 - Fast export (used by the UI; browser renders frames, ffmpeg encodes):
   `GET /api/export/ffmpeg` → `{available}` · `GET /api/export/profiles[?detail=1]` →
   `{default, profiles, issues}` · `POST /api/export/begin` `{fps,name,profile?,hasAudio?}` →
@@ -573,7 +575,8 @@ ffmpeg directly from `media/` sources if a file is needed.
 User-editable at the repo root. A profile is a **raw ffmpeg argument list** plus the
 two things that are not ffmpeg arguments: `jpegQuality` (the browser's frame quality)
 and `extension` (which names the file and therefore picks the muxer). Edit the file
-while the server runs — the UI hot-reloads the profile list via SSE.
+while the server runs — the UI hot-reloads the profile list via an SSE `profiles`
+event (no full project reload).
 
 ```jsonc
 {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ Every Claude Code session then has these tools:
 - `fablecut_import_media` — copy a local file into `./media/` and register it.
 - `fablecut_analyze_reference` — turn a reference video into an edit blueprint
   (shots, beats, BPM, energy, drop) + extract its music. See "Remake a reference video".
+- `fablecut_encode_profiles` — list ffmpeg encoding presets from `encoding-profiles.json`
+  (codec, CRF, JPEG quality). Set `project.encodeProfile` via patch to pin a project default.
 
 ### Token-efficient editing (important for agents)
 
@@ -184,6 +186,7 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
   ],
   "disabledTracks": [ "A2" ],
   // ^ optional — track ids (V4 V3 V2 V1 A1 A2 A3) omitted from preview/export when listed
+  "encodeProfile": "hq",  // optional — fast-export profile id (see encoding-profiles.json)
   "media": [
     { "id": "m_abc", "name": "intro.mp4", "kind": "video",  // video|audio|image|svg
       "src": "/media/intro.mp4",             // path under ./media or ./library
@@ -429,7 +432,9 @@ obvious cuts were missed, raise it if motion is being misread as cuts.
   its music into ./media. `GET /api/analyze?src=…` returns the cached blueprint.
 - `GET  /api/events`  — SSE, emits `change` when project.json, ./media or ./library changes
 - Fast export (used by the UI; browser renders frames, ffmpeg encodes):
-  `GET /api/export/ffmpeg` → `{available}` · `POST /api/export/begin` `{fps,name}` → `{id}`
+  `GET /api/export/ffmpeg` → `{available}` · `GET /api/export/profiles[?detail=1]` →
+  `{default, profiles, issues}` · `POST /api/export/begin` `{fps,name,profile?}` →
+  `{id,profile,label,summary}` (**400** if `profile` is not a defined id)
   · `POST /api/export/frame?id=` (JPEG body, in order) · `POST /api/export/audio?id=` (WAV body)
   · `POST /api/export/end?id=[&discard=1]` → `{src}` under `/exports/`
 
@@ -556,7 +561,83 @@ Realtime export, and `/api/export/begin` all use this value; pass the same
 Export is user-driven (Export button → dialog). Two engines: **Fast** (browser
 renders each frame with the normal compositor — including SVG frames, keys and
 AI masks — streams JPEG frames + an offline WAV mix to the server, ffmpeg
-encodes a CRF-18 faststart MP4 into `./exports/`) and **Realtime**
+encodes via an **encoding profile** into `./exports/`) and **Realtime**
 (MediaRecorder fallback). Claude cannot trigger export headlessly — the
 compositor lives in the browser; ask the user to click Export, or render with
 ffmpeg directly from `media/` sources if a file is needed.
+
+### Encoding profiles (`encoding-profiles.json`)
+
+User-editable at the repo root. Defines ffmpeg settings for Fast export. The
+server validates all fields (no raw ffmpeg strings from the client). Edit the
+file while the server runs — the UI hot-reloads the profile list via SSE.
+
+```jsonc
+{
+  "default": "delivery",           // profile id used when nothing else is set
+  "profiles": {
+    "draft": {
+      "label": "Draft · H.264 fast",
+      "description": "Quick preview — smaller file, faster encode.",
+      "jpegQuality": 0.85,         // browser JPEG frame quality (0.5–1)
+      "video": { "codec": "libx264", "preset": "veryfast", "crf": 23, "pixFmt": "yuv420p" },
+      "audio": { "codec": "aac", "bitrate": "128k" },
+      "mux": { "movflags": "+faststart" }
+    },
+    "delivery": { /* … balanced default … */ },
+    "hq": { /* … slow preset, lower CRF … */ }
+  }
+}
+```
+
+**Allowed values:** video codecs `libx264` · `libx265`; presets `ultrafast`…`veryslow`;
+CRF 0–51; pixel formats `yuv420p` · `yuv422p` · `yuv444p`; audio `aac` · `libopus`
+with bitrates like `192k`. Optional x264 `tune` / `profile` on a profile's `video` object.
+
+**Advanced fields** (optional — for broadcast / custom ffmpeg):
+
+| block | fields | maps to ffmpeg |
+| --- | --- | --- |
+| `encode` | `hideBanner`, `stats`, `loglevel` | global flags on both encode passes |
+| `video` | `g`, `maxrate`, `bufsize`, `x264opts`, `vf` | GOP, rate cap, x264 opts, filter chain |
+| `audio` | `sampleRate`, `strict` | `-ar`, `-strict` (e.g. AAC `-2`) |
+| `mux` | `format`, `extension`, `movflags` | `-f mov`, output `.mov`, faststart |
+
+Notes on how these are handled:
+
+- **Profiles inherit** from the same-named built-in (or `delivery` for new ids), so a
+  profile that only sets `video.crf` keeps the rest. Set `"movflags": null` to clear an
+  inherited value.
+- `mux.format` accepts `mp4` · `mov` · `matroska` (`mkv` is normalized to `matroska`,
+  since `-f mkv` is not a valid muxer name). The output extension follows the container
+  unless `mux.extension` overrides it.
+- `libopus` is switched to `aac` for MOV (no mapping exists) and gets `-strict -2`
+  automatically in MP4 — otherwise the mux pass would fail *after* every frame is rendered.
+- A `loglevel` of `quiet`/`panic`/`fatal` is raised to `error` for the encode passes: that
+  stderr is only ever read back to report *why* an export failed.
+- Anything invalid is **corrected and reported**, never silently applied. Rejected and
+  clamped values are listed on server startup, in `GET /api/export/profiles` (`issues`),
+  and per profile via `fablecut_encode_profiles {detail:true}` (`warnings`).
+- `vf` / `x264opts` are restricted to `[\w=.,:/+\-[\]()%| ]`, so filters needing quotes
+  (e.g. `drawtext=text='hi'`) are refused. Do that work in the timeline instead.
+- Frames arrive as **JPEG (4:2:0)**, so `yuv422p`/`yuv444p` cannot recover chroma the
+  source never had; raise `jpegQuality` before reaching for a wider pixel format.
+
+Example **`broadcast1080i50`** (included in `encoding-profiles.json`) builds an interlaced
+1080i50 `.mov` with your x264 opts, `tinterlace`, 384k AAC @ 48 kHz. Set the project to
+**1920×1080 @ 25fps** — the browser renders progressive frames; the profile's `vf` does
+`fps=50` + `tinterlace=interleave_top`.
+
+**Note:** Fast export pipes **composited JPEG frames** from the browser (`-f image2pipe`),
+not `-i source.mp4`. Filters and x264 settings apply to that frame stream. To transcode an
+existing file verbatim (your one-liner with `-i source.mp4`), run ffmpeg directly — that is
+outside the editor compositor path.
+
+**Which profile is used (priority):**
+1. Profile picked in the Export dialog (one-off; saved to browser settings unless overridden)
+2. `project.encodeProfile` — set via UI reload or `{op:"setProject", set:{encodeProfile:"hq"}}`
+3. Browser setting `encodeProfile` in localStorage (set when you change the Export dropdown)
+4. `default` in `encoding-profiles.json`
+
+**MCP:** `fablecut_encode_profiles` lists profiles; `{detail:true}` includes full settings;
+`{profile:"hq"}` returns one profile. `fablecut_status` shows the effective profile for the project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -610,7 +610,10 @@ Notes on how these are handled:
   inherited value.
 - `mux.format` accepts `mp4` · `mov` · `matroska` (`mkv` is normalized to `matroska`,
   since `-f mkv` is not a valid muxer name). The output extension follows the container
-  unless `mux.extension` overrides it.
+  unless `mux.extension` overrides it with one that matches (`.m4v` for `mp4` is fine).
+  A conflicting pair is **reconciled, not just flagged**: `format` picks the muxer, so the
+  extension is corrected to match it (`mov` + `.mp4` → `.mov`) and the change is reported.
+  Giving only `mux.extension` infers the container from it.
 - `libopus` is switched to `aac` for MOV (no mapping exists) and gets `-strict -2`
   automatically in MP4 — otherwise the mux pass would fail *after* every frame is rendered.
 - A `loglevel` of `quiet`/`panic`/`fatal` is raised to `error` for the encode passes: that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,10 +573,10 @@ ffmpeg directly from `media/` sources if a file is needed.
 ### Encoding profiles (`encoding-profiles.json`)
 
 User-editable at the repo root. A profile is a **raw ffmpeg argument list** plus the
-two things that are not ffmpeg arguments: `jpegQuality` (the browser's frame quality)
-and `extension` (which names the file and therefore picks the muxer). Edit the file
-while the server runs — the UI hot-reloads the profile list via an SSE `profiles`
-event (no full project reload).
+things that are not ffmpeg arguments: `jpegQuality` (browser frame quality),
+`extension` (output container), and optional `color` (output matrix / range tags).
+Edit the file while the server runs — the UI hot-reloads the profile list via an SSE
+`profiles` event (no full project reload).
 
 ```jsonc
 {
@@ -587,6 +587,9 @@ event (no full project reload).
       "description": "Quick preview — smaller file, faster encode.",
       "jpegQuality": 0.85,         // browser JPEG frame quality (0.1–1)
       "extension": ".mp4",
+      // Output color (optional — defaults to BT.709 limited/tv). Independent of
+      // -pix_fmt: yuv420p and yuv422p10le both typically use bt709 for HD SDR.
+      "color": { "matrix": "bt709", "primaries": "bt709", "trc": "bt709", "range": "tv" },
       "args": ["-c:v", "libx264", "-preset", "veryfast", "-crf", "23",
                "-pix_fmt", "yuv420p", "-c:a", "aac", "-b:a", "128k",
                "-movflags", "+faststart", "-shortest"]
@@ -596,10 +599,10 @@ event (no full project reload).
 ```
 
 Export is **one ffmpeg pass**. The server owns the input side and the output path;
-`args` is everything in between, verbatim:
+`args` is everything in between (plus JPEG color conversion derived from `color`):
 
 ```
-ffmpeg -y -f image2pipe -framerate <fps> -i -  [-i audio.wav]  <args…>  exports/<name><extension>
+ffmpeg -y -f image2pipe -framerate <fps> -i -  [-i audio.wav]  <jpeg-color> <args…>  exports/<name><extension>
 ```
 
 - **There is no allow-list.** Any codec, filter, container or flag your local ffmpeg
@@ -612,8 +615,13 @@ ffmpeg -y -f image2pipe -framerate <fps> -i -  [-i audio.wav]  <args…>  export
 - Use the **array form** — each element is passed to `spawn` untouched, so no quoting
   is needed (`["-vf", "drawtext=text='hi there'"]` just works). A plain string is
   accepted and split on whitespace.
-- Nothing is injected for you: `+faststart`, `-shortest`, `-strict -2` for Opus in MP4
-  and pixel-format choices are all yours to write.
+- **`color`** controls JPEG→YUV conversion and stream tags (`-colorspace` /
+  `-color_primaries` / `-color_trc` / `-color_range`). Default is BT.709 limited
+  (`range: "tv"`). Use `"range": "pc"` for full-range masters. Do **not** put those
+  flags in `args` — the engine strips them and applies `color` so vf and tags stay
+  aligned. `-pix_fmt` stays in `args` (sampling / bit depth only).
+- Nothing else is injected for you: `+faststart`, `-shortest`, `-strict -2` for Opus
+  in MP4 and pixel-format choices are all yours to write.
 - Frames arrive as **JPEG (4:2:0)**, so `yuv422p`/`yuv444p` cannot recover chroma the
   source never had; raise `jpegQuality` before reaching for a wider pixel format.
 - The audio mix is only present when the timeline has audio; with no audio there is a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ Every Claude Code session then has these tools:
 - `fablecut_import_media` — copy a local file into `./media/` and register it.
 - `fablecut_analyze_reference` — turn a reference video into an edit blueprint
   (shots, beats, BPM, energy, drop) + extract its music. See "Remake a reference video".
-- `fablecut_encode_profiles` — list ffmpeg encoding presets from `encoding-profiles.json`
-  (codec, CRF, JPEG quality). Set `project.encodeProfile` via patch to pin a project default.
+- `fablecut_encode_profiles` — list export presets from `encoding-profiles.json` (each is a
+  raw ffmpeg args list). Set `project.encodeProfile` via patch to pin a project default.
 
 ### Token-efficient editing (important for agents)
 
@@ -433,9 +433,11 @@ obvious cuts were missed, raise it if motion is being misread as cuts.
 - `GET  /api/events`  — SSE, emits `change` when project.json, ./media or ./library changes
 - Fast export (used by the UI; browser renders frames, ffmpeg encodes):
   `GET /api/export/ffmpeg` → `{available}` · `GET /api/export/profiles[?detail=1]` →
-  `{default, profiles, issues}` · `POST /api/export/begin` `{fps,name,profile?}` →
-  `{id,profile,label,summary}` (**400** if `profile` is not a defined id)
-  · `POST /api/export/frame?id=` (JPEG body, in order) · `POST /api/export/audio?id=` (WAV body)
+  `{default, profiles, issues}` · `POST /api/export/begin` `{fps,name,profile?,hasAudio?}` →
+  `{id,profile,label,summary}` (**400** if `profile` is not a defined id, or if ffmpeg
+  rejects its args in the dry run)
+  · `POST /api/export/frame?id=` (JPEG body, in order) · `POST /api/export/audio?id=` (WAV
+  body — must be sent before the first frame; ffmpeg is spawned on frame 1)
   · `POST /api/export/end?id=[&discard=1]` → `{src}` under `/exports/`
 
 ## Recipes
@@ -560,17 +562,18 @@ Realtime export, and `/api/export/begin` all use this value; pass the same
 
 Export is user-driven (Export button → dialog). Two engines: **Fast** (browser
 renders each frame with the normal compositor — including SVG frames, keys and
-AI masks — streams JPEG frames + an offline WAV mix to the server, ffmpeg
-encodes via an **encoding profile** into `./exports/`) and **Realtime**
+AI masks — streams JPEG frames + an offline WAV mix to the server, a single ffmpeg
+pass encodes them via an **encoding profile** into `./exports/`) and **Realtime**
 (MediaRecorder fallback). Claude cannot trigger export headlessly — the
 compositor lives in the browser; ask the user to click Export, or render with
 ffmpeg directly from `media/` sources if a file is needed.
 
 ### Encoding profiles (`encoding-profiles.json`)
 
-User-editable at the repo root. Defines ffmpeg settings for Fast export. The
-server validates all fields (no raw ffmpeg strings from the client). Edit the
-file while the server runs — the UI hot-reloads the profile list via SSE.
+User-editable at the repo root. A profile is a **raw ffmpeg argument list** plus the
+two things that are not ffmpeg arguments: `jpegQuality` (the browser's frame quality)
+and `extension` (which names the file and therefore picks the muxer). Edit the file
+while the server runs — the UI hot-reloads the profile list via SSE.
 
 ```jsonc
 {
@@ -579,62 +582,43 @@ file while the server runs — the UI hot-reloads the profile list via SSE.
     "draft": {
       "label": "Draft · H.264 fast",
       "description": "Quick preview — smaller file, faster encode.",
-      "jpegQuality": 0.85,         // browser JPEG frame quality (0.5–1)
-      "video": { "codec": "libx264", "preset": "veryfast", "crf": 23, "pixFmt": "yuv420p" },
-      "audio": { "codec": "aac", "bitrate": "128k" },
-      "mux": { "movflags": "+faststart" }
-    },
-    "delivery": { /* … balanced default … */ },
-    "hq": { /* … slow preset, lower CRF … */ }
+      "jpegQuality": 0.85,         // browser JPEG frame quality (0.1–1)
+      "extension": ".mp4",
+      "args": ["-c:v", "libx264", "-preset", "veryfast", "-crf", "23",
+               "-pix_fmt", "yuv420p", "-c:a", "aac", "-b:a", "128k",
+               "-movflags", "+faststart", "-shortest"]
+    }
   }
 }
 ```
 
-**Allowed values:** video codecs `libx264` · `libx265`; presets `ultrafast`…`veryslow`;
-CRF 0–51; pixel formats `yuv420p` · `yuv422p` · `yuv444p`; audio `aac` · `libopus`
-with bitrates like `192k`. Optional x264 `tune` / `profile` on a profile's `video` object.
+Export is **one ffmpeg pass**. The server owns the input side and the output path;
+`args` is everything in between, verbatim:
 
-**Advanced fields** (optional — for broadcast / custom ffmpeg):
+```
+ffmpeg -y -f image2pipe -framerate <fps> -i -  [-i audio.wav]  <args…>  exports/<name><extension>
+```
 
-| block | fields | maps to ffmpeg |
-| --- | --- | --- |
-| `encode` | `hideBanner`, `stats`, `loglevel` | global flags on both encode passes |
-| `video` | `g`, `maxrate`, `bufsize`, `x264opts`, `vf` | GOP, rate cap, x264 opts, filter chain |
-| `audio` | `sampleRate`, `strict` | `-ar`, `-strict` (e.g. AAC `-2`) |
-| `mux` | `format`, `extension`, `movflags` | `-f mov`, output `.mov`, faststart |
-
-Notes on how these are handled:
-
-- **Profiles inherit** from the same-named built-in (or `delivery` for new ids), so a
-  profile that only sets `video.crf` keeps the rest. Set `"movflags": null` to clear an
-  inherited value.
-- `mux.format` accepts `mp4` · `mov` · `matroska` (`mkv` is normalized to `matroska`,
-  since `-f mkv` is not a valid muxer name). The output extension follows the container
-  unless `mux.extension` overrides it with one that matches (`.m4v` for `mp4` is fine).
-  A conflicting pair is **reconciled, not just flagged**: `format` picks the muxer, so the
-  extension is corrected to match it (`mov` + `.mp4` → `.mov`) and the change is reported.
-  Giving only `mux.extension` infers the container from it.
-- `libopus` is switched to `aac` for MOV (no mapping exists) and gets `-strict -2`
-  automatically in MP4 — otherwise the mux pass would fail *after* every frame is rendered.
-- A `loglevel` of `quiet`/`panic`/`fatal` is raised to `error` for the encode passes: that
-  stderr is only ever read back to report *why* an export failed.
-- Anything invalid is **corrected and reported**, never silently applied. Rejected and
-  clamped values are listed on server startup, in `GET /api/export/profiles` (`issues`),
-  and per profile via `fablecut_encode_profiles {detail:true}` (`warnings`).
-- `vf` / `x264opts` are restricted to `[\w=.,:/+\-[\]()%| ]`, so filters needing quotes
-  (e.g. `drawtext=text='hi'`) are refused. Do that work in the timeline instead.
+- **There is no allow-list.** Any codec, filter, container or flag your local ffmpeg
+  supports works — ProRes, DNxHD, NVENC/QSV/VideoToolbox, VP9/AV1, 10-bit, HDR tags.
+  See the shipped `prores422` and `broadcast1080i50` profiles.
+- **Args are validated by ffmpeg itself**, not by a schema: when an export starts the
+  server dry-runs the profile against a 0.1 s synthetic input (`lavfi`). A typo or an
+  encoder your build lacks is rejected up front with ffmpeg's own message, instead of
+  failing after every frame has been rendered.
+- Use the **array form** — each element is passed to `spawn` untouched, so no quoting
+  is needed (`["-vf", "drawtext=text='hi there'"]` just works). A plain string is
+  accepted and split on whitespace.
+- Nothing is injected for you: `+faststart`, `-shortest`, `-strict -2` for Opus in MP4
+  and pixel-format choices are all yours to write.
 - Frames arrive as **JPEG (4:2:0)**, so `yuv422p`/`yuv444p` cannot recover chroma the
   source never had; raise `jpegQuality` before reaching for a wider pixel format.
-
-Example **`broadcast1080i50`** (included in `encoding-profiles.json`) builds an interlaced
-1080i50 `.mov` with your x264 opts, `tinterlace`, 384k AAC @ 48 kHz. Set the project to
-**1920×1080 @ 25fps** — the browser renders progressive frames; the profile's `vf` does
-`fps=50` + `tinterlace=interleave_top`.
+- The audio mix is only present when the timeline has audio; with no audio there is a
+  single input, so avoid hardcoded `-map 1:a`.
 
 **Note:** Fast export pipes **composited JPEG frames** from the browser (`-f image2pipe`),
-not `-i source.mp4`. Filters and x264 settings apply to that frame stream. To transcode an
-existing file verbatim (your one-liner with `-i source.mp4`), run ffmpeg directly — that is
-outside the editor compositor path.
+not `-i source.mp4`. Filters and codec settings apply to that frame stream. To transcode
+an existing file verbatim, run ffmpeg directly — that is outside the compositor path.
 
 **Which profile is used (priority):**
 1. Profile picked in the Export dialog (one-off; saved to browser settings unless overridden)
@@ -642,5 +626,5 @@ outside the editor compositor path.
 3. Browser setting `encodeProfile` in localStorage (set when you change the Export dropdown)
 4. `default` in `encoding-profiles.json`
 
-**MCP:** `fablecut_encode_profiles` lists profiles; `{detail:true}` includes full settings;
-`{profile:"hq"}` returns one profile. `fablecut_status` shows the effective profile for the project.
+**MCP:** `fablecut_encode_profiles` lists profiles; `{detail:true}` includes each `args`
+array; `{profile:"hq"}` returns one profile. `fablecut_status` shows the effective profile.

--- a/README.md
+++ b/README.md
@@ -175,8 +175,10 @@ same time.
 
 **Export**
 
-- Fast export: browser renders every frame + an offline audio mix, ffmpeg
-  encodes a frame-accurate CRF-18 MP4 (keeps rendering if you switch tabs)
+- Fast export: browser renders every frame + an offline audio mix; ffmpeg
+  encodes them via an **encoding profile** from `encoding-profiles.json`
+  (keeps rendering if you switch tabs). The Export dialog has a profile
+  selector; pin a project default with `encodeProfile` in `project.json`
 - Realtime MediaRecorder fallback when ffmpeg isn't available
 
 ## Quick start
@@ -268,7 +270,8 @@ Three equivalent control surfaces:
 
    Tools: `fablecut_status` (auto-starts the editor), `fablecut_docs`,
    `fablecut_get_project`, `fablecut_set_project`, `fablecut_patch_project`,
-   `fablecut_import_media`, `fablecut_analyze_reference`.
+   `fablecut_import_media`, `fablecut_analyze_reference`,
+   `fablecut_encode_profiles`.
 
    FableCut is also published on the **official MCP registry** as
    [`io.github.ronak-create/fablecut`](https://registry.modelcontextprotocol.io/v0/servers?search=fablecut)
@@ -283,7 +286,7 @@ Three equivalent control surfaces:
 2. **The file** — read `project.json`, modify, bump `revision`, write. The UI
    live-reloads.
 3. **REST** — `GET/PUT /api/project`, `POST /api/upload`, `GET /api/library`,
-   SSE at `/api/events`. See CLAUDE.md for the full list.
+   `GET /api/export/profiles`, SSE at `/api/events`. See CLAUDE.md for the full list.
 
 Example: ask Claude Code *"cut these six clips to the beat markers, add a
 teal-orange grade, put a word-pop caption on top and a whoosh on every cut"* —
@@ -315,6 +318,8 @@ mcp-server.js    stdio MCP server exposing the editor to AI agents
 analyze.js       reference-video analyzer: shots, beats/BPM, energy, drop,
                  music extraction (module + CLI)
 CLAUDE.md        the agent manual (schema + recipes) — also served by fablecut_docs
+encoding-profiles.json
+                 Fast-export ffmpeg presets (hot-reloaded)
 project.json     your timeline (created on first run; gitignored)
 media/           project footage (gitignored)
 analysis/        cached edit blueprints from /api/analyze (gitignored)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,8 +46,13 @@ It remains **not** hardened for untrusted networks or multi-tenant use:
 
 - The REST API (`/api/*`) has no authentication — anyone who can reach the port
   can read and overwrite `project.json` and upload files into `media/`.
-- The server reads and writes files under the project directory and shells out to
-  `ffmpeg` for export/remux.
+- The server reads and writes files under the project directory and spawns
+  `ffmpeg` for export/remux. Fast-export profiles in `encoding-profiles.json`
+  (hot-reloaded) are raw ffmpeg argument lists: the browser sends only a
+  profile id, args are passed to `spawn` with no shell, and a dry-run rejects
+  bad args before any frames are rendered. That is expected in the local
+  single-user model — anyone who can edit that file can already run ffmpeg on
+  the machine.
 - Do not expose the port publicly. If you must, put it behind your own
   authentication and network controls.
 

--- a/app.js
+++ b/app.js
@@ -762,6 +762,15 @@ function projectJSON() {
 }
 function listenSSE() {
   const es = new EventSource("/api/events");
+  // Named events: "change" = project/media/library; "profiles" = encoding-profiles.json only
+  es.addEventListener("change", () => syncFromServer());
+  es.addEventListener("profiles", () => {
+    fetchEncodeProfiles().then(() => {
+      if (els.exportSetup && !els.exportSetup.classList.contains("hidden"))
+        populateExportProfileSelect();
+    });
+  });
+  // Legacy default "message" events (old servers that emit bare `data:`)
   es.onmessage = () => syncFromServer();
 }
 /* Pull the server's project if it moved past our revision (an external tool —

--- a/app.js
+++ b/app.js
@@ -5304,25 +5304,27 @@ function loop(ts) {
    – realtime: the original MediaRecorder capture, kept as the fallback for
      local sessions / servers without ffmpeg. */
 
+/* Placeholder until /api/export/profiles answers — the real list (and the real
+   ffmpeg args) always comes from encoding-profiles.json on the server. */
 let encodeProfiles = {
   default: "delivery",
   profiles: {
     draft: {
       label: "Draft · H.264 fast",
       description: "Quick preview — smaller file, faster encode.",
-      summary: "libx264 preset=veryfast crf=23 · aac 128k · JPEG 85%",
+      summary: "-c:v libx264 -preset veryfast -crf 23 -c:a aac -b:a 128k",
       jpegQuality: 0.85,
     },
     delivery: {
       label: "Delivery · H.264 balanced",
       description: "Default export — good quality and compatibility.",
-      summary: "libx264 preset=fast crf=18 · aac 192k · JPEG 95%",
+      summary: "-c:v libx264 -preset fast -crf 18 -c:a aac -b:a 192k",
       jpegQuality: 0.95,
     },
     hq: {
       label: "High quality · H.264 slow",
       description: "Best H.264 quality — slower encode, larger file.",
-      summary: "libx264 preset=slow crf=16 · aac 256k · JPEG 98%",
+      summary: "-c:v libx264 -preset slow -crf 16 -c:a aac -b:a 256k",
       jpegQuality: 0.98,
     },
   },
@@ -5572,6 +5574,9 @@ async function fastExport() {
         fps,
         name: project.name.replace(/[^\w\- ]+/g, "") || "export",
         profile: profileId,
+        // lets the server dry-run the profile with the same input count we
+        // will actually feed it, so -map based profiles are checked correctly
+        hasAudio: !!wav,
       }),
     }).then((r) => r.json());
     if (!begin.id) throw new Error(begin.error || "export begin failed");

--- a/app.js
+++ b/app.js
@@ -205,6 +205,7 @@ function addLiveAudioTrackBuses(ids) {
 const SETTINGS_KEY = "fablecut-settings";
 const DEFAULT_SETTINGS = {
   linkSelect: false, // timeline ↔ project bin selection sync
+  encodeProfile: null, // null = server default from encoding-profiles.json
 };
 let settings = { ...DEFAULT_SETTINGS };
 function loadSettings() {
@@ -246,6 +247,7 @@ const project = {
   outPoint: null, // timeline work-area OUT (seconds), or null
   disabledTracks: [], // track ids (V4…A3) hidden from preview/export when listed
   exportFrame: null, // optional {x,y,w,h} delivery crop inside width×height canvas
+  encodeProfile: null, // optional fast-export profile id (overrides browser setting)
 };
 const state = {
   time: 0, playing: false, pps: 60, snap: true,
@@ -340,6 +342,9 @@ const els = {
   monitorStage: $("monitorStage"), monitorScroll: $("monitorScroll"),
   monitorZoomInner: $("monitorZoomInner"), kfGraphs: $("kfGraphs"),
   exportSetup: $("exportSetup"), engineFast: $("engineFast"), engineRealtime: $("engineRealtime"),
+  exportProfileRow: $("exportProfileRow"),
+  exportProfileSel: $("exportProfileSel"), exportProfileNote: $("exportProfileNote"),
+  exportProfileHint: $("exportProfileHint"),
 };
 const ctx2d = els.preview.getContext("2d");
 
@@ -458,6 +463,7 @@ async function connectServer() {
     listenSSE();
     fetch("/api/export/ffmpeg").then((r) => r.json())
       .then((j) => { state.ffmpeg = !!j.available; }).catch(() => { });
+    fetchEncodeProfiles();
   } catch {
     state.connected = false;
     els.projectName.textContent = project.name + "  ·  ⚪ local session";
@@ -669,6 +675,7 @@ function applyProject(data) {
     outPoint: wa.outPoint,
     disabledTracks,
     exportFrame: normalizeExportFrame(data.exportFrame, data.width || 1280, data.height || 720),
+    encodeProfile: data.encodeProfile || null,
   });
   const folderIds = new Set(project.folders.map((f) => f.id));
   for (const m of project.media) {
@@ -730,7 +737,7 @@ function scheduleSave() {
   }, 400);
 }
 function projectJSON() {
-  const { name, width, height, fps, background, revision, folders, media, clips, markers, inPoint, outPoint, disabledTracks, exportFrame } = project;
+  const { name, width, height, fps, background, revision, folders, media, clips, markers, inPoint, outPoint, disabledTracks, encodeProfile } = project;
   const out = {
     name, width, height, fps, background, revision,
     folders: (folders || []).map(({ id, name, parentId, open }) =>
@@ -738,10 +745,10 @@ function projectJSON() {
     media: media.filter((m) => !m.transient).map(({ id, name, kind, src, duration, width, height, folderId }) =>
       ({ id, name, kind, src, duration, width, height, folderId: folderId || null })),
     clips: clips.map(({ id, mediaId, kind, track, start, in: inn, duration, name, props, keyframes, transitionIn, transitionOut, linkedId, linkGroup }) => {
-      const out = { id, mediaId, kind, track, start, in: inn, duration, name, props, keyframes, transitionIn, transitionOut };
-      if (linkGroup) out.linkGroup = linkGroup;
-      if (linkedId) out.linkedId = linkedId;
-      return out;
+      const clipOut = { id, mediaId, kind, track, start, in: inn, duration, name, props, keyframes, transitionIn, transitionOut };
+      if (linkGroup) clipOut.linkGroup = linkGroup;
+      if (linkedId) clipOut.linkedId = linkedId;
+      return clipOut;
     }),
     markers: (markers || []).map(({ t, label }) => (label ? { t, label } : { t })),
     inPoint: inPoint == null ? null : inPoint,
@@ -750,6 +757,7 @@ function projectJSON() {
   };
   const ef = getExportFrame();
   if (ef) out.exportFrame = ef;
+  if (encodeProfile) out.encodeProfile = encodeProfile;
   return out;
 }
 function listenSSE() {
@@ -765,6 +773,7 @@ async function syncFromServer(force) {
   runtime.pendingSync = false;
   if (state.binTab !== "project") fetchLibrary(state.binTab).then(renderLibrary);
   loadLibraryFonts();
+  fetchEncodeProfiles();
   try {
     const res = await fetch("/api/project", { cache: "no-store" });
     if (!res.ok) return;
@@ -5291,9 +5300,87 @@ function loop(ts) {
 /* Two engines:
    – fast: the browser renders every frame with the normal compositor
      (frame-accurate, works unfocused) and streams JPEGs + an offline audio
-     mix to the server, where ffmpeg encodes a real CRF-18 MP4.
+     mix to the server, where ffmpeg encodes via an encoding profile.
    – realtime: the original MediaRecorder capture, kept as the fallback for
      local sessions / servers without ffmpeg. */
+
+let encodeProfiles = {
+  default: "delivery",
+  profiles: {
+    draft: {
+      label: "Draft · H.264 fast",
+      description: "Quick preview — smaller file, faster encode.",
+      summary: "libx264 preset=veryfast crf=23 · aac 128k · JPEG 85%",
+      jpegQuality: 0.85,
+    },
+    delivery: {
+      label: "Delivery · H.264 balanced",
+      description: "Default export — good quality and compatibility.",
+      summary: "libx264 preset=fast crf=18 · aac 192k · JPEG 95%",
+      jpegQuality: 0.95,
+    },
+    hq: {
+      label: "High quality · H.264 slow",
+      description: "Best H.264 quality — slower encode, larger file.",
+      summary: "libx264 preset=slow crf=16 · aac 256k · JPEG 98%",
+      jpegQuality: 0.98,
+    },
+  },
+};
+
+async function fetchEncodeProfiles() {
+  if (!state.connected) return;
+  try {
+    const r = await fetch("/api/export/profiles", { cache: "no-store" });
+    if (!r.ok) return;
+    const data = await r.json();
+    if (data?.profiles && Object.keys(data.profiles).length) encodeProfiles = data;
+  } catch { }
+}
+function effectiveEncodeProfileId() {
+  return project.encodeProfile || getSetting("encodeProfile") || encodeProfiles.default || "delivery";
+}
+function exportProfileMeta(id) {
+  return encodeProfiles.profiles[id] || { label: id, summary: id, jpegQuality: 0.95 };
+}
+function updateExportProfileNote(id) {
+  const known = Object.hasOwn(encodeProfiles.profiles, id);
+  const p = exportProfileMeta(id);
+  if (els.exportProfileNote) {
+    els.exportProfileNote.textContent = known
+      ? [p.description, p.summary].filter(Boolean).join(" — ")
+      : `"${id}" is not defined in encoding-profiles.json — the export will fail until it is added or another profile is picked.`;
+  }
+  if (els.exportProfileHint) {
+    if (project.encodeProfile) {
+      els.exportProfileHint.textContent =
+        "Project default (encodeProfile in project.json). Pick another profile here for a one-off export.";
+    } else if (getSetting("encodeProfile")) {
+      els.exportProfileHint.textContent = "Browser default — saved when you change this dropdown.";
+    } else {
+      els.exportProfileHint.textContent = "Using server default from encoding-profiles.json.";
+    }
+  }
+}
+function populateExportProfileSelect() {
+  if (!els.exportProfileSel) return;
+  const ids = Object.keys(encodeProfiles.profiles);
+  const cur = effectiveEncodeProfileId();
+  // a project/browser default naming a deleted profile must stay visible rather
+  // than silently falling through to whichever option happens to be first
+  if (cur && !ids.includes(cur)) ids.unshift(cur);
+  els.exportProfileSel.innerHTML = ids.map((id) => {
+    const p = encodeProfiles.profiles[id];
+    const sel = id === cur ? " selected" : "";
+    const label = p ? (p.label || id) : `${id} (not defined on the server)`;
+    return `<option value="${escapeHtml(id)}"${sel}>${escapeHtml(label)}</option>`;
+  }).join("");
+  updateExportProfileNote(els.exportProfileSel.value || cur || "delivery");
+}
+function syncExportProfileVisibility() {
+  const show = els.engineFast.checked && !els.engineFast.disabled;
+  els.exportProfileRow?.classList.toggle("hidden", !show);
+}
 
 function openExportSetup() {
   if (state.exporting) return;
@@ -5340,7 +5427,11 @@ function openExportSetup() {
     warn.textContent = "";
     warn.classList.add("hidden");
   }
-  els.exportSetup.classList.remove("hidden");
+  syncExportProfileVisibility();
+  fetchEncodeProfiles().then(() => {
+    populateExportProfileSelect();
+    els.exportSetup.classList.remove("hidden");
+  });
 }
 function startChosenExport() {
   const useFast = els.engineFast.checked && !els.engineFast.disabled;
@@ -5473,8 +5564,15 @@ async function fastExport() {
     els.exportTitle.textContent = "Mixing audio…";
     const wav = await renderAudioMix(dur);
     if (renderCancelled) throw new Error("cancelled");
+    const profileId = els.exportProfileSel?.value || effectiveEncodeProfileId();
+    const jpegQ = exportProfileMeta(profileId).jpegQuality ?? 0.95;
     const begin = await fetch("/api/export/begin", {
-      method: "POST", body: JSON.stringify({ fps, name: project.name.replace(/[^\w\- ]+/g, "") || "export" }),
+      method: "POST",
+      body: JSON.stringify({
+        fps,
+        name: project.name.replace(/[^\w\- ]+/g, "") || "export",
+        profile: profileId,
+      }),
     }).then((r) => r.json());
     if (!begin.id) throw new Error(begin.error || "export begin failed");
     sessId = begin.id;
@@ -5490,7 +5588,7 @@ async function fastExport() {
       await seekVideosTo(t);
       await prepareFrameAssets(t);       // exact SVG frames + AI masks
       drawFrame(t);
-      const blob = await previewToExportBlob(0.95);
+      const blob = await previewToExportBlob(jpegQ);
       const r = await fetch("/api/export/frame?id=" + sessId, { method: "POST", body: blob });
       if (!r.ok) throw new Error((await r.json()).error || "frame upload failed");
       const pct = ((f + 1) / frames) * 100;
@@ -5589,6 +5687,16 @@ $("btnDelete").addEventListener("click", () => {
 });
 $("btnExport").addEventListener("click", openExportSetup);
 $("btnStartExport").addEventListener("click", startChosenExport);
+els.exportSetup?.addEventListener("change", (e) => {
+  if (e.target.name === "engine") syncExportProfileVisibility();
+});
+els.exportProfileSel?.addEventListener("change", (e) => {
+  const id = e.target.value;
+  if (!project.encodeProfile) {
+    setSetting("encodeProfile", id === encodeProfiles.default ? null : id);
+  }
+  updateExportProfileNote(id);
+});
 $("btnCancelSetup").addEventListener("click", () => els.exportSetup.classList.add("hidden"));
 $("btnCancelExport").addEventListener("click", () => {
   if (state.rendering) renderCancelled = true;

--- a/encode-profiles.js
+++ b/encode-profiles.js
@@ -140,7 +140,8 @@ function validateMux(m, fallback, warn) {
   if (out.format) {
     const fmt = MUX_FORMAT_ALIAS[String(out.format).toLowerCase()];
     if (fmt) out.format = fmt;
-    else { delete out.format; warn(`mux.format "${given.format}" unknown — using mp4`); }
+    // what replaces it is resolved below (from the extension, else mp4)
+    else { delete out.format; warn(`mux.format "${given.format}" unknown — ignored (allowed: mp4, mov, matroska)`); }
   }
   if (out.extension) {
     const raw = String(out.extension).toLowerCase();
@@ -150,8 +151,15 @@ function validateMux(m, fallback, warn) {
   }
   // a bare extension implies the container; keeps -f and the filename in step
   if (!out.format && out.extension) out.format = EXT_FORMAT[out.extension];
-  if (out.format && out.extension && EXT_FORMAT[out.extension] !== out.format)
-    warn(`mux.extension ${out.extension} does not match mux.format ${out.format}`);
+  /* A mismatch is reconciled, not just flagged, so exportContainer() and
+     exportOutputExtension() can never disagree. `format` selects the muxer and
+     therefore the bytes written, so it wins and the file is renamed to match —
+     the alternative would quietly write a different container than requested. */
+  if (out.format && out.extension && EXT_FORMAT[out.extension] !== out.format) {
+    const corrected = FORMAT_EXT[out.format];
+    warn(`mux.extension ${out.extension} does not match mux.format ${out.format} — using ${corrected}`);
+    out.extension = corrected;
+  }
   return out;
 }
 
@@ -173,7 +181,7 @@ function normalizeProfile(id, raw, fallback) {
   const warn = (msg) => warnings.push(msg);
   const mux = validateMux(p.mux, base.mux, warn);
   const audio = validateAudio(p.audio, base.audio, warn);
-  const container = mux.format || "mp4";
+  const container = exportContainer({ mux });
   /* Opus has no MOV mapping at all, and MP4 needs the experimental flag —
      without this the mux pass dies only after every frame has been rendered. */
   if (audio.codec === "libopus") {

--- a/encode-profiles.js
+++ b/encode-profiles.js
@@ -1,209 +1,59 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   Encoding profiles — user-editable ffmpeg settings for Fast export.
+
+   A profile is a raw ffmpeg argument list plus the two things that are NOT
+   ffmpeg arguments: the browser's JPEG frame quality and the output extension.
+   There is deliberately no allow-list — encoding-profiles.json is a local file
+   the user owns, the browser only ever sends a profile *id*, and args are
+   passed to spawn() as an array (no shell), so validating codec names would buy
+   nothing but a smaller set of usable formats. Typos are caught by dryRunProfile
+   against the real ffmpeg build instead, which also knows which encoders it has.
+
+   Export is ONE ffmpeg pass; this module owns the input side and the output
+   path, the profile owns everything in between:
+
+     ffmpeg -y -f image2pipe -framerate <fps> -i - [-i audio.wav]
+            <profile args…> <out><extension>
+   ═══════════════════════════════════════════════════════════════════════════ */
 "use strict";
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
+const { spawnSync } = require("child_process");
 
 const PROFILES_FILE = path.join(__dirname, "encoding-profiles.json");
 
-const VIDEO_CODECS = new Set(["libx264", "libx265"]);
-const VIDEO_PRESETS = new Set([
-  "ultrafast", "superfast", "veryfast", "faster", "fast",
-  "medium", "slow", "slower", "veryslow",
-]);
-const PIX_FMTS = new Set(["yuv420p", "yuv422p", "yuv444p"]);
-const AUDIO_CODECS = new Set(["aac", "libopus"]);
-const X264_TUNES = new Set(["film", "animation", "grain", "stillimage", "fastdecode", "zerolatency"]);
-const X264_PROFILES = new Set(["baseline", "main", "high", "high10", "high422", "high444"]);
-const BITRATE_RE = /^\d+([kKmM])?$/;
-const ID_RE = /^[a-zA-Z][a-zA-Z0-9_-]{0,31}$/;
-const LOGLEVELS = new Set(["quiet", "panic", "fatal", "error", "warning", "info", "verbose", "debug", "trace"]);
-/* "mkv" is an extension, not an ffmpeg muxer name — normalized to "matroska" */
-const MUX_FORMAT_ALIAS = { mp4: "mp4", mov: "mov", matroska: "matroska", mkv: "matroska" };
-const FORMAT_EXT = { mp4: ".mp4", mov: ".mov", matroska: ".mkv" };
-const EXT_FORMAT = { ".mp4": "mp4", ".m4v": "mp4", ".mov": "mov", ".mkv": "matroska" };
-const OUT_EXT = new Set([".mp4", ".mov", ".mkv", ".m4v"]);
-const SAFE_FFMPEG_STR = /^[\w=.,:/+\-[\]()%| ]{0,512}$/;
-/* ffmpeg levels that suppress error text; the frame-pipe pass keeps stderr for
-   diagnostics only (never shown unless the encode fails), so it is clamped up */
-const QUIET_LEVELS = new Set(["quiet", "panic", "fatal"]);
-
+/* Used when encoding-profiles.json is missing or unparseable, so export still
+   works out of the box. Not a merge base: profiles are taken as written. */
+const BUILTIN_ID = "delivery";
 const BUILTIN = {
-  default: "delivery",
-  profiles: {
-    draft: {
-      label: "Draft · H.264 fast",
-      description: "Quick preview — smaller file, faster encode.",
-      jpegQuality: 0.85,
-      video: { codec: "libx264", preset: "veryfast", crf: 23, pixFmt: "yuv420p" },
-      audio: { codec: "aac", bitrate: "128k" },
-      mux: { movflags: "+faststart" },
-    },
-    delivery: {
-      label: "Delivery · H.264 balanced",
-      description: "Default export — good quality and compatibility.",
-      jpegQuality: 0.95,
-      video: { codec: "libx264", preset: "fast", crf: 18, pixFmt: "yuv420p" },
-      audio: { codec: "aac", bitrate: "192k" },
-      mux: { movflags: "+faststart" },
-    },
-    hq: {
-      label: "High quality · H.264 slow",
-      description: "Best H.264 quality — slower encode, larger file.",
-      jpegQuality: 0.98,
-      video: { codec: "libx264", preset: "slow", crf: 16, pixFmt: "yuv420p" },
-      audio: { codec: "aac", bitrate: "256k" },
-      mux: { movflags: "+faststart" },
-    },
-  },
+  label: "Delivery · H.264 balanced",
+  description: "Built-in fallback — good quality and compatibility.",
+  jpegQuality: 0.95,
+  extension: ".mp4",
+  args: ["-c:v", "libx264", "-preset", "fast", "-crf", "18", "-pix_fmt", "yuv420p",
+    "-c:a", "aac", "-b:a", "192k", "-movflags", "+faststart", "-shortest"],
 };
 
 let cache = null;
 let cacheMtime = -1;
 
-function clampNum(v, fallback, min, max) {
-  const n = Number(v);
-  if (!isFinite(n)) return fallback;
-  return Math.min(max, Math.max(min, n));
-}
-
-/* like clampNum, but reports a silent clamp — an out-of-range value that gets
-   quietly corrected is how you end up exporting 8 kHz audio and not knowing */
-function clampReported(v, fallback, min, max, label, warn) {
-  const n = Number(v);
-  if (!isFinite(n)) return fallback;
-  const c = Math.min(max, Math.max(min, n));
-  if (c !== n) warn(`${label} ${n} out of range — clamped to ${c}`);
-  return c;
-}
-
-function validateVideo(v, fallback, warn) {
-  const out = { ...fallback, ...(v || {}) };
-  const drop = (key, why) => { delete out[key]; warn(`video.${key} ignored — ${why}`); };
-  if (!VIDEO_CODECS.has(out.codec)) {
-    warn(`video.codec "${out.codec}" not allowed — using ${fallback.codec}`);
-    out.codec = fallback.codec;
-  }
-  if (!VIDEO_PRESETS.has(out.preset)) {
-    warn(`video.preset "${out.preset}" not allowed — using ${fallback.preset}`);
-    out.preset = fallback.preset;
-  }
-  out.crf = Math.round(clampReported(out.crf, fallback.crf, 0, 51, "video.crf", warn));
-  if (!PIX_FMTS.has(out.pixFmt)) {
-    warn(`video.pixFmt "${out.pixFmt}" not allowed — using ${fallback.pixFmt}`);
-    out.pixFmt = fallback.pixFmt;
-  }
-  if (out.tune && !X264_TUNES.has(out.tune)) drop("tune", "unknown tune");
-  if (out.profile && !X264_PROFILES.has(out.profile)) drop("profile", "unknown H.264 profile");
-  if (out.g != null) {
-    const g = Math.round(clampNum(out.g, 0, 1, 600));
-    if (g > 0) out.g = g; else drop("g", "must be 1–600");
-  }
-  if (out.maxrate && !BITRATE_RE.test(String(out.maxrate))) drop("maxrate", 'expected e.g. "60M"');
-  if (out.bufsize && !BITRATE_RE.test(String(out.bufsize))) drop("bufsize", 'expected e.g. "70M"');
-  for (const key of ["x264opts", "vf"]) {
-    if (!out[key]) { delete out[key]; continue; }
-    const s = String(out[key]).trim();
-    if (s && SAFE_FFMPEG_STR.test(s)) out[key] = s;
-    else drop(key, "contains characters outside the allowed ffmpeg option set");
-  }
-  if (out.x264opts && out.codec !== "libx264")
-    drop("x264opts", `only applies to libx264, not ${out.codec} (which takes -x265-params)`);
-  return out;
-}
-
-function validateAudio(a, fallback, warn) {
-  const out = { ...fallback, ...(a || {}) };
-  if (!AUDIO_CODECS.has(out.codec)) {
-    warn(`audio.codec "${out.codec}" not allowed — using ${fallback.codec}`);
-    out.codec = fallback.codec;
-  }
-  if (!BITRATE_RE.test(String(out.bitrate || ""))) {
-    warn(`audio.bitrate "${out.bitrate}" invalid — using ${fallback.bitrate}`);
-    out.bitrate = fallback.bitrate;
-  }
-  if (out.sampleRate != null) {
-    const sr = Math.round(clampReported(out.sampleRate, 0, 8000, 192000, "audio.sampleRate", warn));
-    if (sr > 0) out.sampleRate = sr;
-    else { delete out.sampleRate; warn("audio.sampleRate ignored — must be 8000–192000"); }
-  }
-  if (out.strict != null) {
-    const st = String(out.strict);
-    if (["-2", "-1", "0", "1", "experimental"].includes(st)) out.strict = st;
-    else { delete out.strict; warn(`audio.strict "${st}" ignored`); }
-  }
-  return out;
-}
-
-function validateMux(m, fallback, warn) {
-  const given = m && typeof m === "object" ? m : {};
-  const out = { ...fallback, ...given };
-  // an explicit null/"" clears an inherited value (e.g. drop +faststart)
-  if ("movflags" in given && (given.movflags === null || given.movflags === "")) delete out.movflags;
-  else if (out.movflags != null && typeof out.movflags !== "string") out.movflags = fallback.movflags;
-  if (out.format) {
-    const fmt = MUX_FORMAT_ALIAS[String(out.format).toLowerCase()];
-    if (fmt) out.format = fmt;
-    // what replaces it is resolved below (from the extension, else mp4)
-    else { delete out.format; warn(`mux.format "${given.format}" unknown — ignored (allowed: mp4, mov, matroska)`); }
-  }
-  if (out.extension) {
-    const raw = String(out.extension).toLowerCase();
-    const ext = raw.startsWith(".") ? raw : `.${raw}`;
-    if (OUT_EXT.has(ext)) out.extension = ext;
-    else { delete out.extension; warn(`mux.extension "${given.extension}" unsupported`); }
-  }
-  // a bare extension implies the container; keeps -f and the filename in step
-  if (!out.format && out.extension) out.format = EXT_FORMAT[out.extension];
-  /* A mismatch is reconciled, not just flagged, so exportContainer() and
-     exportOutputExtension() can never disagree. `format` selects the muxer and
-     therefore the bytes written, so it wins and the file is renamed to match —
-     the alternative would quietly write a different container than requested. */
-  if (out.format && out.extension && EXT_FORMAT[out.extension] !== out.format) {
-    const corrected = FORMAT_EXT[out.format];
-    warn(`mux.extension ${out.extension} does not match mux.format ${out.format} — using ${corrected}`);
-    out.extension = corrected;
-  }
-  return out;
-}
-
-function validateEncode(e, fallback, warn) {
-  const out = { ...fallback, ...(e || {}) };
-  if (out.loglevel && !LOGLEVELS.has(String(out.loglevel))) {
-    warn(`encode.loglevel "${out.loglevel}" unknown — ignored`);
-    delete out.loglevel;
-  }
-  if (out.hideBanner != null) out.hideBanner = !!out.hideBanner;
-  if (out.stats != null) out.stats = !!out.stats;
-  return out;
-}
-
-function normalizeProfile(id, raw, fallback) {
-  const base = fallback || BUILTIN.profiles.delivery;
+function normalizeProfile(id, raw) {
   const p = raw && typeof raw === "object" ? raw : {};
-  const warnings = [];
-  const warn = (msg) => warnings.push(msg);
-  const mux = validateMux(p.mux, base.mux, warn);
-  const audio = validateAudio(p.audio, base.audio, warn);
-  const container = exportContainer({ mux });
-  /* Opus has no MOV mapping at all, and MP4 needs the experimental flag —
-     without this the mux pass dies only after every frame has been rendered. */
-  if (audio.codec === "libopus") {
-    if (container === "mov") {
-      warn("audio.codec libopus cannot be stored in MOV — using aac");
-      audio.codec = "aac";
-    } else if (container === "mp4" && audio.strict == null) {
-      audio.strict = "-2";
-    }
-  }
+  // a string is split on whitespace as a convenience; the array form is
+  // canonical because it needs no quoting (e.g. -vf drawtext=text='hi')
+  const args = Array.isArray(p.args)
+    ? p.args.map(String)
+    : String(p.args || "").split(/\s+/).filter(Boolean);
+  const ext = String(p.extension || BUILTIN.extension).trim().toLowerCase();
+  const q = Number(p.jpegQuality);
   return {
     id,
-    label: String(p.label || base.label || id),
-    description: String(p.description || p.desc || base.description || ""),
-    jpegQuality: clampReported(p.jpegQuality, base.jpegQuality, 0.5, 1, "jpegQuality", warn),
-    video: validateVideo(p.video, base.video, warn),
-    audio,
-    mux,
-    encode: validateEncode(p.encode, base.encode || {}, warn),
-    warnings,
+    label: String(p.label || id),
+    description: String(p.description || p.desc || ""),
+    jpegQuality: q >= 0.1 && q <= 1 ? q : BUILTIN.jpegQuality,
+    extension: ext.startsWith(".") ? ext : `.${ext}`,
+    args,
   };
 }
 
@@ -218,34 +68,27 @@ function loadEncodeProfiles(force) {
   if (cache && !force && mtime === cacheMtime) return cache;
 
   let file = null;
-  let fileError = null;
+  const issues = [];
   try {
-    if (fs.existsSync(PROFILES_FILE)) {
+    if (fs.existsSync(PROFILES_FILE))
       file = JSON.parse(fs.readFileSync(PROFILES_FILE, "utf8").replace(/^\uFEFF/, ""));
-    }
-  } catch (e) { fileError = `encoding-profiles.json could not be parsed (${e.message}) — using built-in profiles`; }
+    else issues.push(`${path.basename(PROFILES_FILE)} not found — using the built-in profile`);
+  } catch (e) {
+    issues.push(`${path.basename(PROFILES_FILE)} could not be parsed (${e.message}) — using the built-in profile`);
+  }
 
   const profiles = {};
-  for (const [id, raw] of Object.entries(BUILTIN.profiles)) {
-    profiles[id] = normalizeProfile(id, raw, raw);
-  }
-  const issues = fileError ? [fileError] : [];
-  if (file?.profiles && typeof file.profiles === "object") {
-    for (const [id, raw] of Object.entries(file.profiles)) {
-      if (!ID_RE.test(id)) {
-        issues.push(`profile id "${id}" skipped — must start with a letter and use [A-Za-z0-9_-] only`);
-        continue;
-      }
-      profiles[id] = normalizeProfile(id, raw, profiles[id] || BUILTIN.profiles.delivery);
-    }
-  }
-  for (const p of Object.values(profiles))
-    for (const w of p.warnings) issues.push(`${p.id}: ${w}`);
+  if (file?.profiles && typeof file.profiles === "object")
+    for (const [id, raw] of Object.entries(file.profiles)) profiles[id] = normalizeProfile(id, raw);
+  for (const [id, p] of Object.entries(profiles))
+    if (!p.args.length) issues.push(`profile "${id}" has no args — ffmpeg will pick its own defaults`);
+  if (!Object.keys(profiles).length) profiles[BUILTIN_ID] = normalizeProfile(BUILTIN_ID, BUILTIN);
 
-  let defaultId = typeof file?.default === "string" ? file.default : BUILTIN.default;
+  let defaultId = typeof file?.default === "string" ? file.default : BUILTIN_ID;
   if (!profiles[defaultId]) {
-    if (file?.default) issues.push(`default "${file.default}" is not a defined profile — using delivery`);
-    defaultId = "delivery";
+    const first = Object.keys(profiles)[0];
+    if (file?.default) issues.push(`default "${file.default}" is not a defined profile — using ${first}`);
+    defaultId = first;
   }
 
   cache = { default: defaultId, profiles, issues };
@@ -266,40 +109,9 @@ function resolveProfile(id) {
   return p;
 }
 
-function profileSummary(p) {
-  const v = p.video;
-  const a = p.audio;
-  const bits = [`${v.codec} preset=${v.preset} crf=${v.crf}`];
-  if (v.g) bits.push(`g=${v.g}`);
-  if (v.vf) bits.push("vf");
-  if (v.x264opts) bits.push("x264opts");
-  bits.push(`${a.codec} ${a.bitrate}`);
-  if (a.sampleRate) bits.push(`${a.sampleRate / 1000}kHz`);
-  if (p.mux?.format) bits.push(p.mux.format);
-  bits.push(`JPEG ${Math.round(p.jpegQuality * 100)}%`);
-  return bits.join(" · ");
-}
-
-function ffmpegGlobalArgs(profile) {
-  const enc = profile.encode || {};
-  const args = [];
-  if (enc.hideBanner) args.push("-hide_banner");
-  if (enc.stats) args.push("-stats");
-  if (enc.loglevel) {
-    /* stderr is captured for failure reporting and never shown otherwise, so a
-       silencing loglevel would only cost us the reason an export died */
-    args.push("-loglevel", QUIET_LEVELS.has(enc.loglevel) ? "error" : enc.loglevel);
-  }
-  return args;
-}
-
-function exportContainer(profile) {
-  return profile.mux?.format || EXT_FORMAT[profile.mux?.extension] || "mp4";
-}
-
-function exportOutputExtension(profile) {
-  if (profile.mux?.extension) return profile.mux.extension;
-  return FORMAT_EXT[exportContainer(profile)] || ".mp4";
+function profileSummary(p, max = 120) {
+  const s = (p.args || []).join(" ") || "(no args — ffmpeg defaults)";
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
 }
 
 function listProfilesPublic(detail) {
@@ -315,66 +127,61 @@ function listProfilesPublic(detail) {
       label: p.label,
       description: p.description,
       jpegQuality: p.jpegQuality,
-      extension: exportOutputExtension(p),
+      extension: p.extension,
       summary: profileSummary(p),
     };
-    out.profiles[id] = detail
-      ? { ...base, video: p.video, audio: p.audio, mux: p.mux, encode: p.encode, warnings: p.warnings }
-      : base;
+    out.profiles[id] = detail ? { ...base, args: p.args } : base;
   }
   return out;
 }
 
-function buildVideoEncodeArgs(profile, fps, outputPath) {
-  const v = profile.video;
-  const args = [...ffmpegGlobalArgs(profile),
-    "-y", "-f", "image2pipe", "-framerate", String(fps), "-i", "-",
-    "-c:v", v.codec,
-  ];
-  if (v.codec === "libx264" || v.codec === "libx265") {
-    args.push("-preset", v.preset, "-crf", String(v.crf));
-    if (v.g) args.push("-g", String(v.g));
-    if (v.maxrate) args.push("-maxrate", v.maxrate);
-    if (v.bufsize) args.push("-bufsize", v.bufsize);
-    // libx264-only private option (libx265 takes -x265-params instead)
-    if (v.x264opts && v.codec === "libx264") args.push("-x264opts", v.x264opts);
-    if (v.tune) args.push("-tune", v.tune);
-    if (v.profile) args.push("-profile:v", v.profile);
-  }
-  /* JPEG frames from the browser are full-range BT.601 (JFIF). Convert them to
-     limited-range BT.709 and tag the stream, otherwise x264 emits bt470bg/pc/
-     unknown and players do the wrong YUV→RGB conversion — darker than preview.
-     Profile `vf` (if any) is appended so color conversion always runs first. */
-  const colorVf = "scale=in_range=full:in_color_matrix=bt601:out_range=tv:out_color_matrix=bt709";
-  args.push("-vf", v.vf ? `${colorVf},${v.vf}` : colorVf);
-  args.push("-pix_fmt", v.pixFmt,
-    "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709", "-color_range", "tv",
-    outputPath);
+/* JPEG frames from the browser are full-range BT.601 (JFIF). Convert them to
+   limited-range BT.709 and tag the stream, otherwise x264 emits bt470bg/pc/
+   unknown and players do the wrong YUV→RGB conversion — darker than preview.
+   This is an input-side concern (the JPEG pipe), so it is prepended to the
+   profile's own -vf rather than left for every profile to remember. */
+const JPEG_COLOR_VF = "scale=in_range=full:in_color_matrix=bt601:out_range=tv:out_color_matrix=bt709";
+const JPEG_COLOR_TAGS = ["-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709", "-color_range", "tv"];
+
+function withJpegColor(profileArgs) {
+  const args = profileArgs.slice();
+  const vfAt = args.indexOf("-vf");
+  if (vfAt >= 0 && args[vfAt + 1] != null) args[vfAt + 1] = `${JPEG_COLOR_VF},${args[vfAt + 1]}`;
+  else args.unshift("-vf", JPEG_COLOR_VF);
+  if (!args.includes("-colorspace")) args.push(...JPEG_COLOR_TAGS);
   return args;
 }
 
-function buildMuxArgs(profile, videoPath, wavPath, outPath) {
-  const a = profile.audio;
-  const container = exportContainer(profile);
-  const args = [...ffmpegGlobalArgs(profile), "-y", "-i", videoPath];
+/* The single export pass. Frames arrive on stdin as a JPEG stream; the audio
+   mix (when the timeline has any) is already on disk by the time we spawn. */
+function buildExportArgs(profile, { fps, wavPath, outPath }) {
+  // -hide_banner so a failure's stderr tail is the actual error, not the build config
+  const args = ["-y", "-hide_banner", "-f", "image2pipe", "-framerate", String(fps), "-i", "-"];
   if (wavPath) args.push("-i", wavPath);
-  args.push("-c:v", "copy");
-  if (wavPath) {
-    args.push("-c:a", a.codec);
-    args.push("-b:a", a.bitrate);
-    if (a.sampleRate) args.push("-ar", String(a.sampleRate));
-    if (a.strict != null) args.push("-strict", String(a.strict));
-    args.push("-shortest");
-  }
-  // Re-assert the bt709 tags on the mux — a stream-copy pass can drop the
-  // container-level colr atom even though the SPS still carries them.
-  args.push("-colorspace", "bt709", "-color_primaries", "bt709",
-    "-color_trc", "bt709", "-color_range", "tv");
-  // -movflags is an MP4/MOV muxer option; Matroska warns and ignores it
-  if (profile.mux?.movflags && container !== "matroska")
-    args.push("-movflags", profile.mux.movflags);
-  args.push("-f", container, outPath);
+  args.push(...withJpegColor(profile.args), outPath);
   return args;
+}
+
+/* Run the profile's args once against a synthetic input before the browser
+   renders anything. Without this a typo (or an encoder this ffmpeg build lacks)
+   would only surface when ffmpeg exits — i.e. after every frame was rendered. */
+function dryRunProfile(profile, { fps = 30, hasAudio = true } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-dry-"));
+  const out = path.join(dir, `probe${profile.extension}`);
+  const args = ["-y", "-hide_banner", "-f", "lavfi",
+    "-i", `color=c=black:s=64x64:r=${fps}:d=0.1`];
+  if (hasAudio) args.push("-f", "lavfi", "-i", "anullsrc=r=48000:cl=stereo");
+  args.push("-t", "0.1", ...withJpegColor(profile.args), out);
+  try {
+    const r = spawnSync("ffmpeg", args, { encoding: "utf8" });
+    if (r.error) return { ok: false, error: r.error.message };
+    if (r.status === 0) return { ok: true };
+    // ffmpeg puts the actual complaint in the last lines of stderr
+    const lines = String(r.stderr || "").trim().split("\n").filter(Boolean);
+    return { ok: false, error: lines.slice(-3).join(" · ") || `ffmpeg exited ${r.status}` };
+  } finally {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { }
+  }
 }
 
 module.exports = {
@@ -384,8 +191,6 @@ module.exports = {
   resolveProfile,
   listProfilesPublic,
   profileSummary,
-  buildVideoEncodeArgs,
-  buildMuxArgs,
-  exportContainer,
-  exportOutputExtension,
+  buildExportArgs,
+  dryRunProfile,
 };

--- a/encode-profiles.js
+++ b/encode-profiles.js
@@ -1,19 +1,20 @@
 /* ═══════════════════════════════════════════════════════════════════════════
    Encoding profiles — user-editable ffmpeg settings for Fast export.
 
-   A profile is a raw ffmpeg argument list plus the two things that are NOT
-   ffmpeg arguments: the browser's JPEG frame quality and the output extension.
+   A profile is a raw ffmpeg argument list plus the things that are NOT ffmpeg
+   arguments: jpegQuality, extension, and optional `color` (output matrix/range).
    There is deliberately no allow-list — encoding-profiles.json is a local file
    the user owns, the browser only ever sends a profile *id*, and args are
    passed to spawn() as an array (no shell), so validating codec names would buy
    nothing but a smaller set of usable formats. Typos are caught by dryRunProfile
    against the real ffmpeg build instead, which also knows which encoders it has.
 
-   Export is ONE ffmpeg pass; this module owns the input side and the output
-   path, the profile owns everything in between:
+   Export is ONE ffmpeg pass; this module owns the input side (JPEG color
+   conversion + tags from profile.color) and the output path; the profile owns
+   everything in between:
 
      ffmpeg -y -f image2pipe -framerate <fps> -i - [-i audio.wav]
-            <profile args…> <out><extension>
+            <jpeg-color vf+tags> <profile args…> <out><extension>
    ═══════════════════════════════════════════════════════════════════════════ */
 "use strict";
 const fs = require("fs");
@@ -26,17 +27,58 @@ const PROFILES_FILE = path.join(__dirname, "encoding-profiles.json");
 /* Used when encoding-profiles.json is missing or unparseable, so export still
    works out of the box. Not a merge base: profiles are taken as written. */
 const BUILTIN_ID = "delivery";
+const DEFAULT_COLOR = {
+  matrix: "bt709",
+  primaries: "bt709",
+  trc: "bt709",
+  range: "tv", // tv = limited, pc = full
+};
 const BUILTIN = {
   label: "Delivery · H.264 balanced",
   description: "Built-in fallback — good quality and compatibility.",
   jpegQuality: 0.95,
   extension: ".mp4",
+  color: { ...DEFAULT_COLOR },
   args: ["-c:v", "libx264", "-preset", "fast", "-crf", "18", "-pix_fmt", "yuv420p",
     "-c:a", "aac", "-b:a", "192k", "-movflags", "+faststart", "-shortest"],
 };
 
+/* Flags the engine injects from profile.color — strip from user args so the
+   JPEG vf out_* and the stream tags cannot disagree. */
+const COLOR_ARG_FLAGS = new Set([
+  "-colorspace", "-color_primaries", "-color_trc", "-color_range",
+]);
+
 let cache = null;
 let cacheMtime = -1;
+
+function normalizeColor(raw) {
+  const c = raw && typeof raw === "object" ? raw : {};
+  const token = (v, fallback) => {
+    const s = String(v == null ? "" : v).trim().toLowerCase();
+    return /^[a-z0-9._-]+$/.test(s) ? s : fallback;
+  };
+  let range = token(c.range, DEFAULT_COLOR.range);
+  if (range === "full") range = "pc";
+  if (range === "limited") range = "tv";
+  if (range !== "tv" && range !== "pc") range = DEFAULT_COLOR.range;
+  const matrix = token(c.matrix ?? c.colorspace, DEFAULT_COLOR.matrix);
+  return {
+    matrix,
+    primaries: token(c.primaries, matrix),
+    trc: token(c.trc ?? c.transfer, matrix),
+    range,
+  };
+}
+
+function stripColorArgs(args) {
+  const out = [];
+  for (let i = 0; i < args.length; i++) {
+    if (COLOR_ARG_FLAGS.has(args[i])) { i++; continue; } // skip flag + value
+    out.push(args[i]);
+  }
+  return out;
+}
 
 function normalizeProfile(id, raw) {
   const p = raw && typeof raw === "object" ? raw : {};
@@ -53,6 +95,7 @@ function normalizeProfile(id, raw) {
     description: String(p.description || p.desc || ""),
     jpegQuality: q >= 0.1 && q <= 1 ? q : BUILTIN.jpegQuality,
     extension: ext.startsWith(".") ? ext : `.${ext}`,
+    color: normalizeColor(p.color),
     args,
   };
 }
@@ -122,12 +165,13 @@ function listProfilesPublic(detail) {
     issues: cfg.issues || [],
   };
   for (const [id, p] of Object.entries(cfg.profiles)) {
-    // jpegQuality is needed by the browser to encode frames — always included
+    // jpegQuality + color are needed by the UI / agents — always included
     const base = {
       label: p.label,
       description: p.description,
       jpegQuality: p.jpegQuality,
       extension: p.extension,
+      color: p.color,
       summary: profileSummary(p),
     };
     out.profiles[id] = detail ? { ...base, args: p.args } : base;
@@ -136,19 +180,31 @@ function listProfilesPublic(detail) {
 }
 
 /* JPEG frames from the browser are full-range BT.601 (JFIF). Convert them to
-   limited-range BT.709 and tag the stream, otherwise x264 emits bt470bg/pc/
-   unknown and players do the wrong YUV→RGB conversion — darker than preview.
-   This is an input-side concern (the JPEG pipe), so it is prepended to the
-   profile's own -vf rather than left for every profile to remember. */
-const JPEG_COLOR_VF = "scale=in_range=full:in_color_matrix=bt601:out_range=tv:out_color_matrix=bt709";
-const JPEG_COLOR_TAGS = ["-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709", "-color_range", "tv"];
+   the profile's output matrix/range and tag the stream, otherwise x264 emits
+   bt470bg/pc/unknown and players do the wrong YUV→RGB conversion — darker than
+   preview. Independent of -pix_fmt (420 vs 422/10-bit). */
+function jpegColorVf(color) {
+  const c = color || DEFAULT_COLOR;
+  return `scale=in_range=full:in_color_matrix=bt601:out_range=${c.range}:out_color_matrix=${c.matrix}`;
+}
+function jpegColorTags(color) {
+  const c = color || DEFAULT_COLOR;
+  return [
+    "-colorspace", c.matrix,
+    "-color_primaries", c.primaries,
+    "-color_trc", c.trc,
+    "-color_range", c.range,
+  ];
+}
 
-function withJpegColor(profileArgs) {
-  const args = profileArgs.slice();
+function withJpegColor(profile) {
+  const color = profile.color || DEFAULT_COLOR;
+  const vf = jpegColorVf(color);
+  const args = stripColorArgs((profile.args || []).slice());
   const vfAt = args.indexOf("-vf");
-  if (vfAt >= 0 && args[vfAt + 1] != null) args[vfAt + 1] = `${JPEG_COLOR_VF},${args[vfAt + 1]}`;
-  else args.unshift("-vf", JPEG_COLOR_VF);
-  if (!args.includes("-colorspace")) args.push(...JPEG_COLOR_TAGS);
+  if (vfAt >= 0 && args[vfAt + 1] != null) args[vfAt + 1] = `${vf},${args[vfAt + 1]}`;
+  else args.unshift("-vf", vf);
+  args.push(...jpegColorTags(color));
   return args;
 }
 
@@ -158,7 +214,7 @@ function buildExportArgs(profile, { fps, wavPath, outPath }) {
   // -hide_banner so a failure's stderr tail is the actual error, not the build config
   const args = ["-y", "-hide_banner", "-f", "image2pipe", "-framerate", String(fps), "-i", "-"];
   if (wavPath) args.push("-i", wavPath);
-  args.push(...withJpegColor(profile.args), outPath);
+  args.push(...withJpegColor(profile), outPath);
   return args;
 }
 
@@ -172,7 +228,7 @@ function dryRunProfile(profile, { fps = 30, hasAudio = true } = {}) {
   const args = ["-y", "-hide_banner", "-f", "lavfi",
     "-i", `color=c=black:s=64x64:r=${fps}:d=0.1`];
   if (hasAudio) args.push("-f", "lavfi", "-i", "anullsrc=r=48000:cl=stereo");
-  args.push("-t", "0.1", ...withJpegColor(profile.args), out);
+  args.push("-t", "0.1", ...withJpegColor(profile), out);
   return new Promise((resolve) => {
     let stderr = "";
     let settled = false;
@@ -201,6 +257,7 @@ function dryRunProfile(profile, { fps = 30, hasAudio = true } = {}) {
 
 module.exports = {
   PROFILES_FILE,
+  DEFAULT_COLOR,
   loadEncodeProfiles,
   invalidateEncodeProfiles,
   resolveProfile,

--- a/encode-profiles.js
+++ b/encode-profiles.js
@@ -87,14 +87,17 @@ function normalizeProfile(id, raw) {
   const args = Array.isArray(p.args)
     ? p.args.map(String)
     : String(p.args || "").split(/\s+/).filter(Boolean);
-  const ext = String(p.extension || BUILTIN.extension).trim().toLowerCase();
+  let ext = String(p.extension || BUILTIN.extension).trim().toLowerCase();
+  if (ext && !ext.startsWith(".")) ext = `.${ext}`;
+  // one suffix only (".mp4") — reject paths, extra dots, empty, or odd chars
+  if (!/^\.[a-z0-9]+$/.test(ext)) ext = BUILTIN.extension;
   const q = Number(p.jpegQuality);
   return {
     id,
     label: String(p.label || id),
     description: String(p.description || p.desc || ""),
     jpegQuality: q >= 0.1 && q <= 1 ? q : BUILTIN.jpegQuality,
-    extension: ext.startsWith(".") ? ext : `.${ext}`,
+    extension: ext,
     color: normalizeColor(p.color),
     args,
   };
@@ -218,6 +221,8 @@ function buildExportArgs(profile, { fps, wavPath, outPath }) {
   return args;
 }
 
+const DRY_RUN_TIMEOUT_MS = 15_000;
+
 /* Run the profile's args once against a synthetic input before the browser
    renders anything. Without this a typo (or an encoder this ffmpeg build lacks)
    would only surface when ffmpeg exits — i.e. after every frame was rendered.
@@ -232,19 +237,25 @@ function dryRunProfile(profile, { fps = 30, hasAudio = true } = {}) {
   return new Promise((resolve) => {
     let stderr = "";
     let settled = false;
+    let proc;
+    let timer;
     const finish = (result) => {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       try { fs.rmSync(dir, { recursive: true, force: true }); } catch { }
       resolve(result);
     };
-    let proc;
     try {
       proc = spawn("ffmpeg", args, { stdio: ["ignore", "ignore", "pipe"] });
     } catch (e) {
       finish({ ok: false, error: e.message || String(e) });
       return;
     }
+    timer = setTimeout(() => {
+      try { proc.kill(); } catch { }
+      finish({ ok: false, error: `ffmpeg dry-run timed out after ${DRY_RUN_TIMEOUT_MS}ms` });
+    }, DRY_RUN_TIMEOUT_MS);
     proc.on("error", (e) => finish({ ok: false, error: e.message || String(e) }));
     proc.stderr.on("data", (d) => { stderr = (stderr + d).slice(-4000); });
     proc.on("close", (code) => {

--- a/encode-profiles.js
+++ b/encode-profiles.js
@@ -1,0 +1,380 @@
+"use strict";
+const fs = require("fs");
+const path = require("path");
+
+const PROFILES_FILE = path.join(__dirname, "encoding-profiles.json");
+
+const VIDEO_CODECS = new Set(["libx264", "libx265"]);
+const VIDEO_PRESETS = new Set([
+  "ultrafast", "superfast", "veryfast", "faster", "fast",
+  "medium", "slow", "slower", "veryslow",
+]);
+const PIX_FMTS = new Set(["yuv420p", "yuv422p", "yuv444p"]);
+const AUDIO_CODECS = new Set(["aac", "libopus"]);
+const X264_TUNES = new Set(["film", "animation", "grain", "stillimage", "fastdecode", "zerolatency"]);
+const X264_PROFILES = new Set(["baseline", "main", "high", "high10", "high422", "high444"]);
+const BITRATE_RE = /^\d+([kKmM])?$/;
+const ID_RE = /^[a-zA-Z][a-zA-Z0-9_-]{0,31}$/;
+const LOGLEVELS = new Set(["quiet", "panic", "fatal", "error", "warning", "info", "verbose", "debug", "trace"]);
+/* "mkv" is an extension, not an ffmpeg muxer name — normalized to "matroska" */
+const MUX_FORMAT_ALIAS = { mp4: "mp4", mov: "mov", matroska: "matroska", mkv: "matroska" };
+const FORMAT_EXT = { mp4: ".mp4", mov: ".mov", matroska: ".mkv" };
+const EXT_FORMAT = { ".mp4": "mp4", ".m4v": "mp4", ".mov": "mov", ".mkv": "matroska" };
+const OUT_EXT = new Set([".mp4", ".mov", ".mkv", ".m4v"]);
+const SAFE_FFMPEG_STR = /^[\w=.,:/+\-[\]()%| ]{0,512}$/;
+/* ffmpeg levels that suppress error text; the frame-pipe pass keeps stderr for
+   diagnostics only (never shown unless the encode fails), so it is clamped up */
+const QUIET_LEVELS = new Set(["quiet", "panic", "fatal"]);
+
+const BUILTIN = {
+  default: "delivery",
+  profiles: {
+    draft: {
+      label: "Draft · H.264 fast",
+      description: "Quick preview — smaller file, faster encode.",
+      jpegQuality: 0.85,
+      video: { codec: "libx264", preset: "veryfast", crf: 23, pixFmt: "yuv420p" },
+      audio: { codec: "aac", bitrate: "128k" },
+      mux: { movflags: "+faststart" },
+    },
+    delivery: {
+      label: "Delivery · H.264 balanced",
+      description: "Default export — good quality and compatibility.",
+      jpegQuality: 0.95,
+      video: { codec: "libx264", preset: "fast", crf: 18, pixFmt: "yuv420p" },
+      audio: { codec: "aac", bitrate: "192k" },
+      mux: { movflags: "+faststart" },
+    },
+    hq: {
+      label: "High quality · H.264 slow",
+      description: "Best H.264 quality — slower encode, larger file.",
+      jpegQuality: 0.98,
+      video: { codec: "libx264", preset: "slow", crf: 16, pixFmt: "yuv420p" },
+      audio: { codec: "aac", bitrate: "256k" },
+      mux: { movflags: "+faststart" },
+    },
+  },
+};
+
+let cache = null;
+let cacheMtime = -1;
+
+function clampNum(v, fallback, min, max) {
+  const n = Number(v);
+  if (!isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
+/* like clampNum, but reports a silent clamp — an out-of-range value that gets
+   quietly corrected is how you end up exporting 8 kHz audio and not knowing */
+function clampReported(v, fallback, min, max, label, warn) {
+  const n = Number(v);
+  if (!isFinite(n)) return fallback;
+  const c = Math.min(max, Math.max(min, n));
+  if (c !== n) warn(`${label} ${n} out of range — clamped to ${c}`);
+  return c;
+}
+
+function validateVideo(v, fallback, warn) {
+  const out = { ...fallback, ...(v || {}) };
+  const drop = (key, why) => { delete out[key]; warn(`video.${key} ignored — ${why}`); };
+  if (!VIDEO_CODECS.has(out.codec)) {
+    warn(`video.codec "${out.codec}" not allowed — using ${fallback.codec}`);
+    out.codec = fallback.codec;
+  }
+  if (!VIDEO_PRESETS.has(out.preset)) {
+    warn(`video.preset "${out.preset}" not allowed — using ${fallback.preset}`);
+    out.preset = fallback.preset;
+  }
+  out.crf = Math.round(clampReported(out.crf, fallback.crf, 0, 51, "video.crf", warn));
+  if (!PIX_FMTS.has(out.pixFmt)) {
+    warn(`video.pixFmt "${out.pixFmt}" not allowed — using ${fallback.pixFmt}`);
+    out.pixFmt = fallback.pixFmt;
+  }
+  if (out.tune && !X264_TUNES.has(out.tune)) drop("tune", "unknown tune");
+  if (out.profile && !X264_PROFILES.has(out.profile)) drop("profile", "unknown H.264 profile");
+  if (out.g != null) {
+    const g = Math.round(clampNum(out.g, 0, 1, 600));
+    if (g > 0) out.g = g; else drop("g", "must be 1–600");
+  }
+  if (out.maxrate && !BITRATE_RE.test(String(out.maxrate))) drop("maxrate", 'expected e.g. "60M"');
+  if (out.bufsize && !BITRATE_RE.test(String(out.bufsize))) drop("bufsize", 'expected e.g. "70M"');
+  for (const key of ["x264opts", "vf"]) {
+    if (!out[key]) { delete out[key]; continue; }
+    const s = String(out[key]).trim();
+    if (s && SAFE_FFMPEG_STR.test(s)) out[key] = s;
+    else drop(key, "contains characters outside the allowed ffmpeg option set");
+  }
+  return out;
+}
+
+function validateAudio(a, fallback, warn) {
+  const out = { ...fallback, ...(a || {}) };
+  if (!AUDIO_CODECS.has(out.codec)) {
+    warn(`audio.codec "${out.codec}" not allowed — using ${fallback.codec}`);
+    out.codec = fallback.codec;
+  }
+  if (!BITRATE_RE.test(String(out.bitrate || ""))) {
+    warn(`audio.bitrate "${out.bitrate}" invalid — using ${fallback.bitrate}`);
+    out.bitrate = fallback.bitrate;
+  }
+  if (out.sampleRate != null) {
+    const sr = Math.round(clampReported(out.sampleRate, 0, 8000, 192000, "audio.sampleRate", warn));
+    if (sr > 0) out.sampleRate = sr;
+    else { delete out.sampleRate; warn("audio.sampleRate ignored — must be 8000–192000"); }
+  }
+  if (out.strict != null) {
+    const st = String(out.strict);
+    if (["-2", "-1", "0", "1", "experimental"].includes(st)) out.strict = st;
+    else { delete out.strict; warn(`audio.strict "${st}" ignored`); }
+  }
+  return out;
+}
+
+function validateMux(m, fallback, warn) {
+  const given = m && typeof m === "object" ? m : {};
+  const out = { ...fallback, ...given };
+  // an explicit null/"" clears an inherited value (e.g. drop +faststart)
+  if ("movflags" in given && (given.movflags === null || given.movflags === "")) delete out.movflags;
+  else if (out.movflags != null && typeof out.movflags !== "string") out.movflags = fallback.movflags;
+  if (out.format) {
+    const fmt = MUX_FORMAT_ALIAS[String(out.format).toLowerCase()];
+    if (fmt) out.format = fmt;
+    else { delete out.format; warn(`mux.format "${given.format}" unknown — using mp4`); }
+  }
+  if (out.extension) {
+    const raw = String(out.extension).toLowerCase();
+    const ext = raw.startsWith(".") ? raw : `.${raw}`;
+    if (OUT_EXT.has(ext)) out.extension = ext;
+    else { delete out.extension; warn(`mux.extension "${given.extension}" unsupported`); }
+  }
+  // a bare extension implies the container; keeps -f and the filename in step
+  if (!out.format && out.extension) out.format = EXT_FORMAT[out.extension];
+  if (out.format && out.extension && EXT_FORMAT[out.extension] !== out.format)
+    warn(`mux.extension ${out.extension} does not match mux.format ${out.format}`);
+  return out;
+}
+
+function validateEncode(e, fallback, warn) {
+  const out = { ...fallback, ...(e || {}) };
+  if (out.loglevel && !LOGLEVELS.has(String(out.loglevel))) {
+    warn(`encode.loglevel "${out.loglevel}" unknown — ignored`);
+    delete out.loglevel;
+  }
+  if (out.hideBanner != null) out.hideBanner = !!out.hideBanner;
+  if (out.stats != null) out.stats = !!out.stats;
+  return out;
+}
+
+function normalizeProfile(id, raw, fallback) {
+  const base = fallback || BUILTIN.profiles.delivery;
+  const p = raw && typeof raw === "object" ? raw : {};
+  const warnings = [];
+  const warn = (msg) => warnings.push(msg);
+  const mux = validateMux(p.mux, base.mux, warn);
+  const audio = validateAudio(p.audio, base.audio, warn);
+  const container = mux.format || "mp4";
+  /* Opus has no MOV mapping at all, and MP4 needs the experimental flag —
+     without this the mux pass dies only after every frame has been rendered. */
+  if (audio.codec === "libopus") {
+    if (container === "mov") {
+      warn("audio.codec libopus cannot be stored in MOV — using aac");
+      audio.codec = "aac";
+    } else if (container === "mp4" && audio.strict == null) {
+      audio.strict = "-2";
+    }
+  }
+  return {
+    id,
+    label: String(p.label || base.label || id),
+    description: String(p.description || p.desc || base.description || ""),
+    jpegQuality: clampReported(p.jpegQuality, base.jpegQuality, 0.5, 1, "jpegQuality", warn),
+    video: validateVideo(p.video, base.video, warn),
+    audio,
+    mux,
+    encode: validateEncode(p.encode, base.encode || {}, warn),
+    warnings,
+  };
+}
+
+function profilesFileMtime() {
+  try { return fs.statSync(PROFILES_FILE).mtimeMs; } catch { return 0; }
+}
+
+function loadEncodeProfiles(force) {
+  /* mtime check instead of a plain memo: the MCP server is long-lived and has
+     no file watcher, so a cache-only read would serve stale profiles forever */
+  const mtime = profilesFileMtime();
+  if (cache && !force && mtime === cacheMtime) return cache;
+
+  let file = null;
+  let fileError = null;
+  try {
+    if (fs.existsSync(PROFILES_FILE)) {
+      file = JSON.parse(fs.readFileSync(PROFILES_FILE, "utf8").replace(/^\uFEFF/, ""));
+    }
+  } catch (e) { fileError = `encoding-profiles.json could not be parsed (${e.message}) — using built-in profiles`; }
+
+  const profiles = {};
+  for (const [id, raw] of Object.entries(BUILTIN.profiles)) {
+    profiles[id] = normalizeProfile(id, raw, raw);
+  }
+  const issues = fileError ? [fileError] : [];
+  if (file?.profiles && typeof file.profiles === "object") {
+    for (const [id, raw] of Object.entries(file.profiles)) {
+      if (!ID_RE.test(id)) {
+        issues.push(`profile id "${id}" skipped — must start with a letter and use [A-Za-z0-9_-] only`);
+        continue;
+      }
+      profiles[id] = normalizeProfile(id, raw, profiles[id] || BUILTIN.profiles.delivery);
+    }
+  }
+  for (const p of Object.values(profiles))
+    for (const w of p.warnings) issues.push(`${p.id}: ${w}`);
+
+  let defaultId = typeof file?.default === "string" ? file.default : BUILTIN.default;
+  if (!profiles[defaultId]) {
+    if (file?.default) issues.push(`default "${file.default}" is not a defined profile — using delivery`);
+    defaultId = "delivery";
+  }
+
+  cache = { default: defaultId, profiles, issues };
+  cacheMtime = mtime;
+  return cache;
+}
+
+function invalidateEncodeProfiles() {
+  cache = null;
+  cacheMtime = -1;
+}
+
+function resolveProfile(id) {
+  const cfg = loadEncodeProfiles();
+  const pid = id || cfg.default;
+  const p = cfg.profiles[pid];
+  if (!p) throw new Error(`Unknown encoding profile "${pid}"`);
+  return p;
+}
+
+function profileSummary(p) {
+  const v = p.video;
+  const a = p.audio;
+  const bits = [`${v.codec} preset=${v.preset} crf=${v.crf}`];
+  if (v.g) bits.push(`g=${v.g}`);
+  if (v.vf) bits.push("vf");
+  if (v.x264opts) bits.push("x264opts");
+  bits.push(`${a.codec} ${a.bitrate}`);
+  if (a.sampleRate) bits.push(`${a.sampleRate / 1000}kHz`);
+  if (p.mux?.format) bits.push(p.mux.format);
+  bits.push(`JPEG ${Math.round(p.jpegQuality * 100)}%`);
+  return bits.join(" · ");
+}
+
+function ffmpegGlobalArgs(profile) {
+  const enc = profile.encode || {};
+  const args = [];
+  if (enc.hideBanner) args.push("-hide_banner");
+  if (enc.stats) args.push("-stats");
+  if (enc.loglevel) {
+    /* stderr is captured for failure reporting and never shown otherwise, so a
+       silencing loglevel would only cost us the reason an export died */
+    args.push("-loglevel", QUIET_LEVELS.has(enc.loglevel) ? "error" : enc.loglevel);
+  }
+  return args;
+}
+
+function exportContainer(profile) {
+  return profile.mux?.format || EXT_FORMAT[profile.mux?.extension] || "mp4";
+}
+
+function exportOutputExtension(profile) {
+  if (profile.mux?.extension) return profile.mux.extension;
+  return FORMAT_EXT[exportContainer(profile)] || ".mp4";
+}
+
+function listProfilesPublic(detail) {
+  const cfg = loadEncodeProfiles();
+  const out = {
+    default: cfg.default, profiles: {},
+    file: path.basename(PROFILES_FILE),
+    issues: cfg.issues || [],
+  };
+  for (const [id, p] of Object.entries(cfg.profiles)) {
+    // jpegQuality is needed by the browser to encode frames — always included
+    const base = {
+      label: p.label,
+      description: p.description,
+      jpegQuality: p.jpegQuality,
+      extension: exportOutputExtension(p),
+      summary: profileSummary(p),
+    };
+    out.profiles[id] = detail
+      ? { ...base, video: p.video, audio: p.audio, mux: p.mux, encode: p.encode, warnings: p.warnings }
+      : base;
+  }
+  return out;
+}
+
+function buildVideoEncodeArgs(profile, fps, outputPath) {
+  const v = profile.video;
+  const args = [...ffmpegGlobalArgs(profile),
+    "-y", "-f", "image2pipe", "-framerate", String(fps), "-i", "-",
+    "-c:v", v.codec,
+  ];
+  if (v.codec === "libx264" || v.codec === "libx265") {
+    args.push("-preset", v.preset, "-crf", String(v.crf));
+    if (v.g) args.push("-g", String(v.g));
+    if (v.maxrate) args.push("-maxrate", v.maxrate);
+    if (v.bufsize) args.push("-bufsize", v.bufsize);
+    if (v.x264opts) args.push("-x264opts", v.x264opts);
+    if (v.tune) args.push("-tune", v.tune);
+    if (v.profile) args.push("-profile:v", v.profile);
+  }
+  /* JPEG frames from the browser are full-range BT.601 (JFIF). Convert them to
+     limited-range BT.709 and tag the stream, otherwise x264 emits bt470bg/pc/
+     unknown and players do the wrong YUV→RGB conversion — darker than preview.
+     Profile `vf` (if any) is appended so color conversion always runs first. */
+  const colorVf = "scale=in_range=full:in_color_matrix=bt601:out_range=tv:out_color_matrix=bt709";
+  args.push("-vf", v.vf ? `${colorVf},${v.vf}` : colorVf);
+  args.push("-pix_fmt", v.pixFmt,
+    "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709", "-color_range", "tv",
+    outputPath);
+  return args;
+}
+
+function buildMuxArgs(profile, videoPath, wavPath, outPath) {
+  const a = profile.audio;
+  const container = exportContainer(profile);
+  const args = [...ffmpegGlobalArgs(profile), "-y", "-i", videoPath];
+  if (wavPath) args.push("-i", wavPath);
+  args.push("-c:v", "copy");
+  if (wavPath) {
+    args.push("-c:a", a.codec);
+    args.push("-b:a", a.bitrate);
+    if (a.sampleRate) args.push("-ar", String(a.sampleRate));
+    if (a.strict != null) args.push("-strict", String(a.strict));
+    args.push("-shortest");
+  }
+  // Re-assert the bt709 tags on the mux — a stream-copy pass can drop the
+  // container-level colr atom even though the SPS still carries them.
+  args.push("-colorspace", "bt709", "-color_primaries", "bt709",
+    "-color_trc", "bt709", "-color_range", "tv");
+  // -movflags is an MP4/MOV muxer option; Matroska warns and ignores it
+  if (profile.mux?.movflags && container !== "matroska")
+    args.push("-movflags", profile.mux.movflags);
+  args.push("-f", container, outPath);
+  return args;
+}
+
+module.exports = {
+  PROFILES_FILE,
+  loadEncodeProfiles,
+  invalidateEncodeProfiles,
+  resolveProfile,
+  listProfilesPublic,
+  profileSummary,
+  buildVideoEncodeArgs,
+  buildMuxArgs,
+  exportContainer,
+  exportOutputExtension,
+};

--- a/encode-profiles.js
+++ b/encode-profiles.js
@@ -19,7 +19,7 @@
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const { spawnSync } = require("child_process");
+const { spawn } = require("child_process");
 
 const PROFILES_FILE = path.join(__dirname, "encoding-profiles.json");
 
@@ -164,7 +164,8 @@ function buildExportArgs(profile, { fps, wavPath, outPath }) {
 
 /* Run the profile's args once against a synthetic input before the browser
    renders anything. Without this a typo (or an encoder this ffmpeg build lacks)
-   would only surface when ffmpeg exits — i.e. after every frame was rendered. */
+   would only surface when ffmpeg exits — i.e. after every frame was rendered.
+   Async spawn so /api/export/begin does not block the event loop. */
 function dryRunProfile(profile, { fps = 30, hasAudio = true } = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-dry-"));
   const out = path.join(dir, `probe${profile.extension}`);
@@ -172,16 +173,30 @@ function dryRunProfile(profile, { fps = 30, hasAudio = true } = {}) {
     "-i", `color=c=black:s=64x64:r=${fps}:d=0.1`];
   if (hasAudio) args.push("-f", "lavfi", "-i", "anullsrc=r=48000:cl=stereo");
   args.push("-t", "0.1", ...withJpegColor(profile.args), out);
-  try {
-    const r = spawnSync("ffmpeg", args, { encoding: "utf8" });
-    if (r.error) return { ok: false, error: r.error.message };
-    if (r.status === 0) return { ok: true };
-    // ffmpeg puts the actual complaint in the last lines of stderr
-    const lines = String(r.stderr || "").trim().split("\n").filter(Boolean);
-    return { ok: false, error: lines.slice(-3).join(" · ") || `ffmpeg exited ${r.status}` };
-  } finally {
-    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { }
-  }
+  return new Promise((resolve) => {
+    let stderr = "";
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { }
+      resolve(result);
+    };
+    let proc;
+    try {
+      proc = spawn("ffmpeg", args, { stdio: ["ignore", "ignore", "pipe"] });
+    } catch (e) {
+      finish({ ok: false, error: e.message || String(e) });
+      return;
+    }
+    proc.on("error", (e) => finish({ ok: false, error: e.message || String(e) }));
+    proc.stderr.on("data", (d) => { stderr = (stderr + d).slice(-4000); });
+    proc.on("close", (code) => {
+      if (code === 0) { finish({ ok: true }); return; }
+      const lines = stderr.trim().split("\n").filter(Boolean);
+      finish({ ok: false, error: lines.slice(-3).join(" · ") || `ffmpeg exited ${code}` });
+    });
+  });
 }
 
 module.exports = {

--- a/encode-profiles.js
+++ b/encode-profiles.js
@@ -105,6 +105,8 @@ function validateVideo(v, fallback, warn) {
     if (s && SAFE_FFMPEG_STR.test(s)) out[key] = s;
     else drop(key, "contains characters outside the allowed ffmpeg option set");
   }
+  if (out.x264opts && out.codec !== "libx264")
+    drop("x264opts", `only applies to libx264, not ${out.codec} (which takes -x265-params)`);
   return out;
 }
 
@@ -334,7 +336,8 @@ function buildVideoEncodeArgs(profile, fps, outputPath) {
     if (v.g) args.push("-g", String(v.g));
     if (v.maxrate) args.push("-maxrate", v.maxrate);
     if (v.bufsize) args.push("-bufsize", v.bufsize);
-    if (v.x264opts) args.push("-x264opts", v.x264opts);
+    // libx264-only private option (libx265 takes -x265-params instead)
+    if (v.x264opts && v.codec === "libx264") args.push("-x264opts", v.x264opts);
     if (v.tune) args.push("-tune", v.tune);
     if (v.profile) args.push("-profile:v", v.profile);
   }

--- a/encoding-profiles.json
+++ b/encoding-profiles.json
@@ -49,7 +49,7 @@
       ]
     },
     "prores422": {
-      "label": "ProRes 422 HQ · MOV - do not use it",
+      "label": "ProRes 422 HQ · MOV",
       "description": "Mezzanine / round-trip master. Large files, edits well anywhere.",
       "jpegQuality": 1,
       "extension": ".mov",

--- a/encoding-profiles.json
+++ b/encoding-profiles.json
@@ -6,6 +6,7 @@
       "description": "Quick preview — smaller file, faster encode.",
       "jpegQuality": 0.85,
       "extension": ".mp4",
+      "color": { "matrix": "bt709", "primaries": "bt709", "trc": "bt709", "range": "tv" },
       "args": [
         "-c:v", "libx264", "-preset", "veryfast", "-crf", "23", "-pix_fmt", "yuv420p",
         "-c:a", "aac", "-b:a", "128k",
@@ -17,6 +18,7 @@
       "description": "Default export — good quality and compatibility.",
       "jpegQuality": 0.95,
       "extension": ".mp4",
+      "color": { "matrix": "bt709", "primaries": "bt709", "trc": "bt709", "range": "tv" },
       "args": [
         "-c:v", "libx264", "-preset", "fast", "-crf", "18", "-pix_fmt", "yuv420p",
         "-c:a", "aac", "-b:a", "192k",
@@ -28,6 +30,7 @@
       "description": "Best H.264 quality — High 4:2:2 profile, 10-bit. Slower encode, larger file; for mastering and grading round-trips, not for browser or QuickTime playback.",
       "jpegQuality": 0.98,
       "extension": ".mp4",
+      "color": { "matrix": "bt709", "primaries": "bt709", "trc": "bt709", "range": "tv" },
       "args": [
         "-c:v", "libx264", "-preset", "slow", "-crf", "16", "-pix_fmt", "yuv422p10le",
         "-c:a", "aac", "-b:a", "256k",
@@ -39,6 +42,7 @@
       "description": "Interlaced H.264 for broadcast-style delivery. Set the project to 1920x1080 @ 25fps (progressive); the filter chain builds the 50i field order.",
       "jpegQuality": 0.98,
       "extension": ".mov",
+      "color": { "matrix": "bt709", "primaries": "bt709", "trc": "bt709", "range": "tv" },
       "args": [
         "-c:v", "libx264", "-preset", "veryfast", "-crf", "18", "-pix_fmt", "yuv420p",
         "-g", "10", "-maxrate", "60M", "-bufsize", "70M",
@@ -53,6 +57,7 @@
       "description": "Mezzanine / round-trip master. Large files, edits well anywhere.",
       "jpegQuality": 1,
       "extension": ".mov",
+      "color": { "matrix": "bt709", "primaries": "bt709", "trc": "bt709", "range": "tv" },
       "args": [
         "-c:v", "prores_ks", "-profile:v", "3", "-pix_fmt", "yuv422p10le",
         "-c:a", "pcm_s16le",

--- a/encoding-profiles.json
+++ b/encoding-profiles.json
@@ -44,7 +44,7 @@
       "extension": ".mov",
       "color": { "matrix": "bt709", "primaries": "bt709", "trc": "bt709", "range": "tv" },
       "args": [
-        "-c:v", "libx264", "-preset", "veryfast", "-crf", "18", "-pix_fmt", "yuv420p",
+        "-c:v", "libx264", "-preset", "fast", "-crf", "18", "-pix_fmt", "yuv420p",
         "-g", "10", "-maxrate", "60M", "-bufsize", "70M",
         "-x264opts", "open_gop=0:interlaced=1:me=hex:subme=2:cabac=1:no-deblock:analyse=all:8x8dct=1:bframes=2:weightp=0:sliced-threads:level=41",
         "-vf", "scale=1920:1080:interl=-1,fps=50,tinterlace=interleave_top:bypass_il",

--- a/encoding-profiles.json
+++ b/encoding-profiles.json
@@ -5,45 +5,59 @@
       "label": "Draft · H.264 fast",
       "description": "Quick preview — smaller file, faster encode.",
       "jpegQuality": 0.85,
-      "video": { "codec": "libx264", "preset": "veryfast", "crf": 23, "pixFmt": "yuv420p" },
-      "audio": { "codec": "aac", "bitrate": "128k" },
-      "mux": { "movflags": "+faststart" }
+      "extension": ".mp4",
+      "args": [
+        "-c:v", "libx264", "-preset", "veryfast", "-crf", "23", "-pix_fmt", "yuv420p",
+        "-c:a", "aac", "-b:a", "128k",
+        "-movflags", "+faststart", "-shortest"
+      ]
     },
     "delivery": {
       "label": "Delivery · H.264 balanced",
       "description": "Default export — good quality and compatibility.",
       "jpegQuality": 0.95,
-      "encode": { "hideBanner": true, "loglevel": "info", "stats": true },
-      "video": { "codec": "libx264", "preset": "fast", "crf": 18, "pixFmt": "yuv420p" },
-      "audio": { "codec": "aac", "bitrate": "192k" },
-      "mux": { "movflags": "+faststart" }
+      "extension": ".mp4",
+      "args": [
+        "-c:v", "libx264", "-preset", "fast", "-crf", "18", "-pix_fmt", "yuv420p",
+        "-c:a", "aac", "-b:a", "192k",
+        "-movflags", "+faststart", "-shortest"
+      ]
     },
     "hq": {
-      "label": "High quality · H.264 slow",
-      "description": "Best H.264 quality — slower encode, larger file.",
+      "label": "High quality · H.264 4:2:2 10-bit slow",
+      "description": "Best H.264 quality — High 4:2:2 profile, 10-bit. Slower encode, larger file; for mastering and grading round-trips, not for browser or QuickTime playback.",
       "jpegQuality": 0.98,
-      "video": { "codec": "libx264", "preset": "slow", "crf": 16, "pixFmt": "yuv420p" },
-      "audio": { "codec": "aac", "bitrate": "256k" },
-      "mux": { "movflags": "+faststart" }
+      "extension": ".mp4",
+      "args": [
+        "-c:v", "libx264", "-preset", "slow", "-crf", "16", "-pix_fmt", "yuv422p10le",
+        "-c:a", "aac", "-b:a", "256k",
+        "-movflags", "+faststart", "-shortest"
+      ]
     },
     "broadcast1080i50": {
       "label": "Broadcast · 1080i50 MOV",
-      "description": "Interlaced H.264 for broadcast-style delivery. Set project to 1920×1080 @ 25fps (progressive); export applies 50i + x264 opts.",
+      "description": "Interlaced H.264 for broadcast-style delivery. Set the project to 1920x1080 @ 25fps (progressive); the filter chain builds the 50i field order.",
       "jpegQuality": 0.98,
-      "encode": { "hideBanner": true, "loglevel": "panic", "stats": true },
-      "video": {
-        "codec": "libx264",
-        "preset": "veryfast",
-        "crf": 18,
-        "pixFmt": "yuv420p",
-        "g": 10,
-        "maxrate": "60M",
-        "bufsize": "70M",
-        "x264opts": "open_gop=0:interlaced=1:me=hex:subme=2:cabac=1:no-deblock:analyse=all:8x8dct=1:bframes=2:weightp=0:sliced-threads:level=41",
-        "vf": "scale=1920:1080:interl=-1,fps=50,tinterlace=interleave_top:bypass_il"
-      },
-      "audio": { "codec": "aac", "bitrate": "384k", "sampleRate": 48000, "strict": "-2" },
-      "mux": { "format": "mov", "extension": ".mov" }
+      "extension": ".mov",
+      "args": [
+        "-c:v", "libx264", "-preset", "veryfast", "-crf", "18", "-pix_fmt", "yuv420p",
+        "-g", "10", "-maxrate", "60M", "-bufsize", "70M",
+        "-x264opts", "open_gop=0:interlaced=1:me=hex:subme=2:cabac=1:no-deblock:analyse=all:8x8dct=1:bframes=2:weightp=0:sliced-threads:level=41",
+        "-vf", "scale=1920:1080:interl=-1,fps=50,tinterlace=interleave_top:bypass_il",
+        "-c:a", "aac", "-b:a", "384k", "-ar", "48000", "-strict", "-2",
+        "-shortest"
+      ]
+    },
+    "prores422": {
+      "label": "ProRes 422 HQ · MOV - do not use it",
+      "description": "Mezzanine / round-trip master. Large files, edits well anywhere.",
+      "jpegQuality": 1,
+      "extension": ".mov",
+      "args": [
+        "-c:v", "prores_ks", "-profile:v", "3", "-pix_fmt", "yuv422p10le",
+        "-c:a", "pcm_s16le",
+        "-shortest"
+      ]
     }
   }
 }

--- a/encoding-profiles.json
+++ b/encoding-profiles.json
@@ -1,0 +1,49 @@
+{
+  "default": "delivery",
+  "profiles": {
+    "draft": {
+      "label": "Draft · H.264 fast",
+      "description": "Quick preview — smaller file, faster encode.",
+      "jpegQuality": 0.85,
+      "video": { "codec": "libx264", "preset": "veryfast", "crf": 23, "pixFmt": "yuv420p" },
+      "audio": { "codec": "aac", "bitrate": "128k" },
+      "mux": { "movflags": "+faststart" }
+    },
+    "delivery": {
+      "label": "Delivery · H.264 balanced",
+      "description": "Default export — good quality and compatibility.",
+      "jpegQuality": 0.95,
+      "encode": { "hideBanner": true, "loglevel": "info", "stats": true },
+      "video": { "codec": "libx264", "preset": "fast", "crf": 18, "pixFmt": "yuv420p" },
+      "audio": { "codec": "aac", "bitrate": "192k" },
+      "mux": { "movflags": "+faststart" }
+    },
+    "hq": {
+      "label": "High quality · H.264 slow",
+      "description": "Best H.264 quality — slower encode, larger file.",
+      "jpegQuality": 0.98,
+      "video": { "codec": "libx264", "preset": "slow", "crf": 16, "pixFmt": "yuv420p" },
+      "audio": { "codec": "aac", "bitrate": "256k" },
+      "mux": { "movflags": "+faststart" }
+    },
+    "broadcast1080i50": {
+      "label": "Broadcast · 1080i50 MOV",
+      "description": "Interlaced H.264 for broadcast-style delivery. Set project to 1920×1080 @ 25fps (progressive); export applies 50i + x264 opts.",
+      "jpegQuality": 0.98,
+      "encode": { "hideBanner": true, "loglevel": "panic", "stats": true },
+      "video": {
+        "codec": "libx264",
+        "preset": "veryfast",
+        "crf": 18,
+        "pixFmt": "yuv420p",
+        "g": 10,
+        "maxrate": "60M",
+        "bufsize": "70M",
+        "x264opts": "open_gop=0:interlaced=1:me=hex:subme=2:cabac=1:no-deblock:analyse=all:8x8dct=1:bframes=2:weightp=0:sliced-threads:level=41",
+        "vf": "scale=1920:1080:interl=-1,fps=50,tinterlace=interleave_top:bypass_il"
+      },
+      "audio": { "codec": "aac", "bitrate": "384k", "sampleRate": 48000, "strict": "-2" },
+      "mux": { "format": "mov", "extension": ".mov" }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -173,6 +173,12 @@
       <input type="radio" name="engine" id="engineRealtime">
       <span><b>Realtime (in-browser)</b><br><span class="dim">Plays the timeline once and records it. Keep the tab focused.</span></span>
     </label>
+    <div class="export-profile-row" id="exportProfileRow">
+      <label class="export-profile-label" for="exportProfileSel">Encoding profile</label>
+      <select class="export-profile-sel" id="exportProfileSel" aria-describedby="exportProfileNote exportProfileHint"></select>
+      <p class="dim export-profile-note" id="exportProfileNote"></p>
+      <p class="dim export-profile-hint" id="exportProfileHint"></p>
+    </div>
     <div class="export-track-warn hidden" id="exportTrackWarn" role="status"></div>
     <div class="dialog-actions">
       <button class="btn" id="btnCancelSetup">Cancel</button>

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -7,13 +7,14 @@
 
    Tools: fablecut_status, fablecut_docs, fablecut_get_project,
           fablecut_set_project, fablecut_patch_project, fablecut_import_media,
-          fablecut_analyze_reference
+          fablecut_analyze_reference, fablecut_encode_profiles
    ═══════════════════════════════════════════════════════════════════════════ */
 "use strict";
 const fs = require("fs");
 const path = require("path");
 const http = require("http");
 const { spawn, spawnSync } = require("child_process");
+const { loadEncodeProfiles, listProfilesPublic, resolveProfile, profileSummary } = require("./encode-profiles");
 
 const {
   APP_DIR, DATA_DIR, MEDIA_DIR, ANALYSIS_DIR, LIBRARY_DIR, PROJECT_FILE, ensureDirs,
@@ -108,7 +109,7 @@ const TOOLS = [
   },
   {
     name: "fablecut_patch_project",
-    description: "Apply targeted edits to the FableCut project WITHOUT round-tripping the whole document — PREFER THIS over get+set for every edit (it is ~10-100x cheaper in tokens and merge-safe by design: it re-reads the latest document from disk, applies your ops in order, bumps revision once, saves atomically). Ops: {op:'addClip', clip:{…}} (id auto-generated if omitted) · {op:'updateClip', id, set:{…}} · {op:'removeClip', id} · {op:'addMedia', media:{…}} · {op:'removeMedia', id} · {op:'setProject', set:{name|width|height|fps|background|markers|disabledTracks}}. updateClip merge rules: top-level keys are replaced (keyframes/transitionIn/transitionOut wholesale), `props` merges key-by-key, and setting any key to null deletes it. All-or-nothing: an invalid op aborts the whole patch unsaved.",
+    description: "Apply targeted edits to the FableCut project WITHOUT round-tripping the whole document — PREFER THIS over get+set for every edit (it is ~10-100x cheaper in tokens and merge-safe by design: it re-reads the latest document from disk, applies your ops in order, bumps revision once, saves atomically). Ops: {op:'addClip', clip:{…}} (id auto-generated if omitted) · {op:'updateClip', id, set:{…}} · {op:'removeClip', id} · {op:'addMedia', media:{…}} · {op:'removeMedia', id} · {op:'setProject', set:{name|width|height|fps|background|markers|disabledTracks|encodeProfile}}. updateClip merge rules: top-level keys are replaced (keyframes/transitionIn/transitionOut wholesale), `props` merges key-by-key, and setting any key to null deletes it. All-or-nothing: an invalid op aborts the whole patch unsaved.",
     inputSchema: {
       type: "object",
       properties: {
@@ -155,6 +156,17 @@ const TOOLS = [
       required: ["path"],
     },
   },
+  {
+    name: "fablecut_encode_profiles",
+    description: "List ffmpeg encoding profiles for Fast export (from encoding-profiles.json). Use to pick a profile id for project.encodeProfile or to inspect codec/CRF/JPEG settings. Edit encoding-profiles.json on disk to add custom profiles — the server hot-reloads it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        detail: { type: "boolean", description: "Include full video/audio/jpeg settings per profile (default: summary only)" },
+        profile: { type: "string", description: "Return one profile by id instead of the full list" },
+      },
+    },
+  },
 ];
 
 /* ── Tool implementations ── */
@@ -173,14 +185,24 @@ async function callTool(name, args) {
         return `${d}: ${n}`;
       }).join(", ");
       const cap = (arr, n) => arr.length > n ? arr.slice(0, n).concat(`… +${arr.length - n} more`) : arr;
+      let encLine = "";
+      try {
+        const cfg = loadEncodeProfiles();
+        const eff = proj.encodeProfile || cfg.default;
+        const p = cfg.profiles[eff];
+        encLine = p
+          ? `Export profile: ${eff} (${p.label}) — ${profileSummary(p)}`
+          : `Export profile: server default "${cfg.default}"`;
+      } catch { encLine = "Export profile: (encoding-profiles.json unavailable)"; }
       return [
         `Editor server: ${up ? "RUNNING — open " + BASE + " in a browser to watch edits live" : "FAILED TO START (check node / port " + PORT + ")"}`,
         `Project: "${proj.name}" — ${proj.width}x${proj.height} @ ${proj.fps}fps, ${proj.clips.length} clip(s), ${dur.toFixed(2)}s, revision ${proj.revision}`,
+        encLine,
         `Registered media: ${cap(proj.media.map((m) => `${m.id} (${m.kind}, ${m.name}${m.duration ? ", " + m.duration + "s" : ""})`), 25).join("; ") || "none"}`,
         `Files in media/: ${cap(files, 25).join(", ") || "none"}`,
         `Library assets (./library): ${libSummary}`,
         `Project file: ${PROJECT_FILE}`,
-        `Tips: fablecut_docs (use \`section\`) for the schema · fablecut_get_project {compact:true} to see the timeline · fablecut_patch_project for edits (cheapest).`,
+        `Tips: fablecut_docs (use \`section\`) for the schema · fablecut_get_project {compact:true} to see the timeline · fablecut_patch_project for edits (cheapest) · fablecut_encode_profiles for export presets.`,
       ].join("\n");
     }
     case "fablecut_docs": {
@@ -311,9 +333,12 @@ async function callTool(name, args) {
             break;
           }
           case "setProject": {
-            const allowed = ["name", "width", "height", "fps", "background", "markers", "disabledTracks", "exportFrame"];
+            const allowed = ["name", "width", "height", "fps", "background", "markers", "disabledTracks", "exportFrame", "encodeProfile"];
             for (const [k, v] of Object.entries(op.set || {})) {
               if (!allowed.includes(k)) throw new Error(`setProject: '${k}' not settable (allowed: ${allowed.join(", ")})`);
+              if (k === "encodeProfile" && v != null) {
+                resolveProfile(String(v)); // validate id exists
+              }
               if (v === null) delete proj[k]; else proj[k] = v;
             }
             notes.push("~project");
@@ -445,6 +470,25 @@ async function callTool(name, args) {
         (entry.duration == null && kind !== "image"
           ? "Note: duration unknown (no ffprobe). The browser UI will probe and fill it in; re-read the project before trimming this media."
           : "Ready to use in clips via mediaId.");
+    }
+    case "fablecut_encode_profiles": {
+      if (args.profile) {
+        const p = resolveProfile(String(args.profile));
+        return JSON.stringify({
+          default: loadEncodeProfiles().default,
+          profile: args.profile,
+          label: p.label,
+          description: p.description,
+          jpegQuality: p.jpegQuality,
+          video: p.video,
+          audio: p.audio,
+          mux: p.mux,
+          encode: p.encode,
+          warnings: p.warnings,
+          summary: profileSummary(p),
+        }, null, 2);
+      }
+      return JSON.stringify(listProfilesPublic(!!args.detail), null, 2);
     }
     default:
       throw new Error("Unknown tool: " + name);

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -188,11 +188,19 @@ async function callTool(name, args) {
       let encLine = "";
       try {
         const cfg = loadEncodeProfiles();
-        const eff = proj.encodeProfile || cfg.default;
-        const p = cfg.profiles[eff];
-        encLine = p
-          ? `Export profile: ${eff} (${p.label}) — ${profileSummary(p)}`
-          : `Export profile: server default "${cfg.default}"`;
+        const describe = (id) => {
+          const p = cfg.profiles[id];
+          return p ? `${id} (${p.label}) — ${profileSummary(p)}` : null;
+        };
+        const pinned = proj.encodeProfile;
+        if (pinned && !cfg.profiles[pinned]) {
+          /* a project pinning a since-deleted profile must not read as "nothing
+             configured" — the bad id and the fallback are two separate facts */
+          encLine = `Export profile: project encodeProfile "${pinned}" is NOT DEFINED in encoding-profiles.json` +
+            ` — falling back to default ${describe(cfg.default) || `"${cfg.default}"`}`;
+        } else {
+          encLine = `Export profile: ${describe(pinned || cfg.default) || `server default "${cfg.default}"`}`;
+        }
       } catch { encLine = "Export profile: (encoding-profiles.json unavailable)"; }
       return [
         `Editor server: ${up ? "RUNNING — open " + BASE + " in a browser to watch edits live" : "FAILED TO START (check node / port " + PORT + ")"}`,

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -158,7 +158,7 @@ const TOOLS = [
   },
   {
     name: "fablecut_encode_profiles",
-    description: "List ffmpeg encoding profiles for Fast export (from encoding-profiles.json). Each profile is a raw ffmpeg argument list plus jpegQuality (browser frame quality) and extension (output container). Use to pick a profile id for project.encodeProfile. Edit encoding-profiles.json on disk to add custom profiles — anything the local ffmpeg supports works, and the server hot-reloads the file. Profiles are dry-run against ffmpeg when an export starts, so a bad argument is rejected before rendering.",
+    description: "List ffmpeg encoding profiles for Fast export (from encoding-profiles.json). Each profile is a raw ffmpeg argument list plus jpegQuality, extension, and optional color (output matrix/range — default BT.709 tv). Use to pick a profile id for project.encodeProfile. Edit encoding-profiles.json on disk to add custom profiles — anything the local ffmpeg supports works, and the server hot-reloads the file. Profiles are dry-run against ffmpeg when an export starts, so a bad argument is rejected before rendering.",
     inputSchema: {
       type: "object",
       properties: {
@@ -489,6 +489,7 @@ async function callTool(name, args) {
           description: p.description,
           jpegQuality: p.jpegQuality,
           extension: p.extension,
+          color: p.color,
           args: p.args,
         }, null, 2);
       }

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -158,11 +158,11 @@ const TOOLS = [
   },
   {
     name: "fablecut_encode_profiles",
-    description: "List ffmpeg encoding profiles for Fast export (from encoding-profiles.json). Use to pick a profile id for project.encodeProfile or to inspect codec/CRF/JPEG settings. Edit encoding-profiles.json on disk to add custom profiles — the server hot-reloads it.",
+    description: "List ffmpeg encoding profiles for Fast export (from encoding-profiles.json). Each profile is a raw ffmpeg argument list plus jpegQuality (browser frame quality) and extension (output container). Use to pick a profile id for project.encodeProfile. Edit encoding-profiles.json on disk to add custom profiles — anything the local ffmpeg supports works, and the server hot-reloads the file. Profiles are dry-run against ffmpeg when an export starts, so a bad argument is rejected before rendering.",
     inputSchema: {
       type: "object",
       properties: {
-        detail: { type: "boolean", description: "Include full video/audio/jpeg settings per profile (default: summary only)" },
+        detail: { type: "boolean", description: "Include the full ffmpeg args array per profile (default: a truncated summary)" },
         profile: { type: "string", description: "Return one profile by id instead of the full list" },
       },
     },
@@ -488,12 +488,8 @@ async function callTool(name, args) {
           label: p.label,
           description: p.description,
           jpegQuality: p.jpegQuality,
-          video: p.video,
-          audio: p.audio,
-          mux: p.mux,
-          encode: p.encode,
-          warnings: p.warnings,
-          summary: profileSummary(p),
+          extension: p.extension,
+          args: p.args,
         }, null, 2);
       }
       return JSON.stringify(listProfilesPublic(!!args.detail), null, 2);

--- a/server.js
+++ b/server.js
@@ -397,10 +397,10 @@ const server = http.createServer(async (req, res) => {
     return;
   }
   if (p === "/api/export/begin" && req.method === "POST") {
-    if (!HAS_FFMPEG) { sendJSON(res, 400, { error: "ffmpeg not found on PATH" }); return; }
     try {
       const opts = JSON.parse((await readBody(req)).toString("utf8") || "{}");
-      if (opts.profile) resolveProfile(opts.profile); // 400, not 500, on a bad id
+      if (opts.profile) resolveProfile(opts.profile); // 400, not 500, on a bad id — even without ffmpeg
+      if (!HAS_FFMPEG) { sendJSON(res, 400, { error: "ffmpeg not found on PATH" }); return; }
       sendJSON(res, 200, await beginExport(opts.fps || 30, opts.name, opts.profile, opts.hasAudio !== false));
     } catch (e) {
       // an unusable profile is the caller's problem, not a server fault

--- a/server.js
+++ b/server.js
@@ -19,6 +19,17 @@ const os = require("os");
 const { spawn, spawnSync, execFile } = require("child_process");
 
 const { analyze } = require("./analyze");
+const {
+  PROFILES_FILE,
+  loadEncodeProfiles,
+  invalidateEncodeProfiles,
+  resolveProfile,
+  listProfilesPublic,
+  profileSummary,
+  buildVideoEncodeArgs,
+  buildMuxArgs,
+  exportOutputExtension,
+} = require("./encode-profiles");
 
 const {
   APP_DIR, DATA_DIR, MEDIA_DIR, EXPORTS_DIR, ANALYSIS_DIR, LIBRARY_DIR,
@@ -93,6 +104,14 @@ function onFsChange() {
 /* watch the directory, not the file — atomic tmp+rename writes would detach a
    direct file watcher on Windows */
 try { fs.watch(DATA_DIR, (ev, f) => { if (f === "project.json") onFsChange(); }); } catch {}
+try {
+  fs.watch(ROOT, (ev, f) => {
+    if (f === path.basename(PROFILES_FILE)) {
+      invalidateEncodeProfiles();
+      onFsChange();
+    }
+  });
+} catch {}
 try { fs.watch(MEDIA_DIR, onFsChange); } catch {}
 for (const d of LIBRARY_SUBDIRS) {
   try { fs.watch(path.join(LIBRARY_DIR, d), onFsChange); } catch {}
@@ -146,32 +165,23 @@ async function faststart(file) {
    The browser renders frames with its own compositor and streams them here as
    JPEGs; ffmpeg encodes them (plus an optional WAV mix) into a real MP4. */
 const exportSessions = new Map();
-function beginExport(fps, name) {
+function beginExport(fps, name, profileId) {
+  const profile = resolveProfile(profileId);
   const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-"));
   const videoPath = path.join(dir, "video.mp4");
-  const proc = spawn("ffmpeg", [
-    "-y", "-f", "image2pipe", "-framerate", String(fps), "-i", "-",
-    // The browser's JPEG frames are full-range BT.601 (JFIF). Convert them to
-    // limited-range BT.709 and TAG the stream, otherwise x264 emits bt470bg/pc/
-    // unknown and players do the wrong YUV->RGB conversion — the render comes
-    // out darker than the preview.
-    "-vf", "scale=in_range=full:in_color_matrix=bt601:out_range=tv:out_color_matrix=bt709",
-    "-c:v", "libx264", "-preset", "fast", "-crf", "18", "-pix_fmt", "yuv420p",
-    "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709",
-    "-color_range", "tv",
-    videoPath,
-  ], { stdio: ["pipe", "ignore", "pipe"] });
+  const proc = spawn("ffmpeg", buildVideoEncodeArgs(profile, fps, videoPath),
+    { stdio: ["pipe", "ignore", "pipe"] });
   let stderr = "";
   proc.stderr.on("data", (d) => { stderr = (stderr + d).slice(-2000); });
   proc.stdin.on("error", () => {}); // EPIPE if ffmpeg dies mid-stream; surfaced via exit code
   const sess = {
-    proc, dir, videoPath, name: safeName(name || "export"),
+    proc, dir, videoPath, profile, name: safeName(name || "export"),
     wav: null, err: () => stderr,
     done: new Promise((res) => proc.on("close", res)),
   };
   exportSessions.set(id, sess);
-  return id;
+  return { id, profile: profile.id, label: profile.label, summary: profileSummary(profile) };
 }
 function cleanupExport(id) {
   const s = exportSessions.get(id);
@@ -304,12 +314,23 @@ const server = http.createServer(async (req, res) => {
     sendJSON(res, 200, { available: HAS_FFMPEG });
     return;
   }
+  if (p === "/api/export/profiles" && req.method === "GET") {
+    try {
+      const detail = url.searchParams.get("detail") === "1";
+      sendJSON(res, 200, listProfilesPublic(detail));
+    } catch (e) { sendJSON(res, 500, { error: String(e) }); }
+    return;
+  }
   if (p === "/api/export/begin" && req.method === "POST") {
     if (!HAS_FFMPEG) { sendJSON(res, 400, { error: "ffmpeg not found on PATH" }); return; }
     try {
       const opts = JSON.parse((await readBody(req)).toString("utf8") || "{}");
-      sendJSON(res, 200, { id: beginExport(opts.fps || 30, opts.name) });
-    } catch (e) { sendJSON(res, 500, { error: String(e) }); }
+      if (opts.profile) resolveProfile(opts.profile); // 400, not 500, on a bad id
+      sendJSON(res, 200, beginExport(opts.fps || 30, opts.name, opts.profile));
+    } catch (e) {
+      const bad = /^Unknown encoding profile/.test(e.message || "");
+      sendJSON(res, bad ? 400 : 500, { error: String(e.message || e) });
+    }
     return;
   }
   if (p === "/api/export/frame" && req.method === "POST") {
@@ -343,18 +364,11 @@ const server = http.createServer(async (req, res) => {
       sess.proc.stdin.end();
       const code = await sess.done;
       if (code !== 0) throw new Error("ffmpeg encode failed: " + sess.err());
-      const out = uniquePath(EXPORTS_DIR, sess.name.replace(/\.mp4$/i, "") + ".mp4");
-      // Re-assert the bt709 tags on the mux — a stream-copy pass can drop the
-      // container-level colr atom even though the SPS still carries them.
-      const TAGS = ["-colorspace", "bt709", "-color_primaries", "bt709",
-                    "-color_trc", "bt709", "-color_range", "tv"];
-      if (sess.wav && fs.existsSync(sess.wav))
-        await run("ffmpeg", ["-y", "-i", sess.videoPath, "-i", sess.wav,
-          "-c:v", "copy", "-c:a", "aac", "-b:a", "192k", "-shortest",
-          ...TAGS, "-movflags", "+faststart", out]);
-      else
-        await run("ffmpeg", ["-y", "-i", sess.videoPath, "-c", "copy",
-          ...TAGS, "-movflags", "+faststart", out]);
+      const profile = sess.profile || resolveProfile();
+      const ext = exportOutputExtension(profile);
+      const out = uniquePath(EXPORTS_DIR, sess.name.replace(/\.(mp4|mov|m4v|mkv)$/i, "") + ext);
+      const wav = sess.wav && fs.existsSync(sess.wav) ? sess.wav : null;
+      await run("ffmpeg", buildMuxArgs(profile, sess.videoPath, wav, out));
       cleanupExport(id);
       sendJSON(res, 200, { ok: true, src: "/exports/" + encodeURIComponent(path.basename(out)) });
     } catch (e) { cleanupExport(id); sendJSON(res, 500, { error: String(e) }); }
@@ -441,5 +455,9 @@ server.listen(PORT, HOST, () => {
   console.log(`  media folder : ${MEDIA_DIR}`);
   console.log(`  library      : ${LIBRARY_DIR} (${LIBRARY_SUBDIRS.join(", ")})`);
   if (DATA_DIR !== APP_DIR) console.log(`  app files    : ${APP_DIR}`);
-  console.log(`  ffmpeg       : ${HAS_FFMPEG ? "found (fast export + faststart remux on)" : "not found (real-time export only)"}\n`);
+  console.log(`  ffmpeg       : ${HAS_FFMPEG ? "found (fast export + faststart remux on)" : "not found (real-time export only)"}`);
+  const enc = loadEncodeProfiles(true);
+  console.log(`  encode prof. : ${PROFILES_FILE} (${Object.keys(enc.profiles).join(", ")} · default ${enc.default})`);
+  for (const issue of enc.issues || []) console.log(`     ⚠ ${issue}`);
+  console.log("");
 });

--- a/server.js
+++ b/server.js
@@ -133,12 +133,29 @@ function readBody(req) {
     req.on("error", reject);
   });
 }
-function uniquePath(dir, name) {
-  let target = path.join(dir, name);
-  const ext = path.extname(name), base = path.basename(name, ext);
-  let i = 1;
-  while (fs.existsSync(target)) target = path.join(dir, `${base}_${i++}${ext}`);
-  return target;
+/** Claim final + sibling `.part` paths with exclusive create (`wx`) so concurrent
+ *  exports cannot pick the same free name before either file exists. */
+function reserveExportPaths(dir, baseName, ext) {
+  const base = baseName.replace(/\.(mp4|mov|m4v|mkv|webm)$/i, "");
+  let i = 0;
+  for (;;) {
+    const stem = i === 0 ? base : `${base}_${i}`;
+    i++;
+    const outPath = path.join(dir, stem + ext);
+    const partPath = path.join(dir, stem + ".part" + ext);
+    if (fs.existsSync(outPath)) continue;
+    try {
+      fs.closeSync(fs.openSync(partPath, "wx")); // exclusive create — claim the name
+    } catch (e) {
+      if (e.code === "EEXIST") continue;
+      throw e;
+    }
+    if (fs.existsSync(outPath)) {
+      try { fs.rmSync(partPath, { force: true }); } catch { }
+      continue;
+    }
+    return { outPath, partPath };
+  }
 }
 function run(cmd, args) {
   return new Promise((resolve, reject) => {
@@ -171,10 +188,14 @@ async function beginExport(fps, name, profileId, hasAudio) {
   const dry = await dryRunProfile(profile, { fps, hasAudio });
   if (!dry.ok) throw new Error(`profile "${profile.id}" was rejected by ffmpeg: ${dry.error}`);
   const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+  const safe = safeName(name || "export");
+  // Reserve the output name now (not at first frame) so concurrent exports
+  // cannot both see the same free path. The empty .part file is overwritten by ffmpeg (-y).
+  const { outPath, partPath } = reserveExportPaths(EXPORTS_DIR, safe, profile.extension);
   const sess = {
-    proc: null, fps, profile, name: safeName(name || "export"),
+    proc: null, fps, profile, name: safe,
     dir: fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-")),
-    wav: null, partPath: null, outPath: null,
+    wav: null, partPath, outPath,
     stderr: "", done: null,
     // ffmpeg's complaint is in the last lines; the rest is progress noise
     err: () => sess.stderr.trim().split("\n").filter(Boolean).slice(-3)
@@ -183,15 +204,9 @@ async function beginExport(fps, name, profileId, hasAudio) {
   exportSessions.set(id, sess);
   return { id, profile: profile.id, label: profile.label, summary: profileSummary(profile) };
 }
-/* Encode into exports/ under a .part name and rename once ffmpeg exits cleanly,
+/* Encode into the paths reserved at /begin; rename .part → final on clean exit
    so an aborted render never leaves something that looks like a finished file. */
 function startEncoder(sess) {
-  const ext = sess.profile.extension;
-  const base = sess.name.replace(/\.(mp4|mov|m4v|mkv|webm)$/i, "");
-  sess.outPath = uniquePath(EXPORTS_DIR, base + ext);
-  // ".part" goes BEFORE the extension — ffmpeg picks its muxer from the
-  // extension, so a trailing ".part" would leave it unable to choose a format
-  sess.partPath = sess.outPath.slice(0, -ext.length) + ".part" + ext;
   const proc = spawn("ffmpeg", buildExportArgs(sess.profile, {
     fps: sess.fps, wavPath: sess.wav, outPath: sess.partPath,
   }), { stdio: ["pipe", "ignore", "pipe"] });

--- a/server.js
+++ b/server.js
@@ -26,9 +26,8 @@ const {
   resolveProfile,
   listProfilesPublic,
   profileSummary,
-  buildVideoEncodeArgs,
-  buildMuxArgs,
-  exportOutputExtension,
+  buildExportArgs,
+  dryRunProfile,
 } = require("./encode-profiles");
 
 const {
@@ -163,32 +162,52 @@ async function faststart(file) {
 
 /* ── Fast export sessions ──
    The browser renders frames with its own compositor and streams them here as
-   JPEGs; ffmpeg encodes them (plus an optional WAV mix) into a real MP4. */
+   JPEGs; a single ffmpeg pass encodes them plus the WAV mix into the final file.
+   ffmpeg is spawned on the FIRST frame, not here: the audio mix is uploaded
+   between /begin and the first frame, and a one-pass encode needs it on disk. */
 const exportSessions = new Map();
-function beginExport(fps, name, profileId) {
+function beginExport(fps, name, profileId, hasAudio) {
   const profile = resolveProfile(profileId);
+  const dry = dryRunProfile(profile, { fps, hasAudio });
+  if (!dry.ok) throw new Error(`profile "${profile.id}" was rejected by ffmpeg: ${dry.error}`);
   const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-"));
-  const videoPath = path.join(dir, "video.mp4");
-  const proc = spawn("ffmpeg", buildVideoEncodeArgs(profile, fps, videoPath),
-    { stdio: ["pipe", "ignore", "pipe"] });
-  let stderr = "";
-  proc.stderr.on("data", (d) => { stderr = (stderr + d).slice(-2000); });
-  proc.stdin.on("error", () => {}); // EPIPE if ffmpeg dies mid-stream; surfaced via exit code
   const sess = {
-    proc, dir, videoPath, profile, name: safeName(name || "export"),
-    wav: null, err: () => stderr,
-    done: new Promise((res) => proc.on("close", res)),
+    proc: null, fps, profile, name: safeName(name || "export"),
+    dir: fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-")),
+    wav: null, partPath: null, outPath: null,
+    stderr: "", done: null,
+    // ffmpeg's complaint is in the last lines; the rest is progress noise
+    err: () => sess.stderr.trim().split("\n").filter(Boolean).slice(-3)
+      .map((l) => l.trim()).join(" · "),
   };
   exportSessions.set(id, sess);
   return { id, profile: profile.id, label: profile.label, summary: profileSummary(profile) };
+}
+/* Encode into exports/ under a .part name and rename once ffmpeg exits cleanly,
+   so an aborted render never leaves something that looks like a finished file. */
+function startEncoder(sess) {
+  const ext = sess.profile.extension;
+  const base = sess.name.replace(/\.(mp4|mov|m4v|mkv|webm)$/i, "");
+  sess.outPath = uniquePath(EXPORTS_DIR, base + ext);
+  // ".part" goes BEFORE the extension — ffmpeg picks its muxer from the
+  // extension, so a trailing ".part" would leave it unable to choose a format
+  sess.partPath = sess.outPath.slice(0, -ext.length) + ".part" + ext;
+  const proc = spawn("ffmpeg", buildExportArgs(sess.profile, {
+    fps: sess.fps, wavPath: sess.wav, outPath: sess.partPath,
+  }), { stdio: ["pipe", "ignore", "pipe"] });
+  proc.stderr.on("data", (d) => { sess.stderr = (sess.stderr + d).slice(-2000); });
+  proc.stdin.on("error", () => { }); // EPIPE if ffmpeg dies mid-stream; surfaced via exit code
+  sess.proc = proc;
+  sess.done = new Promise((res) => proc.on("close", res));
+  return proc;
 }
 function cleanupExport(id) {
   const s = exportSessions.get(id);
   if (!s) return;
   exportSessions.delete(id);
-  try { s.proc.kill(); } catch {}
+  try { s.proc?.kill(); } catch {}
   try { fs.rmSync(s.dir, { recursive: true, force: true }); } catch {}
+  if (s.partPath) try { fs.rmSync(s.partPath, { force: true }); } catch {}
 }
 
 /* Static file with HTTP Range support (required for <video> seeking) */
@@ -326,9 +345,10 @@ const server = http.createServer(async (req, res) => {
     try {
       const opts = JSON.parse((await readBody(req)).toString("utf8") || "{}");
       if (opts.profile) resolveProfile(opts.profile); // 400, not 500, on a bad id
-      sendJSON(res, 200, beginExport(opts.fps || 30, opts.name, opts.profile));
+      sendJSON(res, 200, beginExport(opts.fps || 30, opts.name, opts.profile, opts.hasAudio !== false));
     } catch (e) {
-      const bad = /^Unknown encoding profile/.test(e.message || "");
+      // an unusable profile is the caller's problem, not a server fault
+      const bad = /^Unknown encoding profile|was rejected by ffmpeg/.test(e.message || "");
       sendJSON(res, bad ? 400 : 500, { error: String(e.message || e) });
     }
     return;
@@ -338,9 +358,10 @@ const server = http.createServer(async (req, res) => {
     if (!sess) { sendJSON(res, 404, { error: "no such export session" }); return; }
     try {
       const body = await readBody(req);
-      if (sess.proc.exitCode !== null) throw new Error("ffmpeg exited: " + sess.err());
-      if (!sess.proc.stdin.write(body))
-        await new Promise((r) => sess.proc.stdin.once("drain", r));
+      const proc = sess.proc || startEncoder(sess); // the WAV has landed by now
+      if (proc.exitCode !== null) throw new Error("ffmpeg exited: " + sess.err());
+      if (!proc.stdin.write(body))
+        await new Promise((r) => proc.stdin.once("drain", r));
       sendJSON(res, 200, { ok: true });
     } catch (e) { sendJSON(res, 500, { error: String(e) }); }
     return;
@@ -361,14 +382,13 @@ const server = http.createServer(async (req, res) => {
     if (!sess) { sendJSON(res, 404, { error: "no such export session" }); return; }
     try {
       if (url.searchParams.get("discard")) { cleanupExport(id); sendJSON(res, 200, { ok: true }); return; }
+      if (!sess.proc) throw new Error("no frames were uploaded");
       sess.proc.stdin.end();
       const code = await sess.done;
       if (code !== 0) throw new Error("ffmpeg encode failed: " + sess.err());
-      const profile = sess.profile || resolveProfile();
-      const ext = exportOutputExtension(profile);
-      const out = uniquePath(EXPORTS_DIR, sess.name.replace(/\.(mp4|mov|m4v|mkv)$/i, "") + ext);
-      const wav = sess.wav && fs.existsSync(sess.wav) ? sess.wav : null;
-      await run("ffmpeg", buildMuxArgs(profile, sess.videoPath, wav, out));
+      const out = sess.outPath;
+      fs.renameSync(sess.partPath, out);
+      sess.partPath = null; // renamed — cleanup must not delete the finished file
       cleanupExport(id);
       sendJSON(res, 200, { ok: true, src: "/exports/" + encodeURIComponent(path.basename(out)) });
     } catch (e) { cleanupExport(id); sendJSON(res, 500, { error: String(e) }); }

--- a/server.js
+++ b/server.js
@@ -166,9 +166,9 @@ async function faststart(file) {
    ffmpeg is spawned on the FIRST frame, not here: the audio mix is uploaded
    between /begin and the first frame, and a one-pass encode needs it on disk. */
 const exportSessions = new Map();
-function beginExport(fps, name, profileId, hasAudio) {
+async function beginExport(fps, name, profileId, hasAudio) {
   const profile = resolveProfile(profileId);
-  const dry = dryRunProfile(profile, { fps, hasAudio });
+  const dry = await dryRunProfile(profile, { fps, hasAudio });
   if (!dry.ok) throw new Error(`profile "${profile.id}" was rejected by ffmpeg: ${dry.error}`);
   const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
   const sess = {
@@ -345,7 +345,7 @@ const server = http.createServer(async (req, res) => {
     try {
       const opts = JSON.parse((await readBody(req)).toString("utf8") || "{}");
       if (opts.profile) resolveProfile(opts.profile); // 400, not 500, on a bad id
-      sendJSON(res, 200, beginExport(opts.fps || 30, opts.name, opts.profile, opts.hasAudio !== false));
+      sendJSON(res, 200, await beginExport(opts.fps || 30, opts.name, opts.profile, opts.hasAudio !== false));
     } catch (e) {
       // an unusable profile is the caller's problem, not a server fault
       const bad = /^Unknown encoding profile|was rejected by ffmpeg/.test(e.message || "");

--- a/server.js
+++ b/server.js
@@ -199,7 +199,7 @@ async function beginExport(fps, name, profileId, hasAudio) {
   // cannot both see the same free path. The empty .part file is overwritten by ffmpeg (-y).
   const { outPath, partPath } = reserveExportPaths(EXPORTS_DIR, safe, profile.extension);
   const sess = {
-    proc: null, fps, profile, name: safe,
+    proc: null, fps, profile, name: safe, hasAudio: !!hasAudio,
     dir: fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-")),
     wav: null, partPath, outPath,
     stderr: "", done: null,
@@ -415,7 +415,11 @@ const server = http.createServer(async (req, res) => {
     if (!sess) { sendJSON(res, 404, { error: "no such export session" }); return; }
     try {
       const body = await readBody(req);
-      if (!sess.proc) startEncoder(sess); // the WAV has landed by now
+      if (sess.hasAudio && !sess.wav) {
+        sendJSON(res, 409, { error: "audio mix has not been uploaded yet" });
+        return;
+      }
+      if (!sess.proc) startEncoder(sess);
       await writeExportFrame(sess, body);
       sendJSON(res, 200, { ok: true });
     } catch (e) {
@@ -428,8 +432,9 @@ const server = http.createServer(async (req, res) => {
     const sess = exportSessions.get(url.searchParams.get("id"));
     if (!sess) { sendJSON(res, 404, { error: "no such export session" }); return; }
     try {
-      sess.wav = path.join(sess.dir, "audio.wav");
-      fs.writeFileSync(sess.wav, await readBody(req));
+      const wavPath = path.join(sess.dir, "audio.wav");
+      fs.writeFileSync(wavPath, await readBody(req));
+      sess.wav = wavPath;
       sendJSON(res, 200, { ok: true });
     } catch (e) { sendJSON(res, 500, { error: String(e) }); }
     return;

--- a/server.js
+++ b/server.js
@@ -5,8 +5,10 @@
    Adds to the browser editor:
      • persistent project      ./project.json      (GET/PUT /api/project)
      • media library folder    ./media/            (served at /media/*, POST /api/upload)
-     • live reload             GET /api/events     (SSE; fires when project.json
-                                                    or ./media changes on disk)
+     • live reload             GET /api/events     (SSE: event "change" for
+                                                    project/media/library;
+                                                    event "profiles" for
+                                                    encoding-profiles.json)
 
    Automation: any tool (e.g. Claude Code) can edit project.json or drop files
    into ./media — the browser UI reloads instantly. Schema: see CLAUDE.md.
@@ -92,23 +94,27 @@ if (!fs.existsSync(PROJECT_FILE)) {
 
 /* ── SSE clients + file watching ── */
 const sseClients = new Set();
-function broadcast() {
-  for (const res of sseClients) res.write(`data: change\n\n`);
+function broadcast(event = "change") {
+  const payload = `event: ${event}\ndata: ${event}\n\n`;
+  for (const res of sseClients) res.write(payload);
 }
 let debounce = null;
+let profilesDebounce = null;
 function onFsChange() {
   clearTimeout(debounce);
-  debounce = setTimeout(broadcast, 150);
+  debounce = setTimeout(() => broadcast("change"), 150);
+}
+function onProfilesChange() {
+  invalidateEncodeProfiles();
+  clearTimeout(profilesDebounce);
+  profilesDebounce = setTimeout(() => broadcast("profiles"), 150);
 }
 /* watch the directory, not the file — atomic tmp+rename writes would detach a
    direct file watcher on Windows */
 try { fs.watch(DATA_DIR, (ev, f) => { if (f === "project.json") onFsChange(); }); } catch {}
 try {
   fs.watch(ROOT, (ev, f) => {
-    if (f === path.basename(PROFILES_FILE)) {
-      invalidateEncodeProfiles();
-      onFsChange();
-    }
+    if (f === path.basename(PROFILES_FILE)) onProfilesChange();
   });
 } catch {}
 try { fs.watch(MEDIA_DIR, onFsChange); } catch {}
@@ -211,10 +217,45 @@ function startEncoder(sess) {
     fps: sess.fps, wavPath: sess.wav, outPath: sess.partPath,
   }), { stdio: ["pipe", "ignore", "pipe"] });
   proc.stderr.on("data", (d) => { sess.stderr = (sess.stderr + d).slice(-2000); });
-  proc.stdin.on("error", () => { }); // EPIPE if ffmpeg dies mid-stream; surfaced via exit code
+  // EPIPE on end()/late writes is normal once ffmpeg has exited; writeExportFrame
+  // attaches its own error listener while a backpressured write is in flight.
+  proc.stdin.on("error", () => { });
   sess.proc = proc;
   sess.done = new Promise((res) => proc.on("close", res));
   return proc;
+}
+/** Write one JPEG frame to ffmpeg stdin. If the pipe is full, wait for drain —
+ *  but also reject if ffmpeg exits or the stdin errors, so the HTTP request
+ *  cannot hang forever after a failed encode. */
+function writeExportFrame(sess, body) {
+  const proc = sess.proc;
+  return new Promise((resolve, reject) => {
+    if (!proc || proc.exitCode !== null || proc.killed)
+      return reject(new Error("ffmpeg exited: " + sess.err()));
+
+    let settled = false;
+    const finish = (fn, arg) => {
+      if (settled) return;
+      settled = true;
+      proc.off("close", onClose);
+      proc.stdin.off("error", onErr);
+      proc.stdin.off("drain", onDrain);
+      fn(arg);
+    };
+    const onClose = () => finish(reject, new Error("ffmpeg exited: " + (sess.err() || "closed")));
+    const onErr = (e) => finish(reject, new Error(e?.message || "ffmpeg stdin error"));
+    const onDrain = () => finish(resolve);
+
+    proc.once("close", onClose);
+    proc.stdin.once("error", onErr);
+    let ok;
+    try { ok = proc.stdin.write(body); }
+    catch (e) { return finish(reject, e); }
+    if (proc.exitCode !== null)
+      return finish(reject, new Error("ffmpeg exited: " + sess.err()));
+    if (ok) finish(resolve);
+    else proc.stdin.once("drain", onDrain);
+  });
 }
 function cleanupExport(id) {
   const s = exportSessions.get(id);
@@ -369,16 +410,18 @@ const server = http.createServer(async (req, res) => {
     return;
   }
   if (p === "/api/export/frame" && req.method === "POST") {
-    const sess = exportSessions.get(url.searchParams.get("id"));
+    const id = url.searchParams.get("id");
+    const sess = exportSessions.get(id);
     if (!sess) { sendJSON(res, 404, { error: "no such export session" }); return; }
     try {
       const body = await readBody(req);
-      const proc = sess.proc || startEncoder(sess); // the WAV has landed by now
-      if (proc.exitCode !== null) throw new Error("ffmpeg exited: " + sess.err());
-      if (!proc.stdin.write(body))
-        await new Promise((r) => proc.stdin.once("drain", r));
+      if (!sess.proc) startEncoder(sess); // the WAV has landed by now
+      await writeExportFrame(sess, body);
       sendJSON(res, 200, { ok: true });
-    } catch (e) { sendJSON(res, 500, { error: String(e) }); }
+    } catch (e) {
+      cleanupExport(id);
+      sendJSON(res, 500, { error: String(e.message || e) });
+    }
     return;
   }
   if (p === "/api/export/audio" && req.method === "POST") {

--- a/style.css
+++ b/style.css
@@ -1794,6 +1794,43 @@ body.track-size-s .clip .clip-kf-n {
   line-height: 1.4;
 }
 
+.export-profile-row {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-2);
+}
+
+.export-profile-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.export-profile-sel {
+  width: 100%;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+}
+
+.export-profile-note,
+.export-profile-hint {
+  margin: 6px 0 0;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.export-profile-hint {
+  opacity: 0.75;
+}
+
 .export-track-warn.hidden {
   display: none;
 }

--- a/style.css
+++ b/style.css
@@ -1811,13 +1811,13 @@ body.track-size-s .clip .clip-kf-n {
 
 .export-profile-sel {
   width: 100%;
-  padding: 7px 10px;
+  padding: 6px 10px;
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--panel);
   color: var(--text);
   font: inherit;
-  font-size: 13px;
+  font-size: 12px;
 }
 
 .export-profile-note,

--- a/test/mcp-protocol.test.js
+++ b/test/mcp-protocol.test.js
@@ -81,7 +81,8 @@ test("tools/list advertises well-formed tools", async (t) => {
   // The documented surface must stay present; extra tools are allowed to appear.
   const names = result.tools.map((x) => x.name);
   for (const expected of ["fablecut_status", "fablecut_docs", "fablecut_get_project",
-    "fablecut_set_project", "fablecut_patch_project", "fablecut_import_media"]) {
+    "fablecut_set_project", "fablecut_patch_project", "fablecut_import_media",
+    "fablecut_analyze_reference", "fablecut_encode_profiles"]) {
     assert.ok(names.includes(expected), `missing documented tool ${expected}`);
   }
 });

--- a/test/mcp-tools.test.js
+++ b/test/mcp-tools.test.js
@@ -149,6 +149,33 @@ test("fablecut_set_project refuses to clobber an edit made behind its back", asy
   assert.ok(after.revision > 7, "a forced save still moves the revision forward");
 });
 
+test("fablecut_encode_profiles lists shipped presets and rejects an unknown id", async (t) => {
+  const { mcp } = await boot(t);
+
+  const listed = await mcp.request("tools/list");
+  const names = listed.result.tools.map((x) => x.name);
+  assert.ok(names.includes("fablecut_encode_profiles"), "tools/list must advertise the new tool");
+
+  const summary = JSON.parse((await mcp.callTool("fablecut_encode_profiles")).text);
+  assert.equal(summary.default, "delivery");
+  assert.ok(summary.profiles.delivery, "the shipped delivery profile must be listed");
+  assert.equal(summary.profiles.delivery.args, undefined, "the compact list omits the ffmpeg args array");
+  assert.ok(summary.profiles.delivery.summary, "the compact list still has a summary string");
+
+  const detailed = JSON.parse((await mcp.callTool("fablecut_encode_profiles", { detail: true })).text);
+  assert.ok(Array.isArray(detailed.profiles.delivery.args), "detail:true includes the args array");
+  assert.ok(detailed.profiles.delivery.args.includes("-c:v"), "shipped args look like ffmpeg flags");
+
+  const one = JSON.parse((await mcp.callTool("fablecut_encode_profiles", { profile: "delivery" })).text);
+  assert.equal(one.profile, "delivery");
+  assert.equal(one.extension, ".mp4");
+  assert.ok(Array.isArray(one.args) && one.args.length, "a known id returns its args");
+
+  const miss = await mcp.callTool("fablecut_encode_profiles", { profile: "no-such-profile" });
+  assert.ok(miss.isError, "an unknown profile id must be flagged isError");
+  assert.match(miss.text, /Unknown encoding profile/i);
+});
+
 test("fablecut_set_project validates the document before writing it", async (t) => {
   const { dir, mcp } = await boot(t);
   const before = readProject(dir);

--- a/test/rest-api.test.js
+++ b/test/rest-api.test.js
@@ -104,6 +104,37 @@ test("GET /api/export/ffmpeg reports encoder availability", async (t) => {
   assert.equal(typeof body.available, "boolean");
 });
 
+test("POST /api/export/begin validates the encoding profile", async (t) => {
+  const { base } = await boot(t);
+
+  const listed = await (await fetch(base + "/api/export/profiles")).json();
+  assert.ok(listed.profiles.delivery, "GET /api/export/profiles must list the shipped delivery profile");
+  assert.equal(listed.profiles.delivery.args, undefined, "the compact listing omits args");
+
+  const unknown = await fetch(base + "/api/export/begin", {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fps: 30, name: "t", profile: "no-such-profile", hasAudio: false }),
+  });
+  assert.equal(unknown.status, 400, "an unknown profile id is a client error, not a 500");
+  const unknownBody = await unknown.json();
+  assert.match(unknownBody.error, /Unknown encoding profile/i);
+
+  const ffmpeg = await (await fetch(base + "/api/export/ffmpeg")).json();
+  if (!ffmpeg.available) return;
+
+  const ok = await fetch(base + "/api/export/begin", {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fps: 30, name: "profile-test", profile: "draft", hasAudio: false }),
+  });
+  const body = await ok.json();
+  assert.equal(ok.status, 200, body.error);
+  assert.equal(body.profile, "draft");
+  assert.ok(body.id, "a valid profile starts a session");
+  const end = await fetch(base + "/api/export/end?id=" + encodeURIComponent(body.id) + "&discard=1",
+    { method: "POST" });
+  assert.equal(end.status, 200);
+});
+
 test("the app shell and its assets are served", async (t) => {
   const { base } = await boot(t);
   const index = await fetch(base + "/");


### PR DESCRIPTION
<!-- Thanks for contributing to FableCut! -->

## Add encoding presets for ffmpeg
<img width="459" height="511" alt="image" src="https://github.com/user-attachments/assets/232b9026-1503-4a0b-b68d-91eb29058275" />

Add ffmpeg export profiles that live in `encoding-profiles.json`. During 'fast' export a profile can be set. The existing profile is called **Delivery · H.264 balanced**, three other profiles are added.


``` 
// The definition of a profile:

"delivery": {
      "label": "Delivery · H.264 balanced",
      "description": "Default export — good quality and compatibility.",
      "jpegQuality": 0.95,
      "encode": { "hideBanner": true, "loglevel": "info", "stats": true },
      "video": { "codec": "libx264", "preset": "fast", "crf": 18, "pixFmt": "yuv420p" },
      "audio": { "codec": "aac", "bitrate": "192k" },
      "mux": { "movflags": "+faststart" }
    },
```

## Type of change

- [ ] Bug fix
- [X] New feature (rendering / API)
- [X] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [X] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added selectable export profiles, including Draft, Delivery, High Quality, Broadcast, and ProRes options.
  - Export setup now displays profile descriptions, output formats, hints, and profile-specific image quality.
  - Projects can save a preferred export profile with clear selection priority.
  - Export APIs and tools can list profiles, validate selections, and report active profile details.
  - Added a project frame-rate selector to the monitor header.

- **Documentation**
  - Expanded export documentation with profile configuration, validation, and selection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->