### PR TITLE
fix(mcp): negotiate initialize protocolVersion instead of echoing unknowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- MCP `initialize` no longer echoes an unsupported `protocolVersion`. Missing or unknown versions now negotiate to `2025-11-25` instead of claiming a revision the server does not speak (#58).
+
 ## [1.7.0] - 2026-08-25
 
 The community release — 20 merged pull requests. Audio gets real tracks and real

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -26,6 +26,14 @@ ensureDirs();
 const PORT = process.env.FABLECUT_PORT || 7777;
 const BASE = `http://localhost:${PORT}`;
 
+/* MCP initialize must echo a version we actually speak. Echoing an unknown
+   client version (or crashing) fails handshake with stock SDK clients. */
+const MCP_PROTOCOL_VERSIONS = ["2025-11-25", "2025-06-18", "2024-11-05"];
+const MCP_DEFAULT_PROTOCOL_VERSION = MCP_PROTOCOL_VERSIONS[0];
+function negotiateProtocolVersion(requested) {
+  return MCP_PROTOCOL_VERSIONS.includes(requested) ? requested : MCP_DEFAULT_PROTOCOL_VERSION;
+}
+
 /* ── Helpers ── */
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 function readProject() {
@@ -454,7 +462,7 @@ async function handle(msg) {
       return send({
         jsonrpc: "2.0", id,
         result: {
-          protocolVersion: params?.protocolVersion || "2025-06-18",
+          protocolVersion: negotiateProtocolVersion(params?.protocolVersion),
           capabilities: { tools: {} },
           serverInfo: { name: "fablecut", version: "1.7.0" },
         },


### PR DESCRIPTION
## What does this PR do?

`mcp-server.js` echoed whatever `protocolVersion` the client sent on `initialize`, including versions the server does not speak. Missing versions fell back to `2025-06-18`.

That fails MCP version negotiation: if the server does not support the requested revision, it must answer with one it does support (latest preferred), not echo the unknown value. Stock SDK clients then fail the handshake.

This change:

- Echoes `2025-11-25`, `2025-06-18`, or `2024-11-05` when the client asks for one of those
- Otherwise answers with `2025-11-25` (missing, empty, or unknown)

Closes #58

## Type of change

- [x] Bug fix
- [ ] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [x] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
- [ ] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

Handshake cases over stdio (newline JSON-RPC):

| Client `protocolVersion` | Before | After |
| --- | --- | --- |
| missing / empty params | `2025-06-18` | `2025-11-25` |
| `2099-01-01` | echoed `2099-01-01` | `2025-11-25` |
| `2025-11-25` | echoed | `2025-11-25` |
| `2025-06-18` | echoed | `2025-06-18` |
| `2024-11-05` | echoed | `2024-11-05` |

The process stayed up for all of those. Preview/export N/A — MCP handshake only.

## Checklist

- [x] No new runtime dependencies added
- [x] Preview and export render identically (single compositor)
- [x] Commits are focused and messages are descriptive

Limitation: I did not run `@hasmcp/mcp-spec-test` in Docker. The "server exited" cases in #58 look like the clone/`npm install` launch wrapper (same as #57). The real bug I could reproduce locally is echoing an unsupported version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP protocol version negotiation during initialization.
  - Unsupported or missing protocol versions now fall back to the supported default instead of being echoed incorrectly.
  - Compatible requested versions continue to be honored.

- **Documentation**
  - Added a changelog entry describing the initialization handshake fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->