### PR TITLE
Tag exports BT.709 so they stop rendering darker than the preview

### DIFF
--- a/server.js
+++ b/server.js
@@ -154,7 +154,14 @@ function beginExport(fps, name) {
   const videoPath = path.join(dir, "video.mp4");
   const proc = spawn("ffmpeg", [
     "-y", "-f", "image2pipe", "-framerate", String(fps), "-i", "-",
+    // The browser's JPEG frames are full-range BT.601 (JFIF). Convert them to
+    // limited-range BT.709 and TAG the stream, otherwise x264 emits bt470bg/pc/
+    // unknown and players do the wrong YUV->RGB conversion — the render comes
+    // out darker than the preview.
+    "-vf", "scale=in_range=full:in_color_matrix=bt601:out_range=tv:out_color_matrix=bt709",
     "-c:v", "libx264", "-preset", "fast", "-crf", "18", "-pix_fmt", "yuv420p",
+    "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709",
+    "-color_range", "tv",
     videoPath,
   ], { stdio: ["pipe", "ignore", "pipe"] });
   let stderr = "";
@@ -339,12 +346,17 @@ const server = http.createServer(async (req, res) => {
       const code = await sess.done;
       if (code !== 0) throw new Error("ffmpeg encode failed: " + sess.err());
       const out = uniquePath(EXPORTS_DIR, sess.name.replace(/\.mp4$/i, "") + ".mp4");
+      // Re-assert the bt709 tags on the mux — a stream-copy pass can drop the
+      // container-level colr atom even though the SPS still carries them.
+      const TAGS = ["-colorspace", "bt709", "-color_primaries", "bt709",
+                    "-color_trc", "bt709", "-color_range", "tv"];
       if (sess.wav && fs.existsSync(sess.wav))
         await run("ffmpeg", ["-y", "-i", sess.videoPath, "-i", sess.wav,
           "-c:v", "copy", "-c:a", "aac", "-b:a", "192k", "-shortest",
-          "-movflags", "+faststart", out]);
+          ...TAGS, "-movflags", "+faststart", out]);
       else
-        await run("ffmpeg", ["-y", "-i", sess.videoPath, "-c", "copy", "-movflags", "+faststart", out]);
+        await run("ffmpeg", ["-y", "-i", sess.videoPath, "-c", "copy",
+          ...TAGS, "-movflags", "+faststart", out]);
       cleanupExport(id);
       sendJSON(res, 200, { ok: true, src: "/exports/" + encodeURIComponent(path.basename(out)) });
     } catch (e) { cleanupExport(id); sendJSON(res, 500, { error: String(e) }); }


### PR DESCRIPTION
## The problem

Exports come out noticeably darker and flatter than the timeline preview. It is most visible on saturated reds and on skin.

## Why

`beginExport` pipes the browser's JPEG frames into ffmpeg over `image2pipe`. Those frames are **full-range BT.601 (JFIF)** — that is what canvas `toDataURL`/`toBlob` produces. Nothing in the command declares it, so x264 writes `bt470bg` / unspecified into the SPS. Players then pick the wrong YUV→RGB matrix on playback and the result no longer matches what was composited.

## The fix

Convert full-range BT.601 to limited-range BT.709 on the way in, and tag the encode:

```
-vf scale=in_range=full:in_color_matrix=bt601:out_range=tv:out_color_matrix=bt709
-colorspace bt709 -color_primaries bt709 -color_trc bt709 -color_range tv
```

The tags are re-asserted on the final mux as well. The `-c:v copy` pass drops the container-level `colr` atom even though the SPS still carries the values, and some players read the atom first.

No change to encoder settings, preset, CRF, or output size.

## Checking it

```
ffprobe -v error -select_streams v:0 \
  -show_entries stream=color_space,color_primaries,color_transfer,color_range \
  -of default=noprint_wrappers=1 out.mp4
```

Before: `unknown` / `bt470bg`, `color_range=pc`. After: `bt709` across the board with `color_range=tv`.

Found while cutting a short film in FableCut, where the graded look kept dying on export. Happy to adjust the approach if you would rather tag without the scale filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exported video color accuracy and consistency.
  * Added explicit color metadata to video and audio exports for better playback compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->