### PR TITLE
Web codecs for encoding in the browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ node_modules/
 .DS_Store
 Thumbs.db
 
+# Nub
+.nub-cache/
+
 project-kesarix-backup-rev197.json
 
 projects_desktops/
+.cursor/mcp.json
+pnpm-lock.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,13 +433,15 @@ obvious cuts were missed, raise it if motion is being misread as cuts.
 - `GET  /api/events`  — SSE: named event `change` when project.json, ./media or
   ./library changes; named event `profiles` when `encoding-profiles.json` changes
   (UI refreshes the export-profile list only — no project reload)
-- Fast export (used by the UI; browser renders frames, ffmpeg encodes):
+- Fast / WebCodecs export (browser compositor → server ffmpeg):
   `GET /api/export/ffmpeg` → `{available}` · `GET /api/export/profiles[?detail=1]` →
-  `{default, profiles, issues}` · `POST /api/export/begin` `{fps,name,profile?,hasAudio?}` →
-  `{id,profile,label,summary}` (**400** if `profile` is not a defined id, or if ffmpeg
-  rejects its args in the dry run)
-  · `POST /api/export/frame?id=` (JPEG body, in order) · `POST /api/export/audio?id=` (WAV
-  body — must be sent before the first frame; ffmpeg is spawned on frame 1)
+  `{default, profiles, issues}` · `POST /api/export/begin`
+  `{fps,name,mode?,profile?,hasAudio?}` → `{id,mode,profile?,label,summary}`
+  (`mode` is `"jpeg"` (default, Fast) or `"annexb"` (WebCodecs H.264 elementary stream);
+  jpeg **400** if `profile` is not a defined id, or if ffmpeg rejects its args in the dry run)
+  · `POST /api/export/frame?id=` (JPEG body for jpeg mode, Annex-B NAL bytes for
+  annexb — must be after audio; ffmpeg is spawned on the first frame in both modes)
+  · `POST /api/export/audio?id=` (WAV body — must be sent before the first frame)
   · `POST /api/export/end?id=[&discard=1]` → `{src}` under `/exports/`
 
 ## Recipes
@@ -556,19 +558,34 @@ Omit `exportFrame` to export the full canvas.
 guides (▦) to keep captions out of platform UI zones.
 
 **Project frame rate**: set `fps` in `project.json` (or the Program Monitor FPS
-dropdown — 24 / 25 / 30 / 50 / 60). Preview stepping, timecode frames, Fast/
-Realtime export, and `/api/export/begin` all use this value; pass the same
+dropdown — 24 / 25 / 30 / 50 / 60). Preview stepping, timecode frames, Fast /
+WebCodecs / Realtime export, and `/api/export/begin` all use this value; pass the same
 `fps` when starting an export via the API.
 
 ## Export
 
-Export is user-driven (Export button → dialog). Two engines: **Fast** (browser
-renders each frame with the normal compositor — including SVG frames, keys and
-AI masks — streams JPEG frames + an offline WAV mix to the server, a single ffmpeg
-pass encodes them via an **encoding profile** into `./exports/`) and **Realtime**
-(MediaRecorder fallback). Claude cannot trigger export headlessly — the
-compositor lives in the browser; ask the user to click Export, or render with
-ffmpeg directly from `media/` sources if a file is needed.
+Export is user-driven (Export button → dialog). Three engines:
+
+1. **Fast** — browser renders each frame with the normal compositor (SVG, keys,
+   AI masks), streams JPEGs + an offline WAV mix to the server; a single ffmpeg
+   pass encodes them via an **encoding profile** into `./exports/`. Quality /
+   software path; keeps rendering if you switch tabs.
+2. **WebCodecs** — same frame-accurate compositor loop, but the browser’s
+   `VideoEncoder` produces Annex-B H.264 (Main 4:2:0) and the server stream-copies
+   (`-c:v copy`) while muxing the WAV. Faster uploads, less server CPU. Requires
+   Chromium-class `VideoEncoder` with `avc: { format: "annexb" }` plus ffmpeg.
+   Encoding profiles do not apply (the bitstream is already encoded). No ffmpeg-style
+   CRF — quality is bitrate + VBR/CBR (export dialog; remembered in localStorage).
+   Optional `bitrateMode: "quantizer"` (fixed QP) exists in the spec but is rarely
+   supported by hardware encoders with Annex-B. Unavailable while an `exportFrame`
+   crop is set — use Fast for cropped delivery.
+3. **Realtime (MediaRecorder)** — automatic offline fallback when the server,
+   ffmpeg, or WebCodecs is unavailable. Plays the timeline once and records it;
+   keep the tab focused.
+
+Claude cannot trigger export headlessly — the compositor lives in the browser;
+ask the user to click Export, or render with ffmpeg directly from `media/`
+sources if a file is needed.
 
 ### Encoding profiles (`encoding-profiles.json`)
 
@@ -576,7 +593,7 @@ User-editable at the repo root. A profile is a **raw ffmpeg argument list** plus
 things that are not ffmpeg arguments: `jpegQuality` (browser frame quality),
 `extension` (output container), and optional `color` (output matrix / range tags).
 Edit the file while the server runs — the UI hot-reloads the profile list via an SSE
-`profiles` event (no full project reload).
+`profiles` event (no full project reload). Fast export only; WebCodecs ignores them.
 
 ```jsonc
 {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,8 +440,9 @@ obvious cuts were missed, raise it if motion is being misread as cuts.
   (`fps` is required — pass `project.fps`, no server-side default;
   `mode` is `"jpeg"` (default, Fast) or `"annexb"` (WebCodecs H.264 elementary stream);
   jpeg **400** if `profile` is not a defined id, or if ffmpeg rejects its args in the dry run)
-  · `POST /api/export/frame?id=` (JPEG body for jpeg mode, Annex-B NAL bytes for
-  annexb — must be after audio; ffmpeg is spawned on the first frame in both modes)
+  · `POST /api/export/frame?id=` (JPEG body for jpeg mode; Annex-B bytes for
+  annexb — one POST may carry several concatenated AUs. Must be after audio;
+  ffmpeg is spawned on the first frame in both modes)
   · `POST /api/export/audio?id=` (WAV body — must be sent before the first frame)
   · `POST /api/export/end?id=[&discard=1]` → `{src}` under `/exports/`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
 ```jsonc
 {
   "name": "My Edit",
-  "width": 1280, "height": 720, "fps": 30,   // composition canvas + timeline/export rate (UI: FPS select)
+  "width": 1280, "height": 720, "fps": 30,   // composition canvas + timeline/export rate — sole FPS source (UI: FPS select)
   "exportFrame": { "x": 438, "y": 0, "w": 404, "h": 720 },  // optional delivery crop (even w/h for H.264)
   // ^ omit = export the full canvas. Preview dims outside this rect; Fast export crops
   // JPEGs to w×h. Clip x/y/scale stay relative to the composition center, not the frame.
@@ -437,7 +437,8 @@ obvious cuts were missed, raise it if motion is being misread as cuts.
   `GET /api/export/ffmpeg` → `{available}` · `GET /api/export/profiles[?detail=1]` →
   `{default, profiles, issues}` · `POST /api/export/begin`
   `{fps,name,mode?,profile?,hasAudio?}` → `{id,mode,profile?,label,summary}`
-  (`mode` is `"jpeg"` (default, Fast) or `"annexb"` (WebCodecs H.264 elementary stream);
+  (`fps` is required — pass `project.fps`, no server-side default;
+  `mode` is `"jpeg"` (default, Fast) or `"annexb"` (WebCodecs H.264 elementary stream);
   jpeg **400** if `profile` is not a defined id, or if ffmpeg rejects its args in the dry run)
   · `POST /api/export/frame?id=` (JPEG body for jpeg mode, Annex-B NAL bytes for
   annexb — must be after audio; ffmpeg is spawned on the first frame in both modes)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ same time.
 - **Export frame / reframing** — composition canvas can be larger than the delivery
   crop (`exportFrame` in `project.json`). Preview dims the overscan; drag the
   **Export frame** handle to reframe (e.g. 16:9 canvas → 9:16 export). Fast export
-  crops to the frame; Realtime export is disabled while a frame is set
+  crops to the frame; WebCodecs and Realtime export are disabled while a frame is set
 - **Program Monitor zoom** — mouse-wheel over the preview zooms the composition
   toward the cursor (fit → up to **2 screen pixels per canvas pixel**). Magnified
   view uses **native scrollbars** so overflow stays reachable; middle-click or
@@ -180,7 +180,10 @@ same time.
   encodes them via an **encoding profile** from `encoding-profiles.json`
   (keeps rendering if you switch tabs). The Export dialog has a profile
   selector; pin a project default with `encodeProfile` in `project.json`
-- Realtime MediaRecorder fallback when ffmpeg isn't available
+- WebCodecs export: the browser HW-encodes Annex-B H.264; the server
+  stream-copies and muxes audio. Faster uploads; bitrate/VBR-CBR in the
+  Export dialog. Unavailable while an export frame is set (use Fast)
+- Realtime MediaRecorder fallback when ffmpeg or WebCodecs isn't available
 
 ## Quick start
 

--- a/app.js
+++ b/app.js
@@ -5587,9 +5587,39 @@ function previewToExportBlob(quality = 0.95) {
    HTMLVideoElement has no “step one frame” API — assigning currentTime always
    seeks. On the export hot path a seek-per-frame is the dominant cost, so:
      • already within ½ media-frame → no-op
-     • small forward step + buffered → brief play + requestVideoFrameCallback
-       (sequential decode from the current position, then pause)
-     • reverse / large jump / unbuffered → hard seek (same as before) */
+     • forward through a shot, buffered → play + requestVideoFrameCallback.
+       If the last compositor tick was faster than a timeline frame, leave the
+       element playing (no play/pause per frame). If it was slower (typical Fast
+       JPEG upload), pause after the hit so the file cannot overrun.
+     • reverse / large jump / unbuffered / overshoot → hard seek
+   Incoming clips are seek-prefetched ~1 s before they become active. */
+let exportSeekClock = 0;
+function restoreExportVideoState() {
+  exportSeekClock = 0;
+  for (const el of runtime.clipEls.values()) {
+    try { if (!el.paused) el.pause(); } catch { }
+    if (el._fcPrevMuted != null) {
+      try { el.muted = el._fcPrevMuted; } catch { }
+      el._fcPrevMuted = null;
+    }
+  }
+}
+function videoRangeBuffered(el, from, to) {
+  try {
+    const b = el.buffered;
+    const a = Math.min(from, to), z = Math.max(from, to);
+    for (let i = 0; i < b.length; i++) {
+      if (b.start(i) <= a + 0.05 && b.end(i) >= z - 0.05) return true;
+    }
+  } catch { }
+  return el.readyState >= 3;
+}
+function assignVideoTime(el, mt) {
+  if (typeof el.fastSeek === "function") {
+    try { el.fastSeek(mt); return; } catch { }
+  }
+  el.currentTime = mt;
+}
 function hardSeekVideo(el, mt) {
   return new Promise((res) => {
     if (Math.abs(el.currentTime - mt) < 1e-4 && el.readyState >= 2) { res(); return; }
@@ -5602,20 +5632,19 @@ function hardSeekVideo(el, mt) {
     el.addEventListener("seeked", done);
     try {
       if (!el.paused) el.pause();
-      el.currentTime = mt;
+      assignVideoTime(el, mt);
     } catch { done(); }
   });
 }
-/** Play forward until mediaTime reaches mt, then pause. (Must pause: the export
-    loop does async work between frames, so a free-running element would overrun.) */
-function playAdvanceVideo(el, mt, eps, rate) {
+/** Play forward until mediaTime reaches mt. Pause afterwards unless keepPlaying
+    — a free-running element overruns while the compositor does SVG/encode/HTTP. */
+function playAdvanceVideo(el, mt, eps, rate, { keepPlaying } = {}) {
   return new Promise((res) => {
     let settled = false;
     let rvfcId = null;
     let poll = null;
-    const prevMuted = el.muted;
-    let prevRate = 1;
-    try { prevRate = el.playbackRate; } catch { }
+    if (el._fcPrevMuted == null) el._fcPrevMuted = el.muted;
+    const wasPlaying = !el.paused;
     const cleanup = () => {
       clearTimeout(tm);
       if (poll) { clearInterval(poll); poll = null; }
@@ -5623,9 +5652,9 @@ function playAdvanceVideo(el, mt, eps, rate) {
         try { el.cancelVideoFrameCallback(rvfcId); } catch { }
         rvfcId = null;
       }
-      try { el.pause(); } catch { }
-      try { el.muted = prevMuted; } catch { }
-      try { el.playbackRate = prevRate; } catch { }
+      if (!keepPlaying) {
+        try { el.pause(); } catch { }
+      }
     };
     const finish = () => {
       if (settled) return;
@@ -5654,6 +5683,8 @@ function playAdvanceVideo(el, mt, eps, rate) {
     } else {
       poll = setInterval(() => check(el.currentTime), 4);
     }
+    check(el.currentTime);
+    if (wasPlaying) return;
     const p = el.play();
     if (p && typeof p.catch === "function") {
       p.catch(() => {
@@ -5665,8 +5696,31 @@ function playAdvanceVideo(el, mt, eps, rate) {
     }
   });
 }
+const EXPORT_PREFETCH_S = 1.25;
+function prefetchExportVideos(t) {
+  for (const c of project.clips) {
+    if (c.kind !== "video" || !isTrackEnabled(c.track)) continue;
+    if (activeAt(c, t)) continue;
+    if (c.start > t + EXPORT_PREFETCH_S || clipEnd(c) <= t) continue;
+    const el = getClipEl(c);
+    if (!el) continue;
+    const mt = mediaTimeAt(c, Math.max(t, c.start));
+    if (Math.abs(el.currentTime - mt) < 0.08) continue;
+    try {
+      if (!el.paused) el.pause();
+      assignVideoTime(el, mt);
+    } catch { }
+  }
+}
 async function seekVideosTo(t) {
   const fps = projectFps();
+  const now = performance.now();
+  const frameMs = 1000 / fps;
+  // Last compositor+upload tick faster than a timeline frame → decoder can
+  // stay in play() through the shot. Slower (Fast JPEG) → pause so we don't
+  // overshoot and seek backwards every frame.
+  const keepPlaying = exportSeekClock > 0 && (now - exportSeekClock) < frameMs * 1.4;
+  exportSeekClock = now;
   const waits = [];
   const restoreGain = [];
   for (const c of project.clips) {
@@ -5675,6 +5729,10 @@ async function seekVideosTo(t) {
     const el = getClipEl(c); if (!el) continue;
     if (!activeAt(c, t)) {
       if (!el.paused) el.pause();
+      if (el._fcPrevMuted != null) {
+        try { el.muted = el._fcPrevMuted; } catch { }
+        el._fcPrevMuted = null;
+      }
       const g = runtime.clipGain.get(c.id);
       if (g) g.gain.value = clamp(evalProps(c, t).volume, 0, 4);
       continue;
@@ -5685,7 +5743,15 @@ async function seekVideosTo(t) {
     // One timeline frame in media-time; half-frame = “already on the right frame”
     const mediaFrame = sp / fps;
     const eps = 0.5 * mediaFrame;
-    if (el.readyState >= 2 && Math.abs(el.currentTime - mt) <= eps) continue;
+    const err = el.currentTime - mt;
+    if (el.readyState >= 2 && Math.abs(err) <= eps) {
+      if (keepPlaying && !el.paused) {
+        try { el.playbackRate = sp; } catch { }
+      }
+      continue;
+    }
+    // Keep-playing path: a slightly late displayed frame is cheaper than a seek
+    if (keepPlaying && !el.paused && err > 0 && err <= eps * 2) continue;
 
     const g = runtime.clipGain.get(c.id);
     if (g) {
@@ -5694,10 +5760,14 @@ async function seekVideosTo(t) {
     }
 
     const delta = mt - el.currentTime;
-    // ~4 timeline frames forward + data in buffer → sequential play instead of seek storm
-    const maxPlay = mediaFrame * 4;
-    if (delta > eps && delta <= maxPlay && el.readyState >= 2) {
-      waits.push(playAdvanceVideo(el, mt, eps, sp));
+    const alreadyPlaying = !el.paused;
+    const maxPlay = alreadyPlaying || keepPlaying
+      ? Math.min(3, Math.max(2, mediaFrame * 60))
+      : Math.min(1, Math.max(0.5, mediaFrame * 16));
+    const canPlayFwd = delta > eps && delta <= maxPlay
+      && (alreadyPlaying || (el.readyState >= 2 && videoRangeBuffered(el, el.currentTime, mt)));
+    if (canPlayFwd) {
+      waits.push(playAdvanceVideo(el, mt, eps, sp, { keepPlaying }));
     } else {
       waits.push(hardSeekVideo(el, mt));
     }
@@ -5707,6 +5777,7 @@ async function seekVideosTo(t) {
     const g = runtime.clipGain.get(c.id);
     if (g) g.gain.value = clamp(evalProps(c, t).volume, 0, 4);
   }
+  prefetchExportVideos(t);
 }
 function encodeWAV(buf) {
   const ch = buf.numberOfChannels, len = buf.length, sr = buf.sampleRate;
@@ -5784,6 +5855,7 @@ async function fastExport() {
   els.exportOverlay.classList.remove("hidden");
   els.exportProgress.style.width = "0%";
   els.exportNote.textContent = "Rendering frames → ffmpeg. You can switch tabs; export continues.";
+  restoreExportVideoState();
   const fps = projectFps(), dur = Math.max(1 / fps, projDur());
   const frames = Math.max(1, Math.round(dur * fps));
   let sessId = null;
@@ -5837,6 +5909,7 @@ async function fastExport() {
     if (sessId) fetch("/api/export/end?id=" + sessId + "&discard=1", { method: "POST" }).catch(() => { });
     if (String(e.message) !== "cancelled") alert("Export failed: " + e.message);
   } finally {
+    restoreExportVideoState();
     state.exporting = false; state.rendering = false;
     els.exportOverlay.classList.add("hidden");
     els.exportNote.textContent = "Rendering your sequence in real time. Keep this tab focused.";
@@ -5846,7 +5919,9 @@ async function fastExport() {
 
 /* ── WebCodecs export (browser H.264 → server mux) ── */
 /* Uploads MUST be strictly sequential — concurrent /frame POSTs race on the
-   same ffmpeg stdin and deadlock the pipe (progress freezes around a few %). */
+   same ffmpeg stdin and deadlock the pipe. Annex-B AUs concatenate (start
+   codes), so we batch them: first AU starts ffmpeg, later POSTs carry ~12 AUs
+   or ~128 KiB so HTTP headers stop dominating the payload. */
 let webCodecsAbort = null;
 function waitEncodeQueue(encoder, max = 2, { signal, getError } = {}) {
   const cancelled = () => renderCancelled || !!(signal && signal.aborted);
@@ -5887,15 +5962,28 @@ async function webCodecsExport() {
   els.exportOverlay.classList.remove("hidden");
   els.exportProgress.style.width = "0%";
   els.exportNote.textContent = "Encoding with WebCodecs → ffmpeg mux. You can switch tabs; export continues.";
+  restoreExportVideoState();
   const fps = projectFps(), dur = Math.max(1 / fps, projDur());
   const frames = Math.max(1, Math.round(dur * fps));
   const keyEvery = Math.max(1, Math.round(fps * 2));
   let sessId = null;
   let encoder = null;
   let uploadError = null;
-  // single-flight upload chain: each NAL waits for the previous POST to finish
+  // single-flight POST chain; each body may be several concatenated Annex-B AUs
+  const BATCH_AUS = 12;
+  const BATCH_BYTES = 128 * 1024;
+  let batch = [];
+  let batchBytes = 0;
+  let sentFirstAu = false;
   let uploadTail = Promise.resolve();
   let uploadsInFlight = 0;
+  const concatAus = (parts, n) => {
+    if (parts.length === 1) return parts[0];
+    const out = new Uint8Array(n);
+    let o = 0;
+    for (const p of parts) { out.set(p, o); o += p.length; }
+    return out;
+  };
   const enqueueUpload = (buf) => {
     uploadsInFlight++;
     // recover from a prior rejection so one failed POST doesn't stall the chain
@@ -5911,6 +5999,21 @@ async function webCodecsExport() {
       if (!uploadError) uploadError = err;
     }).finally(() => { uploadsInFlight--; });
     return p;
+  };
+  const flushBatch = (force) => {
+    if (!batch.length) return;
+    const first = !sentFirstAu;
+    if (!force && !first && batchBytes < BATCH_BYTES && batch.length < BATCH_AUS) return;
+    sentFirstAu = true;
+    const parts = batch, n = batchBytes;
+    batch = [];
+    batchBytes = 0;
+    enqueueUpload(concatAus(parts, n));
+  };
+  const enqueueAu = (buf) => {
+    batch.push(buf);
+    batchBytes += buf.length;
+    flushBatch(false);
   };
   const waitUploadBackpressure = (max = 2) => new Promise((res, rej) => {
     const tick = () => {
@@ -5958,7 +6061,7 @@ async function webCodecsExport() {
         if (uploadError || renderCancelled || signal.aborted) return;
         const buf = new Uint8Array(chunk.byteLength);
         chunk.copyTo(buf);
-        enqueueUpload(buf);
+        enqueueAu(buf);
       },
       error: (e) => { uploadError = e; },
     });
@@ -5997,6 +6100,7 @@ async function webCodecsExport() {
     }
     els.exportTitle.textContent = "Finishing…";
     await encoder.flush();
+    flushBatch(true);
     await uploadTail;
     if (uploadError) throw uploadError;
     encoder.close();
@@ -6014,6 +6118,7 @@ async function webCodecsExport() {
     if (msg !== "cancelled") alert("Export failed: " + msg);
   } finally {
     webCodecsAbort = null;
+    restoreExportVideoState();
     state.exporting = false; state.rendering = false;
     els.exportOverlay.classList.add("hidden");
     els.exportNote.textContent = "Rendering your sequence in real time. Keep this tab focused.";

--- a/app.js
+++ b/app.js
@@ -5571,7 +5571,85 @@ function previewToExportBlob(quality = 0.95) {
     els.preview, ef.x, ef.y, ef.w, ef.h, 0, 0, ef.w, ef.h);
   return new Promise((res) => exportCropCanvas.toBlob(res, "image/jpeg", quality));
 }
+/* ── Fast / WebCodecs frame sync ──
+   HTMLVideoElement has no “step one frame” API — assigning currentTime always
+   seeks. On the export hot path a seek-per-frame is the dominant cost, so:
+     • already within ½ media-frame → no-op
+     • small forward step + buffered → brief play + requestVideoFrameCallback
+       (sequential decode from the current position, then pause)
+     • reverse / large jump / unbuffered → hard seek (same as before) */
+function hardSeekVideo(el, mt) {
+  return new Promise((res) => {
+    if (Math.abs(el.currentTime - mt) < 1e-4 && el.readyState >= 2) { res(); return; }
+    const done = () => {
+      clearTimeout(tm);
+      el.removeEventListener("seeked", done);
+      res();
+    };
+    const tm = setTimeout(done, 1500);
+    el.addEventListener("seeked", done);
+    try {
+      if (!el.paused) el.pause();
+      el.currentTime = mt;
+    } catch { done(); }
+  });
+}
+/** Play forward until mediaTime reaches mt, then pause. (Must pause: the export
+    loop does async work between frames, so a free-running element would overrun.) */
+function playAdvanceVideo(el, mt, eps, rate) {
+  return new Promise((res) => {
+    let settled = false;
+    let rvfcId = null;
+    let poll = null;
+    const cleanup = () => {
+      clearTimeout(tm);
+      if (poll) { clearInterval(poll); poll = null; }
+      if (rvfcId != null && typeof el.cancelVideoFrameCallback === "function") {
+        try { el.cancelVideoFrameCallback(rvfcId); } catch { }
+        rvfcId = null;
+      }
+      try { el.pause(); } catch { }
+    };
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      // Play can land a hair early/late — snap only when meaningfully off
+      if (Math.abs(el.currentTime - mt) > eps * 2)
+        hardSeekVideo(el, mt).then(res);
+      else res();
+    };
+    const remain = Math.max(0, mt - el.currentTime);
+    const tm = setTimeout(finish, Math.min(3000, 400 + (remain * 1000) / Math.max(0.1, rate) * 2.5));
+    const check = (mediaTime) => {
+      if ((mediaTime != null ? mediaTime : el.currentTime) >= mt - eps) finish();
+    };
+    try { el.playbackRate = clamp(rate, 0.1, 8); } catch { }
+    // muted → autoplay-friendly after async export setup (user-gesture may be gone)
+    el.muted = true;
+    if (typeof el.requestVideoFrameCallback === "function") {
+      const onFrame = (_now, meta) => {
+        if (settled) return;
+        check(meta?.mediaTime);
+        if (!settled) rvfcId = el.requestVideoFrameCallback(onFrame);
+      };
+      rvfcId = el.requestVideoFrameCallback(onFrame);
+    } else {
+      poll = setInterval(() => check(el.currentTime), 4);
+    }
+    const p = el.play();
+    if (p && typeof p.catch === "function") {
+      p.catch(() => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        hardSeekVideo(el, mt).then(res);
+      });
+    }
+  });
+}
 function seekVideosTo(t) {
+  const fps = Math.max(1, Number(project.fps) || 30);
   const waits = [];
   for (const c of project.clips) {
     if (c.kind !== "video") continue;
@@ -5579,13 +5657,24 @@ function seekVideosTo(t) {
     const el = getClipEl(c); if (!el) continue;
     if (!activeAt(c, t)) { if (!el.paused) el.pause(); continue; }
     const mt = mediaTimeAt(c, t);
-    if (Math.abs(el.currentTime - mt) < 1e-4 && el.readyState >= 2) continue;
-    waits.push(new Promise((res) => {
-      const done = () => { clearTimeout(tm); el.removeEventListener("seeked", done); res(); };
-      const tm = setTimeout(done, 1500);
-      el.addEventListener("seeked", done);
-      try { el.currentTime = mt; } catch { done(); }
-    }));
+    const local = clamp(t - c.start, 0, c.duration);
+    const sp = clamp(kfChannel(c, "speed", local, clipSpeed(c)), 0.1, 8);
+    // One timeline frame in media-time; half-frame = “already on the right frame”
+    const mediaFrame = sp / fps;
+    const eps = 0.5 * mediaFrame;
+    if (el.readyState >= 2 && Math.abs(el.currentTime - mt) <= eps) continue;
+
+    const g = runtime.clipGain.get(c.id);
+    if (g) g.gain.value = 0;
+
+    const delta = mt - el.currentTime;
+    // ~4 timeline frames forward + data in buffer → sequential play instead of seek storm
+    const maxPlay = mediaFrame * 4;
+    if (delta > eps && delta <= maxPlay && el.readyState >= 2) {
+      waits.push(playAdvanceVideo(el, mt, eps, sp));
+    } else {
+      waits.push(hardSeekVideo(el, mt));
+    }
   }
   return Promise.all(waits);
 }

--- a/app.js
+++ b/app.js
@@ -5366,7 +5366,7 @@ function loop(ts) {
      (frame-accurate, works unfocused) and streams JPEGs + an offline audio
      mix to the server, where ffmpeg encodes via an encoding profile.
    – webcodecs: VideoEncoder Annex-B H.264 → server stream-copy mux
-   – realtime: MediaRecorder, kept as the fallback when WebCodecs or the
+   – realtime: MediaRecorder HW-encode H.264 → server stream-copy mux
      server/ffmpeg is unavailable. */
 
 /* Placeholder until /api/export/profiles answers — the real list (and the real

--- a/app.js
+++ b/app.js
@@ -5954,6 +5954,7 @@ function waitEncodeQueue(encoder, max = 2, { signal, getError } = {}) {
 }
 async function webCodecsExport() {
   if (state.exporting) return;
+  await detectWebCodecs();
   if (!state.webCodecs) { startExport(); return; }
   pause();
   state.exporting = true; state.rendering = true; renderCancelled = false;
@@ -6217,7 +6218,12 @@ $("btnCancelSetup").addEventListener("click", () => els.exportSetup.classList.ad
 els.engineFast?.addEventListener("change", syncExportWcOpts);
 els.engineRealtime?.addEventListener("change", syncExportWcOpts);
 $("exportWcBitrate")?.addEventListener("change", persistExportWcOpts);
-$("exportWcMode")?.addEventListener("change", persistExportWcOpts);
+$("exportWcMode")?.addEventListener("change", async () => {
+  persistExportWcOpts();
+  await detectWebCodecs();
+  syncExportWcOpts();
+  if (!els.exportSetup.classList.contains("hidden")) openExportSetup();
+});
 $("btnCancelExport").addEventListener("click", () => {
   if (state.rendering) {
     renderCancelled = true;

--- a/app.js
+++ b/app.js
@@ -5836,7 +5836,14 @@ async function fastExport() {
 /* Uploads MUST be strictly sequential — concurrent /frame POSTs race on the
    same ffmpeg stdin and deadlock the pipe (progress freezes around a few %). */
 let webCodecsAbort = null;
-function waitEncodeQueue(encoder, max = 2) {
+function waitEncodeQueue(encoder, max = 2, { signal, getError } = {}) {
+  const cancelled = () => renderCancelled || !!(signal && signal.aborted);
+  const failed = () => (getError ? getError() : null);
+  if (cancelled()) return Promise.reject(new Error("cancelled"));
+  {
+    const err = failed();
+    if (err) return Promise.reject(err);
+  }
   if (encoder.encodeQueueSize <= max) return Promise.resolve();
   return new Promise((res, rej) => {
     const done = (err) => {
@@ -5845,11 +5852,15 @@ function waitEncodeQueue(encoder, max = 2) {
       err ? rej(err) : res();
     };
     const tick = () => {
-      if (renderCancelled) done(new Error("cancelled"));
-      else if (encoder.encodeQueueSize <= max) done(null);
+      if (cancelled()) done(new Error("cancelled"));
+      else {
+        const err = failed();
+        if (err) done(err);
+        else if (encoder.encodeQueueSize <= max) done(null);
+      }
     };
     encoder.ondequeue = tick;
-    // ondequeue alone won't notice Cancel — poll the flag
+    // ondequeue alone won't notice Cancel / encoder·upload failure — poll
     const poll = setInterval(tick, 50);
     tick();
   });
@@ -5950,7 +5961,7 @@ async function webCodecsExport() {
       if (renderCancelled || signal.aborted) throw new Error("cancelled");
       if (uploadError) throw uploadError;
       await waitUploadBackpressure(2);
-      await waitEncodeQueue(encoder, 2);
+      await waitEncodeQueue(encoder, 2, { signal, getError: () => uploadError });
       const t = f / fps;
       state.time = t;
       await seekVideosTo(t);

--- a/app.js
+++ b/app.js
@@ -503,16 +503,22 @@ async function detectWebCodecs() {
   state.webCodecs = false;
   try {
     if (typeof VideoEncoder !== "function" || typeof VideoEncoder.isConfigSupported !== "function") return;
-    const cfg = {
+    const base = {
       codec: webCodecsAvcCodec(),
       width: Math.max(2, project.width | 0 || 1280),
       height: Math.max(2, project.height | 0 || 720),
       bitrate: 8_000_000,
       framerate: projectFps(),
       avc: { format: "annexb" },
+      latencyMode: "quality",
     };
-    const { supported } = await VideoEncoder.isConfigSupported(cfg);
-    state.webCodecs = !!supported;
+    const requested = getSetting("webCodecsBitrateMode") === "constant" ? "constant" : "variable";
+    const [variable, constant] = await Promise.all([
+      VideoEncoder.isConfigSupported({ ...base, bitrateMode: "variable" }),
+      VideoEncoder.isConfigSupported({ ...base, bitrateMode: "constant" }),
+    ]);
+    const match = requested === "constant" ? constant : variable;
+    state.webCodecs = !!match.supported;
   } catch { state.webCodecs = false; }
 }
 const TIMELINE_START_TIME = 0.000; // composition timeline start (seconds)

--- a/app.js
+++ b/app.js
@@ -5601,6 +5601,9 @@ function playAdvanceVideo(el, mt, eps, rate) {
     let settled = false;
     let rvfcId = null;
     let poll = null;
+    const prevMuted = el.muted;
+    let prevRate = 1;
+    try { prevRate = el.playbackRate; } catch { }
     const cleanup = () => {
       clearTimeout(tm);
       if (poll) { clearInterval(poll); poll = null; }
@@ -5609,6 +5612,8 @@ function playAdvanceVideo(el, mt, eps, rate) {
         rvfcId = null;
       }
       try { el.pause(); } catch { }
+      try { el.muted = prevMuted; } catch { }
+      try { el.playbackRate = prevRate; } catch { }
     };
     const finish = () => {
       if (settled) return;
@@ -5648,14 +5653,20 @@ function playAdvanceVideo(el, mt, eps, rate) {
     }
   });
 }
-function seekVideosTo(t) {
+async function seekVideosTo(t) {
   const fps = Math.max(1, Number(project.fps) || 30);
   const waits = [];
+  const restoreGain = [];
   for (const c of project.clips) {
     if (c.kind !== "video") continue;
     if (!isTrackEnabled(c.track)) continue;
     const el = getClipEl(c); if (!el) continue;
-    if (!activeAt(c, t)) { if (!el.paused) el.pause(); continue; }
+    if (!activeAt(c, t)) {
+      if (!el.paused) el.pause();
+      const g = runtime.clipGain.get(c.id);
+      if (g) g.gain.value = clamp(evalProps(c, t).volume, 0, 4);
+      continue;
+    }
     const mt = mediaTimeAt(c, t);
     const local = clamp(t - c.start, 0, c.duration);
     const sp = clamp(kfChannel(c, "speed", local, clipSpeed(c)), 0.1, 8);
@@ -5665,7 +5676,10 @@ function seekVideosTo(t) {
     if (el.readyState >= 2 && Math.abs(el.currentTime - mt) <= eps) continue;
 
     const g = runtime.clipGain.get(c.id);
-    if (g) g.gain.value = 0;
+    if (g) {
+      g.gain.value = 0;
+      restoreGain.push(c);
+    }
 
     const delta = mt - el.currentTime;
     // ~4 timeline frames forward + data in buffer → sequential play instead of seek storm
@@ -5676,7 +5690,11 @@ function seekVideosTo(t) {
       waits.push(hardSeekVideo(el, mt));
     }
   }
-  return Promise.all(waits);
+  await Promise.all(waits);
+  for (const c of restoreGain) {
+    const g = runtime.clipGain.get(c.id);
+    if (g) g.gain.value = clamp(evalProps(c, t).volume, 0, 4);
+  }
 }
 function encodeWAV(buf) {
   const ch = buf.numberOfChannels, len = buf.length, sr = buf.sampleRate;

--- a/app.js
+++ b/app.js
@@ -248,7 +248,7 @@ function setSetting(key, value) {
 /* ── State ─────────────────────────────────────────────────────────────── */
 const project = {
   name: "Untitled Project",
-  width: 1280, height: 720, fps: 25,
+  width: 1280, height: 720, fps: 30, // overwritten by project.json / applyProject
   background: "#000000",
   revision: 0,
   folders: [], // {id, name, parentId:null|string, open:true} — Project-bin tree (virtual)
@@ -261,6 +261,11 @@ const project = {
   exportFrame: null, // optional {x,y,w,h} delivery crop inside width×height canvas
   encodeProfile: null, // optional fast-export profile id (overrides browser setting)
 };
+/** Sole runtime FPS source — always the loaded project’s `fps`. */
+function projectFps() {
+  const n = Number(project.fps);
+  return (Number.isFinite(n) && n > 0) ? n : 1;
+}
 const state = {
   time: 0, playing: false, pps: 60, snap: true,
   previewRate: 1,        // playback speed for PREVIEW only — never affects export
@@ -377,7 +382,7 @@ function escapeHtml(s) {
 function fmt(t) {
   t = Math.max(0, t);
   const m = Math.floor(t / 60), s = Math.floor(t % 60),
-    f = Math.floor((t % 1) * project.fps);
+    f = Math.floor((t % 1) * projectFps());
   const p = (n) => String(n).padStart(2, "0");
   return `${p(m)}:${p(s)}:${p(f)}`;
 }
@@ -503,7 +508,7 @@ async function detectWebCodecs() {
       width: Math.max(2, project.width | 0 || 1280),
       height: Math.max(2, project.height | 0 || 720),
       bitrate: 8_000_000,
-      framerate: project.fps || 30,
+      framerate: projectFps(),
       avc: { format: "annexb" },
     };
     const { supported } = await VideoEncoder.isConfigSupported(cfg);
@@ -704,7 +709,8 @@ function applyProject(data) {
   const disabledTracks = normalizeDisabledTracks(data.disabledTracks);
   Object.assign(project, {
     name: data.name || "Untitled Project",
-    width: data.width || 1280, height: data.height || 720, fps: data.fps || 30,
+    width: data.width || 1280, height: data.height || 720,
+    fps: (Number(data.fps) > 0 ? Number(data.fps) : project.fps),
     background: data.background || "#000000",
     revision: data.revision || 0,
     folders: normalizeFolders(data.folders),
@@ -2363,7 +2369,7 @@ function drawRuler() {
       type: "draw", w, h, dpr,
       sl: els.timelineScroll.scrollLeft, pps: state.pps,
       markers: project.markers, inPoint: project.inPoint, outPoint: project.outPoint,
-      time: state.time, fps: project.fps,
+      time: state.time, fps: projectFps(),
     });
     return;
   }
@@ -2774,7 +2780,7 @@ function goToKeyframe(dir) {
   }
   const times = keyframeTimelineTimes(clips);
   if (!times.length) { toast("No keyframes"); return; }
-  const eps = 0.5 / Math.max(1, project.fps || 30);
+  const eps = 0.5 / projectFps();
   if (dir > 0) {
     const next = times.find((t) => t > state.time + eps);
     if (next == null) { toast("No next keyframe"); return; }
@@ -3948,7 +3954,7 @@ function refreshAudioHold() {
   const audio = ensureAudio();
   try { audio.ctx.resume(); } catch { }
   const t = state.time;
-  const frameDur = 1 / Math.max(1, project.fps || 30);
+  const frameDur = 1 / projectFps();
   const gen = ++audioHoldGen;
   // Stop previous voices before starting the new slice
   for (const n of audioHoldNodes) disposeAudioHoldNode(n);
@@ -5654,7 +5660,7 @@ function playAdvanceVideo(el, mt, eps, rate) {
   });
 }
 async function seekVideosTo(t) {
-  const fps = Math.max(1, Number(project.fps) || 30);
+  const fps = projectFps();
   const waits = [];
   const restoreGain = [];
   for (const c of project.clips) {
@@ -5772,7 +5778,7 @@ async function fastExport() {
   els.exportOverlay.classList.remove("hidden");
   els.exportProgress.style.width = "0%";
   els.exportNote.textContent = "Rendering frames → ffmpeg. You can switch tabs; export continues.";
-  const fps = project.fps, dur = Math.max(1 / fps, projDur());
+  const fps = projectFps(), dur = Math.max(1 / fps, projDur());
   const frames = Math.max(1, Math.round(dur * fps));
   let sessId = null;
   try {
@@ -5875,7 +5881,7 @@ async function webCodecsExport() {
   els.exportOverlay.classList.remove("hidden");
   els.exportProgress.style.width = "0%";
   els.exportNote.textContent = "Encoding with WebCodecs → ffmpeg mux. You can switch tabs; export continues.";
-  const fps = Number(project.fps) || 30, dur = Math.max(1 / fps, projDur());
+  const fps = projectFps(), dur = Math.max(1 / fps, projDur());
   const frames = Math.max(1, Math.round(dur * fps));
   const keyEvery = Math.max(1, Math.round(fps * 2));
   let sessId = null;

--- a/app.js
+++ b/app.js
@@ -3330,7 +3330,7 @@ function renderInspector(lite) {
       if (!c.keyframes) c.keyframes = {};
       const arr = (c.keyframes[k] = c.keyframes[k] || []);
       const lt = +clamp(state.time - c.start, 0, c.duration).toFixed(3);
-      const near = arr.find((kf) => Math.abs(kf.t - lt) < 0.5 / project.fps);
+      const near = arr.find((kf) => Math.abs(kf.t - lt) < 0.5 / projectFps());
       if (near) near.v = v; else arr.push({ t: lt, v });
       arr.sort((a, b) => a.t - b.t);
       state.dirtyTimeline = true;
@@ -4249,7 +4249,7 @@ function getSvgImage(c, t) {
   if (!aux || !aux.svgText) return null;
   if (!aux.svgAnimated) return aux.img || null;
   const local = Math.max(0, mediaTimeAt(c, t));
-  const q = Math.round(local * project.fps) / project.fps;
+  const q = Math.round(local * projectFps()) / projectFps();
   const hit = aux.svgFrames.get(q);
   if (hit) return hit;
   if (!aux.svgPending) {
@@ -4267,7 +4267,7 @@ async function prepareSvgFrame(c, t) {
   if (!aux.svgText) { try { await loadSvgMedia(getMedia(c.mediaId)); } catch { return; } }
   if (!aux.svgAnimated) return;
   const local = Math.max(0, mediaTimeAt(c, t));
-  const q = Math.round(local * project.fps) / project.fps;
+  const q = Math.round(local * projectFps()) / projectFps();
   if (aux.svgFrames.get(q)) return;
   try {
     const img = await renderSvgFrame(aux, q);
@@ -4354,7 +4354,7 @@ function getGrainTile() {
    Phase jumps per frame so grain "boils" like film. */
 function drawGrain(amount, x, y, w, h, t) {
   const keepA = ctx2d.globalAlpha, keepC = ctx2d.globalCompositeOperation;
-  const off = (Math.floor(t * project.fps) * 7919) % 256;
+  const off = (Math.floor(t * projectFps()) * 7919) % 256;
   ctx2d.globalCompositeOperation = "overlay";
   ctx2d.globalAlpha = keepA * clamp(amount / 100, 0, 1) * 0.55;
   ctx2d.save();
@@ -6146,7 +6146,7 @@ async function startExport() {
   state.time = 0;
   seekMediaWhilePaused();
   await new Promise((r) => setTimeout(r, 350)); // let first frames decode
-  const stream = els.preview.captureStream(project.fps);
+  const stream = els.preview.captureStream(projectFps());
   for (const tr of runtime.audio.recDest.stream.getAudioTracks()) stream.addTrack(tr);
   recChunks = []; recDiscard = false;
   recorder = new MediaRecorder(stream, { mimeType: mime, videoBitsPerSecond: 10_000_000 });
@@ -6228,8 +6228,8 @@ $("btnPlay").addEventListener("click", () => state.playing ? pause() : play());
 els.btnSpeed.addEventListener("click", () => cyclePreviewRate(1));
 $("btnHome").addEventListener("click", gotoHome);
 $("btnEnd").addEventListener("click", gotoEnd);
-$("btnBack").addEventListener("click", () => setTime(state.time - 1 / project.fps));
-$("btnFwd").addEventListener("click", () => setTime(state.time + 1 / project.fps));
+$("btnBack").addEventListener("click", () => setTime(state.time - 1 / projectFps()));
+$("btnFwd").addEventListener("click", () => setTime(state.time + 1 / projectFps()));
 $("btnHelp").addEventListener("click", () => $("helpOverlay").classList.remove("hidden"));
 $("btnCloseHelp").addEventListener("click", () => $("helpOverlay").classList.add("hidden"));
 function settingsFocusables() {
@@ -6785,8 +6785,8 @@ window.addEventListener("keydown", (e) => {
     e.preventDefault();
     goToKeyframe(k === "ArrowRight" ? 1 : -1);
   }
-  else if (k === "ArrowLeft") setTime(state.time - (e.shiftKey ? 1 : 1 / project.fps));
-  else if (k === "ArrowRight") setTime(state.time + (e.shiftKey ? 1 : 1 / project.fps));
+  else if (k === "ArrowLeft") setTime(state.time - (e.shiftKey ? 1 : 1 / projectFps()));
+  else if (k === "ArrowRight") setTime(state.time + (e.shiftKey ? 1 : 1 / projectFps()));
   else if (k === "Home") gotoHome();
   else if (k === "End") gotoEnd();
   else if (k === "[") trimToPlayhead("in");

--- a/app.js
+++ b/app.js
@@ -206,6 +206,9 @@ const SETTINGS_KEY = "fablecut-settings";
 const DEFAULT_SETTINGS = {
   linkSelect: false, // timeline ↔ project bin selection sync
   encodeProfile: null, // null = server default from encoding-profiles.json
+  // WebCodecs has no CRF — bitrate (Mbps) + constant|variable mode
+  webCodecsBitrateMbps: null, // null = auto from canvas size
+  webCodecsBitrateMode: "variable", // "variable" | "constant"
 };
 let settings = { ...DEFAULT_SETTINGS };
 function loadSettings() {
@@ -215,6 +218,15 @@ function loadSettings() {
     const next = { ...DEFAULT_SETTINGS };
     for (const k of Object.keys(DEFAULT_SETTINGS)) {
       if (Object.hasOwn(raw, k)) next[k] = raw[k];
+    }
+    // coerce WebCodecs bitrate settings
+    const mbps = next.webCodecsBitrateMbps;
+    if (mbps != null) {
+      const n = Number(mbps);
+      next.webCodecsBitrateMbps = (Number.isFinite(n) && n > 0) ? n : null;
+    }
+    if (next.webCodecsBitrateMode !== "constant" && next.webCodecsBitrateMode !== "variable") {
+      next.webCodecsBitrateMode = "variable";
     }
     settings = next;
   } catch {
@@ -236,7 +248,7 @@ function setSetting(key, value) {
 /* ── State ─────────────────────────────────────────────────────────────── */
 const project = {
   name: "Untitled Project",
-  width: 1280, height: 720, fps: 30,
+  width: 1280, height: 720, fps: 25,
   background: "#000000",
   revision: 0,
   folders: [], // {id, name, parentId:null|string, open:true} — Project-bin tree (virtual)
@@ -263,6 +275,7 @@ const state = {
   viewZoom: 1,           // program-monitor display zoom (1 = fit stage)
   audioHold: false,      // while paused, loop one frame of audio at the playhead
   ffmpeg: false,         // server reports ffmpeg available
+  webCodecs: false,      // VideoEncoder + Annex-B H.264 supported
   dirtyTimeline: true, gesture: false,
   workAreaPlay: false,   // when true, play + Home/End stay inside IN/OUT
   binTab: "project",     // project | elements | sfx | svg
@@ -466,11 +479,36 @@ async function connectServer() {
     fetch("/api/export/ffmpeg").then((r) => r.json())
       .then((j) => { state.ffmpeg = !!j.available; }).catch(() => { });
     fetchEncodeProfiles();
+    detectWebCodecs();
   } catch {
     state.connected = false;
     els.projectName.textContent = project.name + "  ·  ⚪ local session";
   }
   await probeMissingMeta();
+}
+/* Main-profile AVC level by canvas height; Annex-B is required so ffmpeg
+   can ingest the elementary stream with `-f h264` and no avcC converter. */
+function webCodecsAvcCodec() {
+  const h = project.height || 720;
+  if (h > 1080) return "avc1.4D0032"; // Main@L5.0
+  if (h > 720) return "avc1.4D0028";  // Main@L4.0
+  return "avc1.4D001F";               // Main@L3.1
+}
+async function detectWebCodecs() {
+  state.webCodecs = false;
+  try {
+    if (typeof VideoEncoder !== "function" || typeof VideoEncoder.isConfigSupported !== "function") return;
+    const cfg = {
+      codec: webCodecsAvcCodec(),
+      width: Math.max(2, project.width | 0 || 1280),
+      height: Math.max(2, project.height | 0 || 720),
+      bitrate: 8_000_000,
+      framerate: project.fps || 30,
+      avc: { format: "annexb" },
+    };
+    const { supported } = await VideoEncoder.isConfigSupported(cfg);
+    state.webCodecs = !!supported;
+  } catch { state.webCodecs = false; }
 }
 const TIMELINE_START_TIME = 0.000; // composition timeline start (seconds)
 function normalizeWorkArea(i, o, t0 = TIMELINE_START_TIME) {
@@ -5311,12 +5349,13 @@ function loop(ts) {
 }
 
 /* ═══════════════════════════ EXPORT ═══════════════════════════ */
-/* Two engines:
+/* Three engines:
    – fast: the browser renders every frame with the normal compositor
      (frame-accurate, works unfocused) and streams JPEGs + an offline audio
      mix to the server, where ffmpeg encodes via an encoding profile.
-   – realtime: the original MediaRecorder capture, kept as the fallback for
-     local sessions / servers without ffmpeg. */
+   – webcodecs: VideoEncoder Annex-B H.264 → server stream-copy mux
+   – realtime: MediaRecorder, kept as the fallback when WebCodecs or the
+     server/ffmpeg is unavailable. */
 
 /* Placeholder until /api/export/profiles answers — the real list (and the real
    ffmpeg args) always comes from encoding-profiles.json on the server. */
@@ -5398,18 +5437,61 @@ function syncExportProfileVisibility() {
   els.exportProfileRow?.classList.toggle("hidden", !show);
 }
 
-function openExportSetup() {
+function syncExportWcOpts() {
+  const opts = $("exportWcOpts");
+  if (!opts) return;
+  const show = !!(els.engineRealtime?.checked && state.webCodecs
+    && state.connected && state.ffmpeg && !els.engineRealtime.disabled);
+  opts.classList.toggle("hidden", !show);
+}
+function fillExportWcOpts() {
+  const br = $("exportWcBitrate");
+  const mode = $("exportWcMode");
+  if (br) {
+    const mbps = getSetting("webCodecsBitrateMbps");
+    const want = mbps == null ? "auto" : String(Math.round(Number(mbps)));
+    br.value = [...br.options].some((o) => o.value === want) ? want : "auto";
+  }
+  if (mode) {
+    const m = getSetting("webCodecsBitrateMode");
+    mode.value = m === "constant" ? "constant" : "variable";
+  }
+}
+function persistExportWcOpts() {
+  const br = $("exportWcBitrate");
+  const mode = $("exportWcMode");
+  if (br) {
+    setSetting("webCodecsBitrateMbps", br.value === "auto" ? null : Number(br.value));
+  }
+  if (mode) {
+    setSetting("webCodecsBitrateMode", mode.value === "constant" ? "constant" : "variable");
+  }
+}
+/** Bitrate for VideoEncoder.configure — no CRF in WebCodecs; only bitrate (+ CBR/VBR). */
+function webCodecsBitrate(w, h, fps) {
+  const mbps = getSetting("webCodecsBitrateMbps");
+  if (mbps != null && Number.isFinite(+mbps) && +mbps > 0) {
+    return Math.round(Math.min(100, Math.max(0.5, +mbps)) * 1_000_000);
+  }
+  // ~0.1 bit/pixel/frame, clamped — same heuristic as before
+  return Math.min(20_000_000, Math.max(2_000_000, Math.round(w * h * fps * 0.1)));
+}
+async function openExportSetup() {
   if (state.exporting) return;
   if (!project.clips.length) { alert("Timeline is empty — add some clips first."); return; }
+  await detectWebCodecs();
   const ef = getExportFrame();
   const fastOk = state.connected && state.ffmpeg;
-  const rtOk = !ef; // realtime cannot crop to the delivery frame
+  // WebCodecs and MediaRecorder encode the full canvas — only Fast crops.
+  const wcOk = fastOk && state.webCodecs && !ef;
+  const recOk = !ef && !!(window.MediaRecorder && pickMime());
   els.engineFast.disabled = !fastOk;
-  els.engineRealtime.disabled = !rtOk;
+  els.engineRealtime.disabled = !wcOk && !recOk;
+  // Prefer Fast, then WebCodecs, then MediaRecorder
   if (fastOk) {
     els.engineFast.checked = true;
     els.engineRealtime.checked = false;
-  } else if (rtOk) {
+  } else if (wcOk || recOk) {
     els.engineFast.checked = false;
     els.engineRealtime.checked = true;
   } else {
@@ -5419,16 +5501,24 @@ function openExportSetup() {
   }
   $("engineFastNote").textContent = fastOk
     ? (ef ? "Exports the " + ef.w + "×" + ef.h + " delivery frame (cropped). Keeps rendering if you switch tabs."
-      : "Frame-accurate ffmpeg encode. Keeps rendering if you switch tabs.")
+      : "Frame-accurate. Server encodes H.264 from JPEG frames. Keeps going if you switch tabs.")
     : (ef
       ? "Needs the server + ffmpeg on PATH to export a cropped delivery frame."
       : "Needs the server + ffmpeg on PATH.");
-  const rtNote = $("engineRealtime")?.closest(".engine-opt")?.querySelector(".dim");
-  if (rtNote) rtNote.textContent = ef
-    ? (fastOk
+  const wcNote = $("engineWebCodecsNote");
+  if (wcNote) {
+    if (wcOk) wcNote.textContent = "Frame-accurate. Browser HW-encodes H.264; server muxes with audio. Faster upload than Fast.";
+    else if (ef) wcNote.textContent = fastOk
       ? "Unavailable while an export frame is set — use Fast export."
-      : "Unavailable while an export frame is set. Install ffmpeg, or clear the export frame to use Realtime.")
-    : "Plays the timeline once and records it. Keep the tab focused.";
+      : "Unavailable while an export frame is set. Install ffmpeg, or clear the export frame to use Realtime.";
+    else if (!state.connected || !state.ffmpeg) wcNote.textContent = "Needs the server + ffmpeg. Falling back to in-browser MediaRecorder when selected.";
+    else wcNote.textContent = "This browser does not support VideoEncoder Annex-B H.264. Falling back to MediaRecorder when selected.";
+  }
+  // Relabel the radio when WebCodecs is unavailable but MediaRecorder still works
+  const label = els.engineRealtime?.closest("label")?.querySelector("b");
+  if (label) label.textContent = wcOk ? "WebCodecs (HW encode)" : "Realtime (in-browser)";
+  fillExportWcOpts();
+  syncExportWcOpts();
   const warn = $("exportTrackWarn");
   const disabled = TRACKS.filter((t) =>
     !isTrackEnabled(t.id) && project.clips.some((c) => c.track === t.id)
@@ -5450,9 +5540,10 @@ function openExportSetup() {
   });
 }
 function startChosenExport() {
+  persistExportWcOpts();
   const useFast = els.engineFast.checked && !els.engineFast.disabled;
-  const useRt = els.engineRealtime.checked && !els.engineRealtime.disabled;
-  if (!useFast && !useRt) {
+  const useSecond = els.engineRealtime.checked && !els.engineRealtime.disabled;
+  if (!useFast && !useSecond) {
     const ef = getExportFrame();
     if (ef && !(state.connected && state.ffmpeg)) {
       alert("Export frame cropping needs Fast export (server + ffmpeg). Clear the export frame, or install ffmpeg and try again.");
@@ -5463,6 +5554,7 @@ function startChosenExport() {
   }
   els.exportSetup.classList.add("hidden");
   if (useFast) fastExport();
+  else if (useSecond && state.connected && state.ffmpeg && state.webCodecs && !getExportFrame()) webCodecsExport();
   else startExport();
 }
 
@@ -5608,6 +5700,7 @@ async function fastExport() {
       await prepareFrameAssets(t);       // exact SVG frames + AI masks
       drawFrame(t);
       const blob = await previewToExportBlob(jpegQ);
+      if (!blob) throw new Error("frame encode failed");
       const r = await fetch("/api/export/frame?id=" + sessId, { method: "POST", body: blob });
       if (!r.ok) throw new Error((await r.json()).error || "frame upload failed");
       const pct = ((f + 1) / frames) * 100;
@@ -5632,7 +5725,173 @@ async function fastExport() {
   }
 }
 
-/* ── Realtime export (MediaRecorder fallback) ── */
+/* ── WebCodecs export (browser H.264 → server mux) ── */
+/* Uploads MUST be strictly sequential — concurrent /frame POSTs race on the
+   same ffmpeg stdin and deadlock the pipe (progress freezes around a few %). */
+let webCodecsAbort = null;
+function waitEncodeQueue(encoder, max = 2) {
+  if (encoder.encodeQueueSize <= max) return Promise.resolve();
+  return new Promise((res, rej) => {
+    const done = (err) => {
+      clearInterval(poll);
+      encoder.ondequeue = null;
+      err ? rej(err) : res();
+    };
+    const tick = () => {
+      if (renderCancelled) done(new Error("cancelled"));
+      else if (encoder.encodeQueueSize <= max) done(null);
+    };
+    encoder.ondequeue = tick;
+    // ondequeue alone won't notice Cancel — poll the flag
+    const poll = setInterval(tick, 50);
+    tick();
+  });
+}
+async function webCodecsExport() {
+  if (state.exporting) return;
+  if (!state.webCodecs) { startExport(); return; }
+  pause();
+  state.exporting = true; state.rendering = true; renderCancelled = false;
+  webCodecsAbort = new AbortController();
+  const signal = webCodecsAbort.signal;
+  els.exportOverlay.classList.remove("hidden");
+  els.exportProgress.style.width = "0%";
+  els.exportNote.textContent = "Encoding with WebCodecs → ffmpeg mux. You can switch tabs; export continues.";
+  const fps = Number(project.fps) || 30, dur = Math.max(1 / fps, projDur());
+  const frames = Math.max(1, Math.round(dur * fps));
+  const keyEvery = Math.max(1, Math.round(fps * 2));
+  let sessId = null;
+  let encoder = null;
+  let uploadError = null;
+  // single-flight upload chain: each NAL waits for the previous POST to finish
+  let uploadTail = Promise.resolve();
+  let uploadsInFlight = 0;
+  const enqueueUpload = (buf) => {
+    uploadsInFlight++;
+    // recover from a prior rejection so one failed POST doesn't stall the chain
+    const p = uploadTail.catch(() => {}).then(async () => {
+      if (renderCancelled || signal.aborted) throw new Error("cancelled");
+      if (uploadError) throw uploadError;
+      const r = await fetch("/api/export/frame?id=" + sessId, {
+        method: "POST", body: buf, signal,
+      });
+      if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || "frame upload failed");
+    });
+    uploadTail = p.catch((err) => {
+      if (!uploadError) uploadError = err;
+    }).finally(() => { uploadsInFlight--; });
+    return p;
+  };
+  const waitUploadBackpressure = (max = 2) => new Promise((res, rej) => {
+    const tick = () => {
+      if (renderCancelled || signal.aborted) { clearInterval(poll); rej(new Error("cancelled")); }
+      else if (uploadError) { clearInterval(poll); rej(uploadError); }
+      else if (uploadsInFlight <= max) { clearInterval(poll); res(); }
+    };
+    const poll = setInterval(tick, 20);
+    tick();
+  });
+  try {
+    els.exportTitle.textContent = "Mixing audio…";
+    const wav = await renderAudioMix(dur);
+    if (renderCancelled) throw new Error("cancelled");
+
+    const begin = await fetch("/api/export/begin", {
+      method: "POST",
+      body: JSON.stringify({
+        fps,
+        name: project.name.replace(/[^\w\- ]+/g, "") || "export",
+        mode: "annexb",
+        hasAudio: !!wav,
+      }),
+      signal,
+    }).then((r) => r.json());
+    if (!begin.id) throw new Error(begin.error || "export begin failed");
+    sessId = begin.id;
+    if (wav) {
+      const r = await fetch("/api/export/audio?id=" + sessId, { method: "POST", body: wav, signal });
+      if (!r.ok) throw new Error("audio upload failed");
+    }
+
+    // Always encode at project/frame resolution (not display CSS size).
+    const w = Math.max(2, project.width | 0 || 1280);
+    const h = Math.max(2, project.height | 0 || 720);
+    if (els.preview.width !== w || els.preview.height !== h) {
+      els.preview.width = w;
+      els.preview.height = h;
+    }
+    const codec = webCodecsAvcCodec();
+    const bitrate = webCodecsBitrate(w, h, fps);
+    const bitrateMode = getSetting("webCodecsBitrateMode") === "constant" ? "constant" : "variable";
+    encoder = new VideoEncoder({
+      output: (chunk) => {
+        if (uploadError || renderCancelled || signal.aborted) return;
+        const buf = new Uint8Array(chunk.byteLength);
+        chunk.copyTo(buf);
+        enqueueUpload(buf);
+      },
+      error: (e) => { uploadError = e; },
+    });
+    encoder.configure({
+      codec, width: w, height: h, bitrate, bitrateMode, framerate: fps,
+      avc: { format: "annexb" },
+      latencyMode: "quality",
+    });
+    try { await document.fonts.ready; } catch { }
+
+    for (let f = 0; f < frames; f++) {
+      if (renderCancelled || signal.aborted) throw new Error("cancelled");
+      if (uploadError) throw uploadError;
+      await waitUploadBackpressure(2);
+      await waitEncodeQueue(encoder, 2);
+      const t = f / fps;
+      state.time = t;
+      await seekVideosTo(t);
+      await prepareFrameAssets(t);
+      drawFrame(t);
+      // Absolute µs timestamps; duration = delta so average rate stays exact
+      // (constant Math.round(1e6/fps) drifts, e.g. 33333µs → avg 1000000/33333).
+      const ts = Math.round(f * 1e6 / fps);
+      const frame = new VideoFrame(els.preview, {
+        timestamp: ts,
+        duration: Math.round((f + 1) * 1e6 / fps) - ts,
+      });
+      try {
+        encoder.encode(frame, { keyFrame: f === 0 || f % keyEvery === 0 });
+      } finally {
+        frame.close();
+      }
+      const pct = ((f + 1) / frames) * 100;
+      els.exportProgress.style.width = pct.toFixed(1) + "%";
+      els.exportTitle.textContent = `Encoding… ${pct.toFixed(0)}%`;
+    }
+    els.exportTitle.textContent = "Finishing…";
+    await encoder.flush();
+    await uploadTail;
+    if (uploadError) throw uploadError;
+    encoder.close();
+    encoder = null;
+    const end = await fetch("/api/export/end?id=" + sessId, { method: "POST", signal }).then((r) => r.json());
+    if (!end.src) throw new Error(end.error || "mux failed");
+    const a = document.createElement("a");
+    a.href = end.src;
+    a.download = decodeURIComponent(end.src.split("/").pop());
+    a.click();
+  } catch (e) {
+    try { encoder?.close(); } catch { }
+    if (sessId) fetch("/api/export/end?id=" + sessId + "&discard=1", { method: "POST" }).catch(() => { });
+    const msg = e?.name === "AbortError" ? "cancelled" : String(e.message || e);
+    if (msg !== "cancelled") alert("Export failed: " + msg);
+  } finally {
+    webCodecsAbort = null;
+    state.exporting = false; state.rendering = false;
+    els.exportOverlay.classList.add("hidden");
+    els.exportNote.textContent = "Rendering your sequence in real time. Keep this tab focused.";
+    if (runtime.pendingSync) syncFromServer();
+  }
+}
+
+/* ── Realtime export (MediaRecorder offline / unsupported fallback) ── */
 let recorder = null, recChunks = [], recDiscard = false;
 function pickMime() {
   const cands = [
@@ -5707,7 +5966,10 @@ $("btnDelete").addEventListener("click", () => {
 $("btnExport").addEventListener("click", openExportSetup);
 $("btnStartExport").addEventListener("click", startChosenExport);
 els.exportSetup?.addEventListener("change", (e) => {
-  if (e.target.name === "engine") syncExportProfileVisibility();
+  if (e.target.name === "engine") {
+    syncExportProfileVisibility();
+    syncExportWcOpts();
+  }
 });
 els.exportProfileSel?.addEventListener("change", (e) => {
   const id = e.target.value;
@@ -5717,9 +5979,15 @@ els.exportProfileSel?.addEventListener("change", (e) => {
   updateExportProfileNote(id);
 });
 $("btnCancelSetup").addEventListener("click", () => els.exportSetup.classList.add("hidden"));
+els.engineFast?.addEventListener("change", syncExportWcOpts);
+els.engineRealtime?.addEventListener("change", syncExportWcOpts);
+$("exportWcBitrate")?.addEventListener("change", persistExportWcOpts);
+$("exportWcMode")?.addEventListener("change", persistExportWcOpts);
 $("btnCancelExport").addEventListener("click", () => {
-  if (state.rendering) renderCancelled = true;
-  else finishExport(false);
+  if (state.rendering) {
+    renderCancelled = true;
+    try { webCodecsAbort?.abort(); } catch { }
+  } else finishExport(false);
 });
 $("btnPlay").addEventListener("click", () => state.playing ? pause() : play());
 els.btnSpeed.addEventListener("click", () => cyclePreviewRate(1));

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
           <button class="btn tiny toggle" id="btnExportFrame" title="Toggle export frame overlay (drag handle to reframe)">⬒ Frame</button>
           <button type="button" class="btn tiny toggle hidden" id="btnExportFrameDim" aria-pressed="true" title="Lights off — crop to the export frame"><svg class="ico" viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><g class="ef-bulb-rays" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M8 .4v1.05M1.7 3.45l.85.65M14.3 3.45l-.85.65"/></g><path class="ef-bulb-glass" fill="none" stroke="currentColor" stroke-width="1.55" stroke-linejoin="round" d="M8 1.7A4.1 4.1 0 0 0 3.9 5.8c0 1.62.86 2.72 1.8 3.5.38.32.62.68.62 1.15v.35h4.36v-.35c0-.47.24-.83.62-1.15.94-.78 1.8-1.88 1.8-3.5A4.1 4.1 0 0 0 8 1.7z"/><path fill="none" stroke="currentColor" stroke-width="1.45" stroke-linecap="square" d="M6.25 12.85h3.5M6.7 14.35h2.6"/></svg></button>
           <button class="btn tiny toggle" id="btnGuides" title="Toggle safe-area guides">▦ Safe</button>
-          <span class="dim" id="monitorRes">1280 × 720 · 30fps</span>
+          <span class="dim" id="monitorRes"></span>
         </span>
       </div>
       <div class="monitor-stage" id="monitorStage">

--- a/index.html
+++ b/index.html
@@ -172,13 +172,36 @@
     </label>
     <label class="engine-opt">
       <input type="radio" name="engine" id="engineRealtime">
-      <span><b>Realtime (in-browser)</b><br><span class="dim">Plays the timeline once and records it. Keep the tab focused.</span></span>
+      <span><b>WebCodecs (HW encode)</b><br><span class="dim" id="engineWebCodecsNote">Frame-accurate. Browser encodes H.264; server muxes. Needs a modern Chromium and ffmpeg.</span></span>
     </label>
     <div class="export-profile-row" id="exportProfileRow">
       <label class="export-profile-label" for="exportProfileSel">Encoding profile</label>
       <select class="export-profile-sel" id="exportProfileSel" aria-describedby="exportProfileNote exportProfileHint"></select>
       <p class="dim export-profile-note" id="exportProfileNote"></p>
       <p class="dim export-profile-hint" id="exportProfileHint"></p>
+    </div>
+    <div class="export-wc-opts hidden" id="exportWcOpts">
+      <label class="export-wc-field" for="exportWcBitrate">Bitrate
+        <select id="exportWcBitrate" class="export-wc-sel">
+          <option value="auto">Auto (from resolution)</option>
+          <option value="2">2 Mbps</option>
+          <option value="4">4 Mbps</option>
+          <option value="6">6 Mbps</option>
+          <option value="8">8 Mbps</option>
+          <option value="12">12 Mbps</option>
+          <option value="16">16 Mbps</option>
+          <option value="20">20 Mbps</option>
+          <option value="30">30 Mbps</option>
+          <option value="50">50 Mbps</option>
+        </select>
+      </label>
+      <label class="export-wc-field" for="exportWcMode">Rate control
+        <select id="exportWcMode" class="export-wc-sel">
+          <option value="variable">VBR (variable)</option>
+          <option value="constant">CBR (constant)</option>
+        </select>
+      </label>
+      <p class="dim export-wc-hint">WebCodecs has no CRF — quality is driven by bitrate. VBR spends bits on hard frames; CBR holds a steady rate.</p>
     </div>
     <div class="export-track-warn hidden" id="exportTrackWarn" role="status"></div>
     <div class="dialog-actions">

--- a/ruler-worker.js
+++ b/ruler-worker.js
@@ -12,7 +12,7 @@ let cv = null, g = null;
 function fmt(t, fps) {
   t = Math.max(0, t);
   const m = Math.floor(t / 60), s = Math.floor(t % 60),
-    f = Math.floor((t % 1) * (fps || 30));
+    f = Math.floor((t % 1) * (fps > 0 ? fps : 1));
   const p = (n) => String(n).padStart(2, "0");
   return `${p(m)}:${p(s)}:${p(f)}`;
 }

--- a/server.js
+++ b/server.js
@@ -198,6 +198,12 @@ const COLOR_TAGS = [
   "-color_trc", "bt709", "-color_range", "tv",
 ];
 const COLOR_BSF = "h264_metadata=colour_primaries=1:transfer_characteristics=1:matrix_coefficients=1:video_full_range_flag=0";
+const EXPORT_IDLE_MS = 10 * 60 * 1000; // abandon sessions with no successful activity
+const EXPORT_SWEEP_MS = 60 * 1000;
+let exportSweepTimer = null;
+function touchExport(sess) {
+  if (sess) sess.lastTouch = Date.now();
+}
 function attachProc(sess, proc) {
   sess.proc = proc;
   sess.stderr = "";
@@ -217,7 +223,7 @@ async function beginExport(fps, name, profileId, hasAudio, mode) {
       mode: m, fps: Number(fps) || 30, proc: null, dir,
       name: safe, hasAudio: !!hasAudio,
       wav: null, partPath, outPath,
-      stderr: "", done: null,
+      stderr: "", done: null, lastTouch: Date.now(),
       err: () => sess.stderr.trim().split("\n").filter(Boolean).slice(-3)
         .map((l) => l.trim()).join(" · "),
     };
@@ -235,7 +241,7 @@ async function beginExport(fps, name, profileId, hasAudio, mode) {
   const sess = {
     mode: m, proc: null, fps, profile, name: safe, hasAudio: !!hasAudio,
     dir, wav: null, partPath, outPath,
-    stderr: "", done: null,
+    stderr: "", done: null, lastTouch: Date.now(),
     err: () => sess.stderr.trim().split("\n").filter(Boolean).slice(-3)
       .map((l) => l.trim()).join(" · "),
   };
@@ -316,6 +322,21 @@ function cleanupExport(id) {
   try { s.proc?.kill(); } catch {}
   try { fs.rmSync(s.dir, { recursive: true, force: true }); } catch {}
   if (s.partPath) try { fs.rmSync(s.partPath, { force: true }); } catch {}
+}
+function sweepIdleExports() {
+  const now = Date.now();
+  for (const [id, s] of [...exportSessions]) {
+    if (now - (s.lastTouch || 0) > EXPORT_IDLE_MS) cleanupExport(id);
+  }
+}
+function startExportSweep() {
+  if (exportSweepTimer) return;
+  exportSweepTimer = setInterval(sweepIdleExports, EXPORT_SWEEP_MS);
+}
+function stopExportSweep() {
+  if (!exportSweepTimer) return;
+  clearInterval(exportSweepTimer);
+  exportSweepTimer = null;
 }
 
 /* Static file with HTTP Range support (required for <video> seeking) */
@@ -481,6 +502,7 @@ const server = http.createServer(async (req, res) => {
       const writeJob = sess.writeLock.then(run, run);
       sess.writeLock = writeJob.catch(() => {}); // keep the chain alive after a failed write
       await writeJob;
+      touchExport(sess);
       sendJSON(res, 200, { ok: true });
     } catch (e) {
       cleanupExport(id);
@@ -495,6 +517,7 @@ const server = http.createServer(async (req, res) => {
       const wavPath = path.join(sess.dir, "audio.wav");
       fs.writeFileSync(wavPath, await readBody(req));
       sess.wav = wavPath;
+      touchExport(sess);
       sendJSON(res, 200, { ok: true });
     } catch (e) { sendJSON(res, 500, { error: String(e) }); }
     return;
@@ -505,6 +528,7 @@ const server = http.createServer(async (req, res) => {
     if (!sess) { sendJSON(res, 404, { error: "no such export session" }); return; }
     try {
       if (url.searchParams.get("discard")) { cleanupExport(id); sendJSON(res, 200, { ok: true }); return; }
+      touchExport(sess); // keep alive through final mux
       if (!sess.proc) throw new Error("no frames were uploaded");
       sess.proc.stdin.end();
       const code = await sess.done;
@@ -603,4 +627,17 @@ server.listen(PORT, HOST, () => {
   console.log(`  encode prof. : ${PROFILES_FILE} (${Object.keys(enc.profiles).join(", ")} · default ${enc.default})`);
   for (const issue of enc.issues || []) console.log(`     ⚠ ${issue}`);
   console.log("");
+  startExportSweep();
 });
+
+let shuttingDown = false;
+function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  stopExportSweep();
+  for (const id of [...exportSessions.keys()]) cleanupExport(id);
+  server.close(() => process.exit(0));
+  setTimeout(() => process.exit(0), 2000).unref?.();
+}
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/server.js
+++ b/server.js
@@ -213,6 +213,10 @@ function attachProc(sess, proc) {
 }
 async function beginExport(fps, name, profileId, hasAudio, mode) {
   const m = mode === "annexb" ? "annexb" : "jpeg";
+  const rate = Number(fps);
+  if (!Number.isFinite(rate) || rate <= 0) {
+    throw new Error("export fps required (pass project.fps)");
+  }
   const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
   const safe = safeName(name || "export");
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-"));
@@ -220,7 +224,7 @@ async function beginExport(fps, name, profileId, hasAudio, mode) {
   if (m === "annexb") {
     const { outPath, partPath } = reserveExportPaths(EXPORTS_DIR, safe, ".mp4");
     const sess = {
-      mode: m, fps: Number(fps) || 30, proc: null, dir,
+      mode: m, fps: rate, proc: null, dir,
       name: safe, hasAudio: !!hasAudio,
       wav: null, partPath, outPath,
       stderr: "", done: null, lastTouch: Date.now(),
@@ -233,13 +237,13 @@ async function beginExport(fps, name, profileId, hasAudio, mode) {
   }
 
   const profile = resolveProfile(profileId);
-  const dry = await dryRunProfile(profile, { fps, hasAudio });
+  const dry = await dryRunProfile(profile, { fps: rate, hasAudio });
   if (!dry.ok) throw new Error(`profile "${profile.id}" was rejected by ffmpeg: ${dry.error}`);
   // Reserve the output name now (not at first frame) so concurrent exports
   // cannot both see the same free path. The empty .part file is overwritten by ffmpeg (-y).
   const { outPath, partPath } = reserveExportPaths(EXPORTS_DIR, safe, profile.extension);
   const sess = {
-    mode: m, proc: null, fps, profile, name: safe, hasAudio: !!hasAudio,
+    mode: m, proc: null, fps: rate, profile, name: safe, hasAudio: !!hasAudio,
     dir, wav: null, partPath, outPath,
     stderr: "", done: null, lastTouch: Date.now(),
     err: () => sess.stderr.trim().split("\n").filter(Boolean).slice(-3)
@@ -475,10 +479,10 @@ const server = http.createServer(async (req, res) => {
       const mode = opts.mode === "annexb" ? "annexb" : "jpeg";
       if (mode !== "annexb" && opts.profile) resolveProfile(opts.profile); // 400, not 500, on a bad id — even without ffmpeg
       if (!HAS_FFMPEG) { sendJSON(res, 400, { error: "ffmpeg not found on PATH" }); return; }
-      sendJSON(res, 200, await beginExport(opts.fps || 30, opts.name, opts.profile, opts.hasAudio !== false, mode));
+      sendJSON(res, 200, await beginExport(opts.fps, opts.name, opts.profile, opts.hasAudio !== false, mode));
     } catch (e) {
       // an unusable profile is the caller's problem, not a server fault
-      const bad = /^Unknown encoding profile|was rejected by ffmpeg/.test(e.message || "");
+      const bad = /^Unknown encoding profile|was rejected by ffmpeg|export fps required/.test(e.message || "");
       sendJSON(res, bad ? 400 : 500, { error: String(e.message || e) });
     }
     return;

--- a/server.js
+++ b/server.js
@@ -183,32 +183,65 @@ async function faststart(file) {
   } catch { try { fs.rmSync(tmp); } catch {} }
 }
 
-/* ── Fast export sessions ──
-   The browser renders frames with its own compositor and streams them here as
-   JPEGs; a single ffmpeg pass encodes them plus the WAV mix into the final file.
-   ffmpeg is spawned on the FIRST frame, not here: the audio mix is uploaded
-   between /begin and the first frame, and a one-pass encode needs it on disk. */
+/* ── Export sessions ──
+   Two modes share the same HTTP session API:
+     jpeg   — browser streams JPEGs; ffmpeg encodes via an encoding profile (Fast)
+     annexb — browser streams Annex-B H.264 NALs; ffmpeg stream-copies (WebCodecs)
+   Both spawn on the FIRST frame, not here: the audio mix is uploaded between
+   /begin and the first frame, and a one-pass encode needs it on disk. */
 const exportSessions = new Map();
-async function beginExport(fps, name, profileId, hasAudio) {
+/* Container + bitstream BT.709/tv for the WebCodecs (annexb) path.
+   `-c copy` alone drops the colr atom; the bsf writes VUI so players see
+   primaries/transfer, not "unknown". JPEG Fast export uses profile.color instead. */
+const COLOR_TAGS = [
+  "-colorspace", "bt709", "-color_primaries", "bt709",
+  "-color_trc", "bt709", "-color_range", "tv",
+];
+const COLOR_BSF = "h264_metadata=colour_primaries=1:transfer_characteristics=1:matrix_coefficients=1:video_full_range_flag=0";
+function attachProc(sess, proc) {
+  sess.proc = proc;
+  sess.stderr = "";
+  proc.stderr.on("data", (d) => { sess.stderr = (sess.stderr + d).slice(-2000); });
+  proc.stdin.on("error", () => {}); // EPIPE if ffmpeg dies mid-stream
+  sess.done = new Promise((res) => proc.on("close", res));
+}
+async function beginExport(fps, name, profileId, hasAudio, mode) {
+  const m = mode === "annexb" ? "annexb" : "jpeg";
+  const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+  const safe = safeName(name || "export");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-"));
+
+  if (m === "annexb") {
+    const { outPath, partPath } = reserveExportPaths(EXPORTS_DIR, safe, ".mp4");
+    const sess = {
+      mode: m, fps: Number(fps) || 30, proc: null, dir,
+      name: safe, hasAudio: !!hasAudio,
+      wav: null, partPath, outPath,
+      stderr: "", done: null,
+      err: () => sess.stderr.trim().split("\n").filter(Boolean).slice(-3)
+        .map((l) => l.trim()).join(" · "),
+    };
+    sess.writeLock = Promise.resolve();
+    exportSessions.set(id, sess);
+    return { id, mode: m };
+  }
+
   const profile = resolveProfile(profileId);
   const dry = await dryRunProfile(profile, { fps, hasAudio });
   if (!dry.ok) throw new Error(`profile "${profile.id}" was rejected by ffmpeg: ${dry.error}`);
-  const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
-  const safe = safeName(name || "export");
   // Reserve the output name now (not at first frame) so concurrent exports
   // cannot both see the same free path. The empty .part file is overwritten by ffmpeg (-y).
   const { outPath, partPath } = reserveExportPaths(EXPORTS_DIR, safe, profile.extension);
   const sess = {
-    proc: null, fps, profile, name: safe, hasAudio: !!hasAudio,
-    dir: fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-")),
-    wav: null, partPath, outPath,
+    mode: m, proc: null, fps, profile, name: safe, hasAudio: !!hasAudio,
+    dir, wav: null, partPath, outPath,
     stderr: "", done: null,
-    // ffmpeg's complaint is in the last lines; the rest is progress noise
     err: () => sess.stderr.trim().split("\n").filter(Boolean).slice(-3)
       .map((l) => l.trim()).join(" · "),
   };
+  sess.writeLock = Promise.resolve();
   exportSessions.set(id, sess);
-  return { id, profile: profile.id, label: profile.label, summary: profileSummary(profile) };
+  return { id, mode: m, profile: profile.id, label: profile.label, summary: profileSummary(profile) };
 }
 /* Encode into the paths reserved at /begin; rename .part → final on clean exit
    so an aborted render never leaves something that looks like a finished file. */
@@ -224,9 +257,9 @@ function startEncoder(sess) {
   sess.done = new Promise((res) => proc.on("close", res));
   return proc;
 }
-/** Write one JPEG frame to ffmpeg stdin. If the pipe is full, wait for drain —
- *  but also reject if ffmpeg exits or the stdin errors, so the HTTP request
- *  cannot hang forever after a failed encode. */
+/** Write one frame (JPEG or Annex-B NAL) to ffmpeg stdin. If the pipe is full,
+ *  wait for drain — but also reject if ffmpeg exits or the stdin errors, so the
+ *  HTTP request cannot hang forever after a failed encode. */
 function writeExportFrame(sess, body) {
   const proc = sess.proc;
   return new Promise((resolve, reject) => {
@@ -256,6 +289,25 @@ function writeExportFrame(sess, body) {
     if (ok) finish(resolve);
     else proc.stdin.once("drain", onDrain);
   });
+}
+/* One-pass mux for WebCodecs: H.264 elementary stream on stdin + optional WAV.
+   Use input `-r` (not only `-framerate`): HW encoders stamp AUs with µs-rounded
+   durations (e.g. 33333µs ≈ 1/30), which otherwise become avg_frame_rate
+   1000000/33333. `-r` forces CFR PTS so the MP4 matches project.fps exactly. */
+function startAnnexbEncoder(sess) {
+  const fps = sess.fps;
+  const args = [
+    "-y", "-hide_banner",
+    "-fflags", "+genpts",
+    "-f", "h264", "-r", String(fps), "-i", "pipe:0",
+  ];
+  if (sess.wav) args.push("-i", sess.wav);
+  args.push("-map", "0:v:0", "-c:v", "copy", "-bsf:v", COLOR_BSF, ...COLOR_TAGS);
+  // do not use -shortest: with unset/generated PTS it drops the audio track
+  if (sess.wav) args.push("-map", "1:a:0", "-c:a", "aac", "-b:a", "192k");
+  args.push("-movflags", "+faststart+write_colr", sess.partPath);
+  attachProc(sess, spawn("ffmpeg", args, { stdio: ["pipe", "ignore", "pipe"] }));
+  return sess.proc;
 }
 function cleanupExport(id) {
   const s = exportSessions.get(id);
@@ -399,9 +451,10 @@ const server = http.createServer(async (req, res) => {
   if (p === "/api/export/begin" && req.method === "POST") {
     try {
       const opts = JSON.parse((await readBody(req)).toString("utf8") || "{}");
-      if (opts.profile) resolveProfile(opts.profile); // 400, not 500, on a bad id — even without ffmpeg
+      const mode = opts.mode === "annexb" ? "annexb" : "jpeg";
+      if (mode !== "annexb" && opts.profile) resolveProfile(opts.profile); // 400, not 500, on a bad id — even without ffmpeg
       if (!HAS_FFMPEG) { sendJSON(res, 400, { error: "ffmpeg not found on PATH" }); return; }
-      sendJSON(res, 200, await beginExport(opts.fps || 30, opts.name, opts.profile, opts.hasAudio !== false));
+      sendJSON(res, 200, await beginExport(opts.fps || 30, opts.name, opts.profile, opts.hasAudio !== false, mode));
     } catch (e) {
       // an unusable profile is the caller's problem, not a server fault
       const bad = /^Unknown encoding profile|was rejected by ffmpeg/.test(e.message || "");
@@ -415,12 +468,19 @@ const server = http.createServer(async (req, res) => {
     if (!sess) { sendJSON(res, 404, { error: "no such export session" }); return; }
     try {
       const body = await readBody(req);
+      if (!body || !body.length) throw new Error("empty frame");
       if (sess.hasAudio && !sess.wav) {
         sendJSON(res, 409, { error: "audio mix has not been uploaded yet" });
         return;
       }
-      if (!sess.proc) startEncoder(sess);
-      await writeExportFrame(sess, body);
+      // queue behind any in-flight write so concurrent POSTs cannot interleave stdin
+      const run = async () => {
+        if (!sess.proc) sess.mode === "annexb" ? startAnnexbEncoder(sess) : startEncoder(sess);
+        await writeExportFrame(sess, body);
+      };
+      const p = sess.writeLock.then(run, run);
+      sess.writeLock = p.catch(() => {}); // keep the chain alive after a failed write
+      await p;
       sendJSON(res, 200, { ok: true });
     } catch (e) {
       cleanupExport(id);

--- a/server.js
+++ b/server.js
@@ -17,7 +17,6 @@
 const http = require("http");
 const fs = require("fs");
 const path = require("path");
-const os = require("os");
 const { spawn, spawnSync, execFile } = require("child_process");
 
 const { analyze } = require("./analyze");
@@ -220,7 +219,8 @@ async function beginExport(fps, name, profileId, hasAudio, mode) {
   }
   const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
   const safe = safeName(name || "export");
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-"));
+  // Same filesystem as the finished file so renameSync(partPath, out) cannot EXDEV.
+  const dir = fs.mkdtempSync(path.join(EXPORTS_DIR, "fablecut-"));
 
   if (m === "annexb") {
     const { outPath, partPath } = reserveExportPaths(EXPORTS_DIR, safe, ".mp4");

--- a/server.js
+++ b/server.js
@@ -186,7 +186,8 @@ async function faststart(file) {
 /* ── Export sessions ──
    Two modes share the same HTTP session API:
      jpeg   — browser streams JPEGs; ffmpeg encodes via an encoding profile (Fast)
-     annexb — browser streams Annex-B H.264 NALs; ffmpeg stream-copies (WebCodecs)
+     annexb — browser streams Annex-B H.264 (one POST may concatenate several AUs);
+              ffmpeg stream-copies (WebCodecs)
    Both spawn on the FIRST frame, not here: the audio mix is uploaded between
    /begin and the first frame, and a one-pass encode needs it on disk. */
 const exportSessions = new Map();

--- a/server.js
+++ b/server.js
@@ -478,9 +478,9 @@ const server = http.createServer(async (req, res) => {
         if (!sess.proc) sess.mode === "annexb" ? startAnnexbEncoder(sess) : startEncoder(sess);
         await writeExportFrame(sess, body);
       };
-      const p = sess.writeLock.then(run, run);
-      sess.writeLock = p.catch(() => {}); // keep the chain alive after a failed write
-      await p;
+      const writeJob = sess.writeLock.then(run, run);
+      sess.writeLock = writeJob.catch(() => {}); // keep the chain alive after a failed write
+      await writeJob;
       sendJSON(res, 200, { ok: true });
     } catch (e) {
       cleanupExport(id);

--- a/style.css
+++ b/style.css
@@ -1795,6 +1795,40 @@ body.track-size-s .clip .clip-kf-n {
   font-size: 12px;
 }
 
+.export-wc-opts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  align-items: flex-end;
+  margin: -4px 0 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-2);
+}
+.export-wc-opts.hidden { display: none; }
+.export-wc-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted, #9a9aaa);
+}
+.export-wc-sel {
+  min-width: 160px;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel, #1a1a22);
+  color: inherit;
+  font: inherit;
+}
+.export-wc-hint {
+  flex: 1 1 100%;
+  margin: 0;
+  font-size: 12px;
+}
+
 .export-track-warn {
   margin: 0 0 12px;
   padding: 9px 12px;


### PR DESCRIPTION
## Replace MediaRecorder with WebCodecs for 'realtime' rendering.

<img width="436" height="452" alt="image" src="https://github.com/user-attachments/assets/a1c56891-79f0-4c71-99db-410a110b97c7" />

WebCodecs are used for encoding final video instead of MediaRecorder (still there as a fallback). Only encoding is done in the browser, muxing is still processed by ffmpeg on the server. As seek() per each frame was used before ~40ms was added to each frame processsing time. This process was optimized as well. Technically, the speed above realtime can be expected.


## Type of change

- [ ] Bug fix
- [X] New feature (rendering / API)
- [X] Docs
- [X] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [X] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added WebCodecs H.264 export with configurable bitrate and VBR/CBR controls.
  - Added project frame-rate and export-frame controls in the Program Monitor.
  - Added automatic export-engine detection with fallback support.
- **Bug Fixes**
  - Improved frame sequencing, cancellation, buffering, and export reliability.
  - Corrected timecode formatting for non-positive frame rates.
  - Improved handling of incomplete or failed exports.
- **Documentation**
  - Expanded guidance for WebCodecs export frames and audio submission order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->