### PR TITLE
feat(svg): add countdown-ring, rec-indicator, and swipe-up animated overlays

### DIFF
--- a/library/svg/countdown-ring.svg
+++ b/library/svg/countdown-ring.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400">
+  <!-- FableCut animated SVG · one-shot (~3s) · countdown ring 3 → 2 → 1
+       Useful for video intros, transitions, and "ready" cues. -->
+  <style>
+    /* Ring sweep — draws a circular arc over 1s per digit */
+    .ring {
+      fill: none;
+      stroke-width: 8;
+      stroke-linecap: round;
+      stroke-dasharray: 502.65;
+      stroke-dashoffset: 502.65;
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: sweep 1s cubic-bezier(.4,0,.2,1) both;
+    }
+    @keyframes sweep {
+      0%   { stroke-dashoffset: 502.65; opacity: 0.3; }
+      10%  { opacity: 1; }
+      100% { stroke-dashoffset: 0; opacity: 1; }
+    }
+
+    /* Digit pop-in */
+    .digit {
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+      font-weight: 700;
+      font-size: 120px;
+      text-anchor: middle;
+      dominant-baseline: central;
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: pop 0.4s cubic-bezier(.34,1.56,.64,1) both;
+      opacity: 0;
+    }
+    @keyframes pop {
+      0%   { transform: scale(0.3); opacity: 0; }
+      60%  { transform: scale(1.1); opacity: 1; }
+      100% { transform: scale(1);   opacity: 1; }
+    }
+
+    /* Digit fade-out at end of each second */
+    .digit-out {
+      animation: fadeOut 0.25s ease-in both;
+    }
+    @keyframes fadeOut {
+      0%   { opacity: 1; transform: scale(1); }
+      100% { opacity: 0; transform: scale(0.8); }
+    }
+
+    /* Outer glow pulse */
+    .glow {
+      fill: none;
+      stroke-width: 2;
+      opacity: 0;
+      animation: glowPulse 1s ease-out both;
+    }
+    @keyframes glowPulse {
+      0%   { opacity: 0.6; stroke-width: 8; }
+      100% { opacity: 0;   stroke-width: 30; }
+    }
+  </style>
+
+  <!-- "3" group — 0s to 1s -->
+  <g>
+    <!-- glow -->
+    <circle class="glow" style="--d:0s" cx="200" cy="200" r="150" stroke="#ff6b6b"/>
+    <!-- ring -->
+    <circle class="ring" style="--d:0s" cx="200" cy="200" r="80" stroke="#ff6b6b"/>
+    <!-- digit -->
+    <text class="digit" style="--d:0s" x="200" y="200" fill="#ff6b6b">3</text>
+  </g>
+
+  <!-- "2" group — 1s to 2s -->
+  <g>
+    <circle class="glow" style="--d:1s" cx="200" cy="200" r="150" stroke="#ffd166"/>
+    <circle class="ring" style="--d:1s" cx="200" cy="200" r="80" stroke="#ffd166"/>
+    <text class="digit" style="--d:1s" x="200" y="200" fill="#ffd166">2</text>
+  </g>
+
+  <!-- "1" group — 2s to 3s -->
+  <g>
+    <circle class="glow" style="--d:2s" cx="200" cy="200" r="150" stroke="#6ee7b7"/>
+    <circle class="ring" style="--d:2s" cx="200" cy="200" r="80" stroke="#6ee7b7"/>
+    <text class="digit" style="--d:2s" x="200" y="200" fill="#6ee7b7">1</text>
+  </g>
+</svg>

--- a/library/svg/countdown-ring.svg
+++ b/library/svg/countdown-ring.svg
@@ -12,6 +12,7 @@
       transform-box: fill-box;
       transform-origin: center;
       animation: sweep 1s cubic-bezier(.4,0,.2,1) both;
+      animation-delay: var(--d, 0s);
     }
     @keyframes sweep {
       0%   { stroke-dashoffset: 502.65; opacity: 0.3; }
@@ -28,13 +29,18 @@
       dominant-baseline: central;
       transform-box: fill-box;
       transform-origin: center;
-      animation: pop 0.4s cubic-bezier(.34,1.56,.64,1) both;
+      animation: pop 0.4s cubic-bezier(.34,1.56,.64,1) both,
+                 hideAtEnd 0.01s linear 1s both;
+      animation-delay: var(--d, 0s), calc(var(--d, 0s) + 0.99s);
       opacity: 0;
     }
     @keyframes pop {
       0%   { transform: scale(0.3); opacity: 0; }
       60%  { transform: scale(1.1); opacity: 1; }
       100% { transform: scale(1);   opacity: 1; }
+    }
+    @keyframes hideAtEnd {
+      to { opacity: 0; }
     }
 
     /* Digit fade-out at end of each second */
@@ -52,6 +58,7 @@
       stroke-width: 2;
       opacity: 0;
       animation: glowPulse 1s ease-out both;
+      animation-delay: var(--d, 0s);
     }
     @keyframes glowPulse {
       0%   { opacity: 0.6; stroke-width: 8; }

--- a/library/svg/rec-indicator.svg
+++ b/library/svg/rec-indicator.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80" viewBox="0 0 200 80">
+  <!-- FableCut animated SVG · loop · live-recording REC indicator
+       Pulsing red dot + "REC" label. Great for "live" overlays. -->
+  <style>
+    .dot {
+      fill: #ff3b30;
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: pulse 1.2s ease-in-out infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.4; transform: scale(0.75); }
+    }
+    .ring {
+      fill: none;
+      stroke: #ff3b30;
+      stroke-width: 2;
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: ringPulse 1.2s ease-out infinite;
+    }
+    @keyframes ringPulse {
+      0%   { opacity: 0.8; r: 14; }
+      100% { opacity: 0;   r: 28; }
+    }
+    .label {
+      font-family: 'Helvetica Neue', Arial, sans-serif;
+      font-weight: 700;
+      font-size: 28px;
+      fill: #ff3b30;
+      letter-spacing: 3px;
+    }
+  </style>
+  <!-- Pulsing ring -->
+  <circle class="ring" style="--d:0s" cx="30" cy="40" r="14"/>
+  <!-- Solid dot -->
+  <circle class="dot" style="--d:0s" cx="30" cy="40" r="10"/>
+  <!-- REC text -->
+  <text class="label" x="58" y="48">REC</text>
+</svg>

--- a/library/svg/swipe-up.svg
+++ b/library/svg/swipe-up.svg
@@ -22,6 +22,7 @@
     }
     .fade-arrow {
       animation: fadeUp 1s ease-in-out infinite;
+      animation-delay: var(--d, 0s);
     }
     @keyframes fadeUp {
       0%, 100% { opacity: 0.2; transform: translateY(10px); }

--- a/library/svg/swipe-up.svg
+++ b/library/svg/swipe-up.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="200" viewBox="0 0 120 200">
+  <!-- FableCut animated SVG · loop · "swipe up" hand gesture
+       Bouncing upward arrow/hand for social-media CTAs. -->
+  <style>
+    .hand {
+      transform-box: fill-box;
+      transform-origin: center bottom;
+      animation: bounce 1s cubic-bezier(.36,0,.66,1) infinite;
+    }
+    @keyframes bounce {
+      0%, 100% { transform: translateY(0); }
+      40%      { transform: translateY(-30px); }
+      60%      { transform: translateY(-30px); }
+    }
+    .arrow {
+      stroke: #ffffff;
+      stroke-width: 4;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      fill: none;
+      opacity: 0.9;
+    }
+    .fade-arrow {
+      animation: fadeUp 1s ease-in-out infinite;
+    }
+    @keyframes fadeUp {
+      0%, 100% { opacity: 0.2; transform: translateY(10px); }
+      40%      { opacity: 0.9; transform: translateY(-10px); }
+      60%      { opacity: 0.9; transform: translateY(-10px); }
+    }
+  </style>
+  <!-- Trailing chevrons (fade up) -->
+  <g class="fade-arrow" style="--d:0s">
+    <polyline class="arrow" points="30,140 60,110 90,140"/>
+  </g>
+  <g class="fade-arrow" style="--d:0.15s">
+    <polyline class="arrow" points="30,170 60,140 90,170" opacity="0.5"/>
+  </g>
+  <!-- Hand / main chevron -->
+  <g class="hand">
+    <polyline class="arrow" points="20,100 60,55 100,100" stroke-width="5"/>
+    <!-- Palm base -->
+    <rect x="45" y="95" width="30" height="12" rx="6" fill="#ffffff" opacity="0.85"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Three new time-driven animated SVG elements for the built-in asset library (), closing #27.

### New SVGs

| File | Type | Duration | Use case |
|------|------|----------|----------|
|  | one-shot | ~3s | Video intros, ready cues, transitions |
|  | loop | continuous | Live/REC overlays, streaming UI |
|  | loop | continuous | Social-media CTAs, engagement prompts |

### Convention compliance

All three follow the required conventions from CLAUDE.md:

- ✅ CSS `@keyframes` in `<style>` block (no SMIL)
- ✅ `--d` custom property for staggered delays (no literal `animation-delay`)
- ✅ `transform-box: fill-box; transform-origin: center;` for rotation/scale
- ✅ `animation-fill-mode: both` for one-shots, `infinite` for loops
- ✅ Root `<svg>` has `width`/`height` and `viewBox`
- ✅ Self-contained — no external hrefs
- ✅ Frame-accurate — animations driven by clip local time, not wall-clock

### Design details

**countdown-ring.svg** — A circular arc that sweeps closed over 1s per digit (3→2→1), with a pop-in digit and expanding glow ring. Each digit uses a distinct color (red→gold→green) for visual progression.

**rec-indicator.svg** — Pulsing red dot with an expanding ring aura and bold "REC" label. The dot scales between 1.0 and 0.75 with opacity fade; the ring expands and fades simultaneously.

**swipe-up.svg** — Bouncing upward chevron with two trailing fade-in/fade-out chevrons below. The main hand group translates vertically on a 1s loop; trailing chevrons stagger with `--d`.

### Testing

- [x] All SVGs pass XML validation
- [x] Follows same patterns as existing `sparkles.svg`, `confetti-burst.svg`, `underline-swoosh.svg`
- [x] No JavaScript dependencies
- [x] No external resources loaded