### PR TITLE
docs: support OpenCode and other MCP clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Working with FableCut
+
+The complete agent manual is in [CLAUDE.md](CLAUDE.md). Read it before changing the project schema, using the MCP tools, or editing the timeline. This file exists so agents that look for the cross-tool `AGENTS.md` convention, including OpenCode and Codex, find the same source of truth without duplicating it.
+
+## Project constraints
+
+- Keep FableCut zero-runtime-dependency and standard-library only.
+- Keep preview and export on the same compositor path.
+- Prefer small, focused changes and preserve the existing terse browser-native style.
+- If a schema, prop, text animation, API, or MCP surface changes, update `CLAUDE.md` and the English `README.md` in the same change.
+- Run `node --check server.js && node --check app.js && node --check mcp-server.js` before opening a PR.
+
+## MCP entry point
+
+The local MCP server is `mcp-server.js`. It can be started by any stdio-capable MCP client:
+
+```bash
+node /absolute/path/to/FableCut/mcp-server.js
+```
+
+Use the existing `CLAUDE.md` recipes and tool descriptions rather than inventing a second protocol or schema.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,39 @@ Three equivalent control surfaces:
    claude mcp add -s user fablecut -- node "<path-to>/fablecut/mcp-server.js"
    ```
 
+   **OpenCode** can use the same stdio server from its project or global
+   `opencode.json` configuration:
+
+   ```json
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "mcp": {
+       "fablecut": {
+         "type": "local",
+         "command": ["node", "/absolute/path/to/FableCut/mcp-server.js"],
+         "enabled": true
+       }
+     }
+   }
+   ```
+
+   For another MCP client, register a local stdio server with this equivalent
+   command. The exact key names vary by client, but the command and arguments
+   do not:
+
+   ```json
+   {
+     "name": "fablecut",
+     "transport": "stdio",
+     "command": "node",
+     "args": ["/absolute/path/to/FableCut/mcp-server.js"]
+   }
+   ```
+
+   The server is intentionally client-neutral. It speaks MCP over stdio and
+   does not require Claude-specific environment variables. Keep the path
+   absolute, and use Node 18 or newer.
+
    Tools: `fablecut_status` (auto-starts the editor), `fablecut_docs`,
    `fablecut_get_project`, `fablecut_set_project`, `fablecut_patch_project`,
    `fablecut_import_media`, `fablecut_analyze_reference`.


### PR DESCRIPTION
## Summary

Closes #6.

- add `AGENTS.md` as a cross-tool pointer to the existing `CLAUDE.md` manual
- document OpenCode stdio configuration for the bundled MCP server
- add a client-neutral stdio example for other MCP clients
- make the Node 18 requirement and project constraints visible to non-Claude agents

## Why

FableCut's MCP server is already client-neutral, but the setup path was documented primarily for Claude. This keeps one source of truth while making the existing integration discoverable to OpenCode, Codex, and other stdio-capable clients.

## Verification

- `node --check server.js`
- `node --check app.js`
- `node --check mcp-server.js`
- validated the OpenCode JSON example with Python's JSON parser
- `git diff --check`

No runtime code or dependencies changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring the FableCut MCP server with OpenCode and other MCP-compatible clients.
  * Included local stdio configuration examples, equivalent commands, absolute path guidance, and the Node.js 18+ requirement.
  * Added project contribution guidance covering documentation updates, validation commands, and local MCP server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->