### PR TITLE
test: add a behavioral test suite and run it in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,8 @@ Closes #
 
 ## How was it verified?
 
-- [ ] `node --check server.js && node --check app.js && node --check mcp-server.js` passes
+- [ ] `npm test` passes (CI runs it on Node 18 / 20 / 22)
+- [ ] Added or updated a test in `test/` if this touches the MCP surface, the REST API, or the SVG library
 - [ ] Opened the editor and confirmed the change in **preview**
 - [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
 - [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,27 @@ on:
     branches: [main]
 
 jobs:
+  test:
+    name: Tests (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The oldest version package.json supports, the current LTS, and latest.
+        node: ["18", "20", "22"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      # No install step on purpose: FableCut has no runtime dependencies and the
+      # suite uses only node:test. A missing `npm install` here is the feature.
+      - name: Run the test suite
+        run: npm test
+
   check:
     name: Syntax & sanity
     runs-on: ubuntu-latest
@@ -66,18 +87,4 @@ jobs:
               console.error('library was not seeded'); process.exit(1);
             }
             console.log('split layout OK');
-          "
-
-      - name: Validate library SVGs
-        run: |
-          node -e "
-            const fs = require('fs');
-            const dir = 'library/svg';
-            let bad = 0;
-            for (const f of fs.readdirSync(dir).filter(n => n.endsWith('.svg'))) {
-              const s = fs.readFileSync(dir + '/' + f, 'utf8').trim();
-              if (!s.includes('<svg') || !s.endsWith('</svg>')) { console.error('malformed:', f); bad++; }
-            }
-            if (bad) process.exit(1);
-            console.log('all SVGs OK');
           "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A real test suite (`npm test`, zero dependencies, `node:test`): MCP protocol
+  negotiation and framing, MCP tool semantics including the conflict rules, the
+  REST API with its Host/Origin and path-traversal guards, and the shipped SVG
+  library. CI runs it on Node 18, 20 and 22 for every pull request.
+
 ### Fixed
 - MCP `initialize` no longer echoes an unsupported `protocolVersion`. Missing or unknown versions now negotiate to `2025-11-25` instead of claiming a revision the server does not speak (#58).
+- `CLAUDE.md` pointed agents at `fablecut_docs {section:"props"}`, which matches no `## ` heading and returns nothing useful; it now names a real section.
 
 ## [1.7.0] - 2026-08-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Editing via full get→modify→set costs thousands of tokens per change. Cheape
    `{ops:[{op:"updateClip", id:"c_v2", set:{props:{filterPreset:"noir"}}}]}`.
    It re-reads the latest document internally, so it is merge-safe by design
    (no CONFLICT dance) and never destroys concurrent UI tweaks.
-3. **Docs**: request `fablecut_docs {section:"props"}` (or "Recipes", "Remake", …)
+3. **Docs**: request `fablecut_docs {section:"schema"}` (or "Recipes", "Remake", …)
    instead of the whole manual; skip it entirely if the schema is already in context.
 4. **Media questions** (duration, fps, size): read them from the registered media
    entries — don't shell out to ffprobe; the browser probes and writes them back.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,12 +40,20 @@ recommended) **ffmpeg on PATH** for fast export and upload remuxing.
 
 1. Fork and branch from `main` (`git checkout -b my-feature`).
 2. Make your change. Keep commits focused.
-3. **Sanity-check the JS** before pushing:
+3. **Run the test suite** before pushing:
    ```bash
-   node --check server.js && node --check app.js && node --check mcp-server.js
+   npm test          # node --test — no install needed, no dependencies
    ```
+   It covers the MCP protocol and tools, the REST API and its path/Host guards,
+   and the shipped SVG library. CI runs the same command on Node 18, 20 and 22
+   for every pull request. Add a test with your change when it touches any of
+   those surfaces — see [`test/`](test/) and the harness in `test/helpers.js`
+   (every test gets a throwaway data dir and its own port, so the suite never
+   touches your real `project.json`).
+
    Then open the editor and confirm your change renders in **both** preview and a
-   test export.
+   test export — the compositor itself runs in the browser and is not covered by
+   the suite.
 4. If you touched the `project.json` schema, props, transitions, text anims, or
    the API, **update `CLAUDE.md` and the `README.md` feature list** in the same PR.
 5. Open a pull request against `main` using the PR template. Describe what changed

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Zero-dependency browser video editor that AI agents can drive — JSON timeline, MCP server, REST API, live-reloading UI.",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "keywords": [
     "video-editor",

--- a/test/assets.test.js
+++ b/test/assets.test.js
@@ -1,0 +1,98 @@
+/* Shipped assets and their documented contracts.
+
+   The SVG rules below are not style preferences — each one maps to a way the
+   compositor actually fails. Animated SVGs are frozen at time t by injecting
+   `*{animation-play-state:paused!important; animation-delay:calc(var(--d,0s) - t)!important}`
+   after the opening <svg> tag and rasterising the result through a data: URI
+   (see svgUrlAt / loadSvgMedia in app.js). Anything that defeats that
+   injection, or that a data: URI cannot load, renders wrongly in preview and
+   export alike. */
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { ROOT } = require("./helpers");
+
+const SVG_DIR = path.join(ROOT, "library", "svg");
+const svgFiles = fs.readdirSync(SVG_DIR).filter((f) => f.endsWith(".svg"));
+
+test("there are library SVGs to validate", () => {
+  // Guards the suite itself: a glob that silently matches nothing would make
+  // every check below vacuously pass.
+  assert.ok(svgFiles.length > 0, "no SVGs found — the checks below would be meaningless");
+});
+
+test("every library SVG is well-formed and self-contained", () => {
+  for (const f of svgFiles) {
+    const s = fs.readFileSync(path.join(SVG_DIR, f), "utf8").trim();
+    assert.match(s, /^<svg[\s>]|^<\?xml/i, `${f}: does not start with an <svg> root`);
+    assert.match(s, /<\/svg>$/, `${f}: truncated — does not end with </svg>`);
+
+    // parseSvgSize() falls back to 800x600 when it cannot find a size, which
+    // silently rescales the clip on the canvas.
+    assert.match(s, /<svg[^>]*\s(width|viewBox)=/i, `${f}: needs a width/height or viewBox`);
+
+    // Rasterisation happens from a data: URI, which cannot fetch anything.
+    assert.doesNotMatch(s, /(?:href|src)\s*=\s*["']https?:/i,
+      `${f}: external reference will not load when rasterised from a data: URI`);
+  }
+});
+
+test("animated library SVGs stay drivable by the compositor clock", () => {
+  for (const f of svgFiles) {
+    const s = fs.readFileSync(path.join(SVG_DIR, f), "utf8");
+
+    // SMIL is wall-clock driven and ignores the injected CSS entirely, so it
+    // would animate in preview and freeze (or drift) in export.
+    assert.doesNotMatch(s, /<animate(?:Transform|Motion)?[\s>]/i,
+      `${f}: uses SMIL <animate>; CSS @keyframes are required`);
+
+    // The engine's override is !important at specificity (0,0,0). An author
+    // !important on a class selector outranks it and pins the animation.
+    assert.doesNotMatch(s, /animation-delay\s*:[^;}]*!important/i,
+      `${f}: !important animation-delay overrides the compositor's time driver`);
+    assert.doesNotMatch(s, /animation-play-state\s*:[^;}]*!important/i,
+      `${f}: !important animation-play-state defeats the compositor's pause`);
+
+    // A hardcoded delay is silently discarded by the override, so the author's
+    // intended stagger is lost. `--d` is the supported way to express it.
+    const delays = s.match(/animation-delay\s*:[^;}]*/gi) || [];
+    for (const d of delays) {
+      assert.match(d, /var\(\s*--d/,
+        `${f}: hardcoded "${d.trim()}" is discarded at render time; set --d on the element instead`);
+    }
+
+    // A file that declares --d but has no keyframes is staging a stagger that
+    // will never run.
+    if (/--d\s*:/.test(s)) {
+      assert.match(s, /@keyframes/,
+        `${f}: sets --d for a stagger but defines no @keyframes`);
+    }
+  }
+});
+
+test("the documented starter SVGs still ship", () => {
+  // CLAUDE.md points authors at these by name as the worked examples.
+  for (const named of ["sparkles.svg", "lower-third.svg", "confetti-burst.svg", "underline-swoosh.svg"]) {
+    assert.ok(svgFiles.includes(named), `CLAUDE.md cites library/svg/${named} but it is missing`);
+  }
+});
+
+test("shipped JSON files parse", () => {
+  const files = ["package.json", "manifest.json", "glama.json", "project.json"];
+  for (const f of files) {
+    const p = path.join(ROOT, f);
+    if (!fs.existsSync(p)) continue;   // optional files stay optional
+    assert.doesNotThrow(() => JSON.parse(fs.readFileSync(p, "utf8")), `${f} is not valid JSON`);
+  }
+});
+
+test("package.json declares no runtime dependencies", () => {
+  // The project's headline constraint: `node server.js` must work on a bare
+  // clone with no npm install.
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+  assert.deepEqual(pkg.dependencies ?? {}, {},
+    "FableCut must stay zero-runtime-dependency");
+  assert.ok(pkg.scripts?.test, "package.json needs a test script so CI can run the suite");
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,193 @@
+/* Shared harness for the FableCut test suite.
+
+   Every test runs against a throwaway FABLECUT_DATA_DIR and a private port, so
+   the suite never touches the developer's real project.json or collides with an
+   editor they already have open on 7777. Readiness is always established by
+   polling for a real response — never by sleeping for a guessed interval. */
+"use strict";
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const ROOT = path.join(__dirname, "..");
+
+/* A minimal but schema-valid project, used as the starting state for tests. */
+function seedProject(over = {}) {
+  return {
+    name: "Test Project", width: 1280, height: 720, fps: 30, revision: 1,
+    media: [{ id: "m_a", name: "a.mp4", kind: "video", src: "/media/a.mp4", duration: 10 }],
+    clips: [{ id: "c_a", mediaId: "m_a", kind: "video", track: "V1", start: 0, in: 0, duration: 5 }],
+    ...over,
+  };
+}
+
+/* Temp data dir, removed when the test finishes (pass or fail). */
+function makeDataDir(t, project = seedProject()) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-test-"));
+  fs.writeFileSync(path.join(dir, "project.json"), JSON.stringify(project, null, 2));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+const readProject = (dir) => JSON.parse(fs.readFileSync(path.join(dir, "project.json"), "utf8"));
+const writeProject = (dir, doc) =>
+  fs.writeFileSync(path.join(dir, "project.json"), JSON.stringify(doc, null, 2));
+
+/* Ask the OS for a port nobody is using, then release it for the child. */
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer();
+    probe.unref();
+    probe.on("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+/* Start server.js on its own port + data dir and wait until it actually
+   answers. Rejects fast if the child dies instead of hanging until timeout. */
+async function startServer(t, dataDir) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const port = await freePort();
+    const child = spawn(process.execPath, [path.join(ROOT, "server.js")], {
+      cwd: ROOT,
+      env: { ...process.env, PORT: String(port), HOST: "127.0.0.1", FABLECUT_DATA_DIR: dataDir },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let exited = null;
+    child.on("exit", (code) => { exited = code; });
+    let stderr = "";
+    child.stderr.on("data", (c) => { stderr += c; });
+    child.stdout.resume();
+
+    const base = `http://127.0.0.1:${port}`;
+    const stop = () => new Promise((resolve) => {
+      if (exited !== null) return resolve();
+      child.once("exit", () => resolve());
+      child.kill();
+    });
+
+    const deadline = Date.now() + 20_000;
+    let ready = false;
+    while (Date.now() < deadline && exited === null) {
+      try {
+        const r = await fetch(base + "/api/project");
+        if (r.status === 200) { await r.text(); ready = true; break; }
+      } catch { /* not listening yet */ }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (ready) {
+      t.after(stop);
+      return { base, port, child, stop };
+    }
+    await stop();
+    // A lost port race is the only retryable failure; anything else is a bug.
+    if (!/EADDRINUSE/.test(stderr)) {
+      throw new Error(`server.js did not become ready (exit=${exited})\n${stderr}`);
+    }
+  }
+  throw new Error("could not find a free port for server.js after 3 attempts");
+}
+
+/* A raw HTTP GET that sends the request line and headers verbatim.
+
+   fetch() cannot express these tests: it refuses to set a Host header, and the
+   WHATWG URL parser collapses `%2e%2e` before the request leaves the client, so
+   a traversal attempt would never reach the server at all. */
+function rawGet(port, rawPath, headers = {}) {
+  const http = require("node:http");
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: "127.0.0.1", port, method: "GET", path: rawPath, headers },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (c) => { body += c; });
+        res.on("end", () => resolve({ status: res.statusCode, headers: res.headers, body }));
+      });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+/* Line-delimited JSON-RPC client for mcp-server.js over stdio. Responses are
+   matched by id, so out-of-order or interleaved replies cannot cross wires. */
+function startMcp(t, dataDir, env = {}) {
+  const child = spawn(process.execPath, [path.join(ROOT, "mcp-server.js")], {
+    cwd: ROOT,
+    env: { ...process.env, FABLECUT_DATA_DIR: dataDir, ...env },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const pending = new Map();
+  const inbox = [];           // messages with no matching request (notifications)
+  let exited = null, stderr = "", buf = "";
+  child.on("exit", (code) => {
+    exited = code;
+    for (const { reject } of pending.values())
+      reject(new Error(`mcp-server exited (code ${code}) with the request in flight\n${stderr}`));
+    pending.clear();
+  });
+  child.stderr.on("data", (c) => { stderr += c; });
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    buf += chunk;
+    let nl;
+    while ((nl = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (!line) continue;
+      const msg = JSON.parse(line);
+      const p = pending.get(msg.id);
+      if (p) { pending.delete(msg.id); p.resolve(msg); } else inbox.push(msg);
+    }
+  });
+
+  let nextId = 1;
+  const api = {
+    child,
+    get exited() { return exited; },
+    get stderr() { return stderr; },
+    /* Unsolicited messages received so far — used to prove notifications get
+       no reply, and that nothing extra is written to the wire. */
+    unmatched: () => inbox.slice(),
+    notify(method, params) {
+      child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+    },
+    request(method, params, { timeout = 15_000 } = {}) {
+      if (exited !== null) return Promise.reject(new Error(`mcp-server already exited (${exited})`));
+      const id = nextId++;
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(new Error(`timed out waiting for a response to ${method}`));
+        }, timeout);
+        pending.set(id, {
+          resolve: (m) => { clearTimeout(timer); resolve(m); },
+          reject: (e) => { clearTimeout(timer); reject(e); },
+        });
+        child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      });
+    },
+    /* Convenience: call a tool and return its text payload. */
+    async callTool(name, args = {}) {
+      const res = await api.request("tools/call", { name, arguments: args });
+      assert.ok(res.result, `tools/call ${name} returned no result: ${JSON.stringify(res)}`);
+      return { text: res.result.content[0].text, isError: !!res.result.isError };
+    },
+    stop: () => new Promise((resolve) => {
+      if (exited !== null) return resolve();
+      child.once("exit", () => resolve());
+      child.stdin.end();
+      child.kill();
+    }),
+  };
+  t.after(api.stop);
+  return api;
+}
+
+module.exports = { ROOT, seedProject, makeDataDir, readProject, writeProject, startServer, startMcp, rawGet };

--- a/test/mcp-protocol.test.js
+++ b/test/mcp-protocol.test.js
@@ -1,0 +1,115 @@
+/* MCP wire protocol: the handshake and JSON-RPC framing every client depends on.
+   Regression cover for #58 / #59 — an initialize that echoed a version the
+   server does not speak, and handshake edge cases that must not kill the
+   process. Each case also proves the server is still alive afterwards, because
+   "answered once, then died" is exactly the failure that was reported. */
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { ROOT, makeDataDir, startMcp } = require("./helpers");
+
+const SUPPORTED = ["2025-11-25", "2025-06-18", "2024-11-05"];
+const LATEST = "2025-11-25";
+
+async function stillAlive(mcp) {
+  const pong = await mcp.request("ping", {});
+  assert.deepEqual(pong.result, {}, "server should answer ping after the handshake");
+}
+
+test("initialize echoes each protocol version the server actually speaks", async (t) => {
+  const mcp = startMcp(t, makeDataDir(t));
+  for (const version of SUPPORTED) {
+    const res = await mcp.request("initialize", { protocolVersion: version, capabilities: {} });
+    assert.equal(res.result.protocolVersion, version, `should echo supported ${version}`);
+  }
+  await stillAlive(mcp);
+});
+
+test("initialize downgrades an unsupported version instead of echoing it", async (t) => {
+  const mcp = startMcp(t, makeDataDir(t));
+  for (const bogus of ["2099-01-01", "not-a-version", "2024-01-01", ""]) {
+    const res = await mcp.request("initialize", { protocolVersion: bogus, capabilities: {} });
+    assert.notEqual(res.result.protocolVersion, bogus,
+      `must not claim to speak ${JSON.stringify(bogus)}`);
+    assert.equal(res.result.protocolVersion, LATEST);
+  }
+  await stillAlive(mcp);
+});
+
+test("initialize without a version is served on the default and does not kill the server", async (t) => {
+  const mcp = startMcp(t, makeDataDir(t));
+  for (const params of [undefined, {}, { capabilities: {} }]) {
+    const res = await mcp.request("initialize", params);
+    assert.equal(res.result.protocolVersion, LATEST);
+  }
+  await stillAlive(mcp);
+});
+
+test("initialize result carries the capabilities and serverInfo clients read", async (t) => {
+  const mcp = startMcp(t, makeDataDir(t));
+  const { result } = await mcp.request("initialize", { protocolVersion: LATEST });
+  assert.deepEqual(result.capabilities, { tools: {} });
+  assert.equal(result.serverInfo.name, "fablecut");
+  assert.match(result.serverInfo.version, /^\d+\.\d+\.\d+$/);
+});
+
+test("the advertised server version tracks package.json", async () => {
+  // Drift here means clients report a version the release does not match.
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+  const src = fs.readFileSync(path.join(ROOT, "mcp-server.js"), "utf8");
+  const declared = (src.match(/serverInfo:\s*\{[^}]*version:\s*"([^"]+)"/) || [])[1];
+  assert.equal(declared, pkg.version,
+    "mcp-server.js serverInfo.version and package.json version must be bumped together");
+});
+
+test("tools/list advertises well-formed tools", async (t) => {
+  const mcp = startMcp(t, makeDataDir(t));
+  await mcp.request("initialize", { protocolVersion: LATEST });
+  const { result } = await mcp.request("tools/list");
+  assert.ok(Array.isArray(result.tools) && result.tools.length > 0);
+  for (const tool of result.tools) {
+    assert.match(tool.name, /^fablecut_[a-z_]+$/, `odd tool name: ${tool.name}`);
+    assert.ok(tool.description && tool.description.length > 20, `${tool.name} needs a real description`);
+    assert.equal(tool.inputSchema.type, "object", `${tool.name} inputSchema must be an object schema`);
+    for (const req of tool.inputSchema.required || []) {
+      assert.ok(tool.inputSchema.properties?.[req],
+        `${tool.name} marks "${req}" required but never defines it`);
+    }
+  }
+  // The documented surface must stay present; extra tools are allowed to appear.
+  const names = result.tools.map((x) => x.name);
+  for (const expected of ["fablecut_status", "fablecut_docs", "fablecut_get_project",
+    "fablecut_set_project", "fablecut_patch_project", "fablecut_import_media"]) {
+    assert.ok(names.includes(expected), `missing documented tool ${expected}`);
+  }
+});
+
+test("tools/call on an unknown tool is an error result, not a crash", async (t) => {
+  const mcp = startMcp(t, makeDataDir(t));
+  await mcp.request("initialize", { protocolVersion: LATEST });
+  const { text, isError } = await mcp.callTool("fablecut_does_not_exist", {});
+  assert.ok(isError, "unknown tool must be flagged isError");
+  assert.match(text, /Unknown tool/i);
+  await stillAlive(mcp);
+});
+
+test("an unknown method returns JSON-RPC -32601", async (t) => {
+  const mcp = startMcp(t, makeDataDir(t));
+  const res = await mcp.request("resources/list");
+  assert.equal(res.error.code, -32601);
+  assert.equal(res.result, undefined, "an error response must not also carry a result");
+  await stillAlive(mcp);
+});
+
+test("notifications get no reply", async (t) => {
+  const mcp = startMcp(t, makeDataDir(t));
+  await mcp.request("initialize", { protocolVersion: LATEST });
+  mcp.notify("notifications/initialized", {});
+  mcp.notify("notifications/cancelled", { requestId: 999 });
+  // Round-trip a real request: anything the notifications wrongly emitted would
+  // have arrived by the time this reply does.
+  await stillAlive(mcp);
+  assert.deepEqual(mcp.unmatched(), [], "notifications must not produce responses");
+});

--- a/test/mcp-tools.test.js
+++ b/test/mcp-tools.test.js
@@ -1,0 +1,168 @@
+/* MCP tool semantics: the editing contract agents actually drive — patch ops,
+   validation, and the optimistic-concurrency rules documented in CLAUDE.md.
+   fablecut_status is deliberately not exercised: it spawns the editor server as
+   a side effect, which is covered directly in rest-api.test.js instead. */
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { makeDataDir, readProject, writeProject, seedProject, startMcp } = require("./helpers");
+
+const boot = async (t, project) => {
+  const dir = makeDataDir(t, project);
+  const mcp = startMcp(t, dir);
+  await mcp.request("initialize", { protocolVersion: "2025-11-25" });
+  return { dir, mcp };
+};
+
+test("fablecut_docs returns the manual, and can slice it by section", async (t) => {
+  const { mcp } = await boot(t);
+  const full = await mcp.callTool("fablecut_docs");
+  assert.match(full.text, /# FableCut/);
+
+  const section = await mcp.callTool("fablecut_docs", { section: "schema" });
+  assert.ok(section.text.length < full.text.length, "a section must be smaller than the manual");
+  assert.match(section.text, /^## /, "a section slice starts at its heading");
+  assert.match(section.text, /props reference/i);
+
+  // Every section name the manual advertises as an example must resolve —
+  // only `## ` headings are searched, so a `###`-only example is a dead end.
+  for (const name of ["schema", "Recipes", "Remake", "Export", "REST API"]) {
+    const hit = await mcp.callTool("fablecut_docs", { section: name });
+    assert.match(hit.text, /^## /, `the manual advertises section "${name}" but it matches nothing`);
+  }
+
+  // An unmatched section is a helpful listing, not an error or a crash.
+  const miss = await mcp.callTool("fablecut_docs", { section: "no-such-section" });
+  assert.equal(miss.isError, false);
+  assert.match(miss.text, /No '## ' section matches/);
+});
+
+test("fablecut_get_project returns the document, and compact hides default props", async (t) => {
+  const project = seedProject();
+  // Defaults the UI persists on every clip; the compact view should drop them.
+  project.clips[0].props = { scale: 1, opacity: 1, volume: 1, filterPreset: "noir" };
+  const { mcp } = await boot(t, project);
+
+  const full = JSON.parse((await mcp.callTool("fablecut_get_project")).text);
+  assert.equal(full.revision, 1);
+  assert.equal(full.clips[0].props.scale, 1, "the full document keeps every prop");
+
+  const { text } = await mcp.callTool("fablecut_get_project", { compact: true });
+  assert.match(text, /c_a V1 0s\+5s video/, "compact lists the clip");
+  assert.match(text, /filterPreset/, "a non-default prop must survive");
+  assert.doesNotMatch(text, /"scale"/, "default-valued props must be hidden");
+});
+
+test("fablecut_patch_project applies a batch atomically and bumps the revision once", async (t) => {
+  const { dir, mcp } = await boot(t);
+  const { text, isError } = await mcp.callTool("fablecut_patch_project", {
+    ops: [
+      { op: "addMedia", media: { id: "m_b", kind: "audio", src: "/library/sfx/whoosh.mp3" } },
+      { op: "addClip", clip: { id: "c_b", mediaId: "m_b", kind: "audio", track: "A1", start: 2, duration: 3 } },
+      { op: "updateClip", id: "c_a", set: { props: { filterPreset: "noir" } } },
+      { op: "setProject", set: { name: "Renamed" } },
+    ],
+  });
+  assert.equal(isError, false, text);
+
+  const doc = readProject(dir);
+  assert.equal(doc.revision, 2, "one patch call is exactly one revision bump");
+  assert.equal(doc.name, "Renamed");
+  assert.equal(doc.media.length, 2);
+  assert.equal(doc.clips.find((c) => c.id === "c_b").track, "A1");
+  assert.equal(doc.clips.find((c) => c.id === "c_a").props.filterPreset, "noir");
+  // addMedia fills in a name from the src when one is not supplied.
+  assert.equal(doc.media.find((m) => m.id === "m_b").name, "whoosh.mp3");
+});
+
+test("updateClip merges into props, and null deletes a key", async (t) => {
+  const project = seedProject();
+  project.clips[0].props = { filterPreset: "noir", scale: 2 };
+  const { dir, mcp } = await boot(t, project);
+
+  await mcp.callTool("fablecut_patch_project", {
+    ops: [{ op: "updateClip", id: "c_a", set: { props: { opacity: 0.5, filterPreset: null } } }],
+  });
+  const props = readProject(dir).clips[0].props;
+  assert.equal(props.scale, 2, "untouched props survive a merge");
+  assert.equal(props.opacity, 0.5, "new props are merged in");
+  assert.ok(!("filterPreset" in props), "null removes a prop");
+});
+
+test("patch ops reject edits that would corrupt the timeline", async (t) => {
+  const { dir, mcp } = await boot(t);
+  const cases = [
+    [{ op: "addClip", clip: { id: "c_x", mediaId: "m_nope", kind: "video", track: "V1", start: 0, duration: 1 } },
+      /unknown mediaId/i],
+    [{ op: "addClip", clip: { id: "c_a", mediaId: "m_a", kind: "video", track: "V1", start: 0, duration: 1 } },
+      /duplicate clip id/i],
+    [{ op: "addClip", clip: { id: "c_y", mediaId: "m_a", kind: "video", track: "V1" } },
+      /addClip needs/i],
+    [{ op: "updateClip", id: "c_missing", set: { start: 1 } }, /no clip/i],
+    [{ op: "removeClip", id: "c_missing" }, /no clip/i],
+    [{ op: "removeMedia", id: "m_a" }, /is used by clip c_a/i],
+    [{ op: "setProject", set: { revision: 99 } }, /not settable/i],
+    [{ op: "frobnicate" }, /Unknown op/i],
+  ];
+  for (const [op, expected] of cases) {
+    const { text, isError } = await mcp.callTool("fablecut_patch_project", { ops: [op] });
+    assert.ok(isError, `${op.op} should have been rejected, got: ${text}`);
+    assert.match(text, expected);
+  }
+  const empty = await mcp.callTool("fablecut_patch_project", { ops: [] });
+  assert.ok(empty.isError, "an empty op list is a mistake, not a no-op");
+
+  // Nothing above may have touched the document.
+  assert.deepEqual(readProject(dir), seedProject(), "rejected patches must not write");
+});
+
+test("text and adjust clips need no media, unlike footage clips", async (t) => {
+  const { dir, mcp } = await boot(t);
+  const { isError, text } = await mcp.callTool("fablecut_patch_project", {
+    ops: [
+      { op: "addClip", clip: { id: "c_t", mediaId: null, kind: "text", track: "V2", start: 0, duration: 2, props: { text: "Hi" } } },
+      { op: "addClip", clip: { id: "c_j", mediaId: null, kind: "adjust", track: "V3", start: 0, duration: 1, props: { shake: 18 } } },
+    ],
+  });
+  assert.equal(isError, false, text);
+  assert.equal(readProject(dir).clips.length, 3);
+});
+
+test("fablecut_set_project refuses to clobber an edit made behind its back", async (t) => {
+  const { dir, mcp } = await boot(t);
+  const doc = JSON.parse((await mcp.callTool("fablecut_get_project")).text);
+
+  // The user drags a clip in the UI while the agent is thinking.
+  writeProject(dir, { ...readProject(dir), revision: 7, name: "Edited in the UI" });
+
+  doc.name = "Agent edit";
+  const conflict = await mcp.callTool("fablecut_set_project", { project: doc });
+  assert.ok(conflict.isError, "a stale save must be refused");
+  assert.match(conflict.text, /CONFLICT/);
+  assert.equal(readProject(dir).name, "Edited in the UI", "the user's work must survive");
+
+  // force is the documented escape hatch.
+  const forced = await mcp.callTool("fablecut_set_project", { project: doc, force: true });
+  assert.equal(forced.isError, false, forced.text);
+  const after = readProject(dir);
+  assert.equal(after.name, "Agent edit");
+  assert.ok(after.revision > 7, "a forced save still moves the revision forward");
+});
+
+test("fablecut_set_project validates the document before writing it", async (t) => {
+  const { dir, mcp } = await boot(t);
+  const before = readProject(dir);
+  const cases = [
+    [{ project: "nope" }, /must be an object/i],
+    [{ project: { clips: [] } }, /clips.*media/i],
+    [{ project: { media: [], clips: [{ track: "V1", start: 0, duration: 1 }] } }, /needs id, track/i],
+    [{ project: { media: [], clips: [{ id: "c", kind: "video", mediaId: "m_ghost", track: "V1", start: 0, duration: 1 }] } },
+      /unknown mediaId/i],
+  ];
+  for (const [args, expected] of cases) {
+    const { text, isError } = await mcp.callTool("fablecut_set_project", args);
+    assert.ok(isError, `should have been rejected: ${JSON.stringify(args)}`);
+    assert.match(text, expected);
+  }
+  assert.deepEqual(readProject(dir), before, "an invalid save must leave the file untouched");
+});

--- a/test/rest-api.test.js
+++ b/test/rest-api.test.js
@@ -1,0 +1,192 @@
+/* server.js: the REST contract the editor UI and external tools rely on, plus
+   the guards that keep a localhost file API from becoming a hole in the box.
+   Each test gets its own port and data dir, so they are safe to run in parallel
+   and never touch the developer's real project. */
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { makeDataDir, readProject, seedProject, startServer, rawGet } = require("./helpers");
+
+const boot = async (t, project) => {
+  const dir = makeDataDir(t, project);
+  const { base } = await startServer(t, dir);
+  return { dir, base };
+};
+
+test("GET /api/project serves the document on disk", async (t) => {
+  const { base } = await boot(t);
+  const res = await fetch(base + "/api/project");
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /application\/json/);
+  assert.deepEqual(await res.json(), seedProject());
+});
+
+test("PUT /api/project saves a newer revision", async (t) => {
+  const { dir, base } = await boot(t);
+  const doc = { ...seedProject(), revision: 2, name: "Saved" };
+  const res = await fetch(base + "/api/project", {
+    method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(doc),
+  });
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { ok: true, revision: 2 });
+  assert.equal(readProject(dir).name, "Saved");
+});
+
+test("PUT /api/project rejects a stale write instead of clobbering it", async (t) => {
+  const { dir, base } = await boot(t);
+  // revision 1 is already on disk: an equal or lower revision is a stale read.
+  for (const revision of [1, 0, undefined]) {
+    const res = await fetch(base + "/api/project", {
+      method: "PUT", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...seedProject(), revision, name: "Clobbered" }),
+    });
+    assert.equal(res.status, 409, `revision ${revision} should conflict`);
+    const body = await res.json();
+    assert.match(body.error, /stale revision/);
+    assert.equal(body.revision, 1, "the response tells the client where disk actually is");
+  }
+  assert.equal(readProject(dir).name, "Test Project", "a rejected write must not land");
+});
+
+test("PUT /api/project?force=1 overwrites deliberately", async (t) => {
+  const { dir, base } = await boot(t);
+  const res = await fetch(base + "/api/project?force=1", {
+    method: "PUT", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...seedProject(), revision: 1, name: "Forced" }),
+  });
+  assert.equal(res.status, 200);
+  assert.equal(readProject(dir).name, "Forced");
+});
+
+test("PUT /api/project rejects malformed JSON without corrupting the file", async (t) => {
+  const { dir, base } = await boot(t);
+  const res = await fetch(base + "/api/project", { method: "PUT", body: "{not json" });
+  assert.equal(res.status, 400);
+  assert.deepEqual(readProject(dir), seedProject());
+});
+
+test("GET /api/library lists assets and validates the dir argument", async (t) => {
+  const { base } = await boot(t);
+  const res = await fetch(base + "/api/library?dir=svg");
+  assert.equal(res.status, 200);
+  const items = await res.json();
+  assert.ok(items.length > 0, "the shipped SVG library should be seeded into the data dir");
+  for (const item of items) {
+    assert.ok(item.src.startsWith("/library/svg/"), `bad src: ${item.src}`);
+    assert.equal(typeof item.size, "number");
+  }
+  // A served src must actually resolve — a listing that links to 404s is useless.
+  const one = await fetch(base + items[0].src);
+  assert.equal(one.status, 200);
+
+  for (const bad of ["", "bogus", "../..", "sfx/../../.."]) {
+    const r = await fetch(base + "/api/library?dir=" + encodeURIComponent(bad));
+    assert.equal(r.status, 400, `dir=${bad} should be refused`);
+    await r.text();
+  }
+});
+
+test("GET /api/media lists the media folder", async (t) => {
+  const { base } = await boot(t);
+  const res = await fetch(base + "/api/media");
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(await res.json()));
+});
+
+test("GET /api/export/ffmpeg reports encoder availability", async (t) => {
+  const { base } = await boot(t);
+  const body = await (await fetch(base + "/api/export/ffmpeg")).json();
+  // Both answers are legitimate — CI may or may not have ffmpeg. What matters
+  // is that the UI gets a definite boolean and can pick an export engine.
+  assert.equal(typeof body.available, "boolean");
+});
+
+test("the app shell and its assets are served", async (t) => {
+  const { base } = await boot(t);
+  const index = await fetch(base + "/");
+  assert.equal(index.status, 200);
+  assert.match(index.headers.get("content-type"), /text\/html/);
+  assert.match(await index.text(), /<canvas|<body/i);
+
+  const js = await fetch(base + "/app.js");
+  assert.equal(js.status, 200);
+  assert.match(js.headers.get("content-type"), /javascript/);
+  await js.text();
+
+  const missing = await fetch(base + "/nope.js");
+  assert.equal(missing.status, 404);
+  await missing.text();
+});
+
+test("requests from a foreign Host or Origin are refused (DNS-rebinding guard)", async (t) => {
+  const dir = makeDataDir(t);
+  const { port } = await startServer(t, dir);
+  // A page on evil.example resolving its own hostname to 127.0.0.1 must not
+  // reach the API — otherwise any website could read and rewrite the timeline.
+  const byHost = await rawGet(port, "/api/project", { Host: "evil.example" });
+  assert.equal(byHost.status, 403);
+  assert.match(byHost.body, /forbidden/);
+
+  const byOrigin = await rawGet(port, "/api/project",
+    { Host: `127.0.0.1:${port}`, Origin: "http://evil.example" });
+  assert.equal(byOrigin.status, 403);
+
+  // The legitimate cases still work.
+  for (const headers of [{ Host: `localhost:${port}` }, { Host: `127.0.0.1:${port}` },
+    { Host: `localhost:${port}`, Origin: `http://localhost:${port}` }]) {
+    const ok = await rawGet(port, "/api/project", headers);
+    assert.equal(ok.status, 200, `legit request refused: ${JSON.stringify(headers)}`);
+  }
+});
+
+test("traversal out of the served roots and dot-directories are refused", async (t) => {
+  const dir = makeDataDir(t);
+  const { port } = await startServer(t, dir);
+  const host = { Host: `127.0.0.1:${port}` };
+
+  // A file outside both the app dir and the data dir. The data dir is itself a
+  // temp dir, so this sits one level up from it — a reachable target if the
+  // path guards were missing.
+  const canary = path.join(os.tmpdir(), "fablecut-canary-secret.txt");
+  fs.writeFileSync(canary, "CANARY_MUST_NOT_BE_SERVED");
+  t.after(() => fs.rmSync(canary, { force: true }));
+
+  // Percent-encoded separators survive URL normalisation and reach the guard.
+  const escapes = [
+    "/library/..%2f..%2fproject.json",
+    "/library/svg/..%2f..%2f..%2fserver.js",
+    "/library/..%2f..%2f..%2f..%2ffablecut-canary-secret.txt",
+  ];
+  for (const p of escapes) {
+    const res = await rawGet(port, p, host);
+    assert.equal(res.status, 403, `${p} escaped the library root (got ${res.status})`);
+  }
+
+  // A backslash is a separator on Windows but an ordinary filename character on
+  // POSIX, so the status legitimately differs by platform — what must hold
+  // everywhere is that it never returns the file.
+  const backslash = await rawGet(port, "/library/..%5c..%5cserver.js", host);
+  assert.notEqual(backslash.status, 200, "backslash traversal served a file");
+  assert.doesNotMatch(backslash.body, /createServer/, "backslash traversal leaked source");
+
+  // Dot-directories and dotfiles are never served, however they are reached.
+  for (const p of ["/.git/config", "/.env", "/library/../.env"]) {
+    const res = await rawGet(port, p, host);
+    assert.equal(res.status, 403, `${p} was not refused (got ${res.status})`);
+  }
+
+  // Whatever a payload normalises to, nothing outside the roots may come back.
+  for (const p of [...escapes, "/%2e%2e/fablecut-canary-secret.txt",
+    "/../fablecut-canary-secret.txt", "/library/%2e%2e/%2e%2e/project.json"]) {
+    const res = await rawGet(port, p, host);
+    assert.doesNotMatch(res.body, /CANARY_MUST_NOT_BE_SERVED/, `${p} leaked a file outside the roots`);
+  }
+
+  // The guard must not break legitimate nested library paths.
+  const ok = await rawGet(port, "/library/svg/sparkles.svg", host);
+  assert.equal(ok.status, 200);
+  assert.match(ok.body, /<svg/);
+});


### PR DESCRIPTION
## What does this PR do?

CI only syntax-checked the JS, so the bugs that actually shipped were invisible to it — including the MCP `initialize` handshake in #58 / #59. This adds a behavioral test suite and runs it on every PR.

**35 tests, ~5s, zero dependencies** (`node:test` only — `npm test` works on a bare clone, so the no-install constraint is preserved).

| File | Covers |
| --- | --- |
| `test/mcp-protocol.test.js` | version negotiation (supported / unknown / missing), `tools/list` shape, unknown tool, unknown method, notifications draw no reply |
| `test/mcp-tools.test.js` | patch-op validation, prop merge and `null`-delete, the conflict contract and its `force` escape hatch |
| `test/rest-api.test.js` | revision 409 rules, Host/Origin DNS-rebinding guard, library path-traversal escapes |
| `test/assets.test.js` | SVG rules derived from how the compositor actually drives them |
| `test/helpers.js` | harness — every test gets a throwaway `FABLECUT_DATA_DIR` and its own port |

Each MCP protocol case re-pings the server afterwards, because "answered once, then exited" was the failure reported in #58.

CI gains a `test` job on Node 18 / 20 / 22 next to the existing syntax job. No install step: the suite uses only the standard library.

## Type of change

- [ ] Bug fix
- [ ] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [x] Refactor / internal

## How was it verified?

- [x] `npm test` passes (35/35 locally)
- [x] Mutation-checked: reverting the #59 negotiation fix makes exactly one test fail, and the suite genuinely failed against a pre-#59 checkout before the merge was pulled
- [ ] Opened the editor and confirmed the change in **preview** — N/A, no runtime code changed
- [ ] Confirmed the change in an **export** — N/A

Notes on making the tests honest rather than green:

- **No sleeps.** Readiness is established by polling for a real response with a deadline; the harness fails fast if a child process dies instead of hanging until timeout. Ports are allocated by the OS, with a retry on the one genuinely retryable failure.
- **Two of my own tests were passing for fake reasons and were rewritten.** `fetch()` refuses to set a `Host` header, and the WHATWG URL parser collapses `%2e%2e` client-side — so neither "attack" ever reached the server. Both now go over raw HTTP (`rawGet`), written against probed responses rather than assumptions.
- The `%5c` traversal case asserts the property that holds on both platforms (never returns the file) rather than a status code, since a backslash is a separator only on Windows.

## Two incidental findings

1. `CLAUDE.md` told agents to request `fablecut_docs {section:"props"}`, but only `## ` headings are searched and "props reference" is a `###` — that example returns nothing useful. Fixed to a real section, with a test that every advertised section resolves.
2. `library/svg/swipe-up.svg` violates the documented "never write a literal `animation-delay`" rule, but the compositor's injected `!important` overrides it, so it renders correctly. **Left as-is** — the test enforces what actually breaks (`!important` delays, SMIL, external refs, hardcoded non-`--d` delays) rather than forcing a cosmetic change.

## Heads-up

`serverInfo.version` is asserted to match `package.json`. It passes today, but it will fail on the next release if only one of the two is bumped. That is intentional — the drift is a real bug — but it is a tripwire worth knowing about in advance.

## Checklist

- [x] No new runtime dependencies added
- [x] Preview and export render identically (single compositor) — no renderer code touched
- [x] Commits are focused and messages are descriptive

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive automated test suite covering the MCP protocol and tools, REST API behavior, project editing, asset integrity, and security protections.
  * Tests run automatically across Node.js 18, 20, and 22.

* **Documentation**
  * Updated contribution guidance to use `npm test` for verification.
  * Added release notes describing test coverage and corrected documentation references.

* **Chores**
  * Added the `npm test` command for running the project’s automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->