### PR TITLE
feat: 'add frames per second' <select /> per project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Project FPS select in the Program Monitor header (next to aspect presets) —
+  pick 24 / 25 / 30 / 50 / 60 fps; writes `project.fps` and persists like canvas
+  size. Non-preset rates appear as Custom.
 - Preview playback speed — a monitor toolbar toggle plus **J**/**K**/**L** shortcuts cycle the preview player through 1×, 1.5×, 2×, and 4× (L faster, J slower, K play/pause and reset to 1×). It rides on top of each clip's own speed and is forced back to 1× during export, so renders always come out at real time.
 
 ## [1.6.0] - 2026-07-14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
 ```jsonc
 {
   "name": "My Edit",
-  "width": 1280, "height": 720, "fps": 30,   // canvas/export settings
+  "width": 1280, "height": 720, "fps": 30,   // timeline + export rate (UI: Program Monitor FPS select)
   "background": "#000000",                    // canvas color behind all clips (optional)
   "revision": 7,                              // bump on every write!
   "markers": [ { "t": 2.5 }, { "t": 5.0, "label": "drop" } ],
@@ -522,6 +522,11 @@ or simply `transitionOut: {type:"fade", duration:3}`.
 
 **Vertical reel**: set project `width:1080, height:1920`; use the UI's safe-area
 guides (▦) to keep captions out of platform UI zones.
+
+**Project frame rate**: set `fps` in `project.json` (or the Program Monitor FPS
+dropdown — 24 / 25 / 30 / 50 / 60). Preview stepping, timecode frames, Fast/
+Realtime export, and `/api/export/begin` all use this value; pass the same
+`fps` when starting an export via the API.
 
 ## Export
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ same time.
   audio at the playhead (useful when stepping frame-by-frame). Scrubbing or
   frame-step retargets the held slice; meters stay live. **Play** / **Pause**
   turns it off.
-- Canvas aspect presets (16:9, 9:16 reels, 4:5, 1:1) + safe-area guides
+- Canvas aspect presets (16:9, 9:16 reels, 4:5, 1:1) + project FPS select
+  (24 / 25 / 30 / 50 / 60; non-preset rates show as Custom) + safe-area guides
 - **Program Monitor zoom** — mouse-wheel over the preview zooms the composition
   toward the cursor (fit → up to **2 screen pixels per canvas pixel**). Magnified
   view uses **native scrollbars** so overflow stays reachable; middle-click or

--- a/app.js
+++ b/app.js
@@ -131,6 +131,7 @@ const ASPECT_PRESETS = [
   { label: "4:5 · IG 1080×1350", w: 1080, h: 1350 },
   { label: "1:1 · 1080×1080", w: 1080, h: 1080 },
 ];
+const FPS_PRESETS = [24, 25, 30, 50, 60];
 const WAVE_PEAKS_PER_SEC = 50;
 const TRACK_IDS = new Set(TRACKS.map((t) => t.id));
 // Audio lanes available for a video's per-channel linked audio (index = props.audioChannel).
@@ -319,8 +320,8 @@ const els = {
   btnAudioHold: $("btnAudioHold"),
   exportOverlay: $("exportOverlay"), exportProgress: $("exportProgress"),
   exportTitle: $("exportTitle"), exportNote: $("exportNote"),
-  projectName: $("projectName"), monitorRes: $("monitorRes"),
-  aspectSel: $("aspectSel"), btnGuides: $("btnGuides"), btnZoom100: $("btnZoom100"),
+  projectName: $("projectName"),
+  aspectSel: $("aspectSel"), fpsSel: $("fpsSel"), btnGuides: $("btnGuides"), btnZoom100: $("btnZoom100"),
   safeOverlay: $("safeOverlay"), btnSpeed: $("btnSpeed"),
   monitorStage: $("monitorStage"), monitorScroll: $("monitorScroll"),
   monitorZoomInner: $("monitorZoomInner"), kfGraphs: $("kfGraphs"),
@@ -612,8 +613,8 @@ function applyProject(data) {
   for (const el of runtime.clipEls.values()) { try { el.pause(); el.src = ""; } catch { } }
   runtime.clipEls.clear(); runtime.clipGain.clear();
   els.preview.width = project.width; els.preview.height = project.height;
-  els.monitorRes.textContent = `${project.width} × ${project.height} · ${project.fps}fps`;
   syncAspectSel();
+  syncFpsSel();
   pruneSelection(); // keep the selection across external reloads where possible
   state.dirtyTimeline = true;
   renderBin(); renderInspector();
@@ -5568,7 +5569,7 @@ els.binTabs.addEventListener("contextmenu", (e) => {
   openProjectTabMenu(e.clientX, e.clientY);
 });
 
-/* ── Canvas aspect presets + safe-area guides ── */
+/* ── Canvas aspect presets + project FPS + safe-area guides ── */
 function syncAspectSel() {
   if (!els.aspectSel) return;
   const i = ASPECT_PRESETS.findIndex((a) => a.w === project.width && a.h === project.height);
@@ -5576,13 +5577,31 @@ function syncAspectSel() {
     ASPECT_PRESETS.map((a, j) => `<option value="${j}" ${j === i ? "selected" : ""}>${a.label}</option>`).join("") +
     (i < 0 ? `<option value="custom" selected>Custom · ${project.width}×${project.height}</option>` : "");
 }
+function syncFpsSel() {
+  if (!els.fpsSel) return;
+  const fps = Number(project.fps);
+  const i = FPS_PRESETS.findIndex((v) => v === fps);
+  els.fpsSel.innerHTML =
+    FPS_PRESETS.map((v, j) => `<option value="${j}" ${j === i ? "selected" : ""}>${v} fps</option>`).join("") +
+    (i < 0 && Number.isFinite(fps) && fps > 0
+      ? `<option value="custom" selected>Custom · ${fps} fps</option>`
+      : "");
+}
 els.aspectSel.addEventListener("change", () => {
   const a = ASPECT_PRESETS[+els.aspectSel.value];
   if (!a) return;
   project.width = a.w; project.height = a.h;
   els.preview.width = a.w; els.preview.height = a.h;
-  els.monitorRes.textContent = `${a.w} × ${a.h} · ${project.fps}fps`;
   syncAspectSel();
+  seekMediaWhilePaused();
+  scheduleSave();
+});
+els.fpsSel?.addEventListener("change", () => {
+  const v = FPS_PRESETS[+els.fpsSel.value];
+  if (!(v > 0)) return;
+  project.fps = v;
+  syncFpsSel();
+  state.dirtyTimeline = true;
   seekMediaWhilePaused();
   scheduleSave();
 });

--- a/index.html
+++ b/index.html
@@ -74,8 +74,8 @@
         </span>
         <span class="panel-head-actions">
           <select id="aspectSel" class="head-select" title="Canvas aspect preset"></select>
+          <select id="fpsSel" class="head-select" title="Project frame rate"></select>
           <button class="btn tiny toggle" id="btnGuides" title="Toggle safe-area guides">▦ Safe</button>
-          <span class="dim" id="monitorRes">1280 × 720 · 30fps</span>
         </span>
       </div>
       <div class="monitor-stage" id="monitorStage">

--- a/style.css
+++ b/style.css
@@ -920,6 +920,7 @@ body.track-size-s .clip.selected {
   font: 12px "Segoe UI", sans-serif;
   max-width: 170px;
 }
+#fpsSel.head-select { max-width: 88px; }
 
 /* ── Safe-area guides (positioned over the canvas by JS) ── */
 #safeOverlay {


### PR DESCRIPTION
## Allows to set a fps value per project

<img width="300" height="179" alt="image" src="https://github.com/user-attachments/assets/781fb080-876b-4b7f-a320-7946a2955757" />

**fps** can be set per project; only the resolution was settable before

## Type of change

- [ ] Bug fix
- [X] New feature (transition / preset / text anim / effect / API)
- [X] Docs
- [X] Refactor / internal

## How was it verified?

- [X] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [X] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Project FPS selector to the Program Monitor header.
  * Choose from preset frame rates: 24, 25, 30, 50, or 60 FPS.
  * Non-preset frame rates are displayed as **Custom**.
  * Selected FPS values are saved with the project and applied to timeline previews, timecode, and exports.
* **Documentation**
  * Updated project and feature documentation to describe FPS settings and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->