### PR TITLE
'download from url' feature

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ node_modules/
 .DS_Store
 Thumbs.db
 
+# Nub
+.nub-cache/
+
 project-kesarix-backup-rev197.json
 
 projects_desktops/

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ Thumbs.db
 project-kesarix-backup-rev197.json
 
 projects_desktops/
+pnpm-lock.yaml
+.cursor/mcp.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Import from URL** — `POST /api/import-url` downloads an HTTPS video, audio
+  or image into `./media/` and returns a same-origin `/media/…` src. The
+  editor **+ URL** button and `fablecut_import_media` (now accepts `https://`
+  as well as a local path) use it. HTTPS-only with SSRF guards (no localhost /
+  private / link-local / CGNAT, including after DNS and redirects). A raw
+  HTTPS `media.src` is still unsupported — canvas CORS would break export.
 - A real test suite (`npm test`, zero dependencies, `node:test`): MCP protocol
   negotiation and framing, MCP tool semantics including the conflict rules, the
   REST API with its Host/Origin and path-traversal guards, and the shipped SVG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or image into `./media/` and returns a same-origin `/media/…` src. The
   editor **+ URL** button and `fablecut_import_media` (now accepts `https://`
   as well as a local path) use it. HTTPS-only with SSRF guards (no localhost /
-  private / link-local / CGNAT, including after DNS and redirects). A raw
-  HTTPS `media.src` is still unsupported — canvas CORS would break export.
+  private / link-local / CGNAT, including after DNS and redirects). Remote SVG
+  is refused so a scripted file cannot run on the editor origin. A raw HTTPS
+  `media.src` is still unsupported — canvas CORS would break export.
 - A real test suite (`npm test`, zero dependencies, `node:test`): MCP protocol
   negotiation and framing, MCP tool semantics including the conflict rules, the
   REST API with its Host/Origin and path-traversal guards, and the shipped SVG

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,10 @@ directory without touching anyone's timeline or footage. **Don't assume
 `project.json` is beside `mcp-server.js`** — call `fablecut_status`, which
 reports the real paths.
 
+Tests (and nothing else) may set **`FABLECUT_NO_FS_WATCH=1`** to skip `fs.watch`.
+On Windows, libuv can abort the process when a file is created under a temp
+data dir. Production leaves watching on so the UI live-reloads.
+
 ## Run
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,7 +432,9 @@ obvious cuts were missed, raise it if motion is being misread as cuts.
 - `POST /api/import-url` — body `{url:"https://…"}` downloads the file into
   `./media/` and returns `{src,name}` (same-origin `/media/…`, like upload).
   HTTPS only; rejects localhost, private/link-local/CGNAT addresses, and
-  redirects to those. Does not write `project.json` — register the media
+  redirects to those. Remote SVG is refused (`/media/*.svg` is served
+  same-origin as `image/svg+xml` — a scripted SVG opened as a document would
+  run on the editor origin). Does not write `project.json` — register the media
   afterwards (UI and `fablecut_import_media` do this). Do **not** put the
   HTTPS URL in `media.src`: canvas CORS would break thumbs, FX and export.
 - `POST /api/analyze` — body `{src:"/media/ref.mp4", threshold?, music?}`: analyze a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ Every Claude Code session then has these tools:
   `fablecut_get_project {compact:true}` returns a one-line-per-clip summary instead.
 - `fablecut_patch_project` — apply targeted ops (add/update/remove clip/media,
   set project fields) without round-tripping the document. **Prefer this for edits.**
-- `fablecut_import_media` — copy a local file into `./media/` and register it.
+- `fablecut_import_media` — copy a local file (or download an `https://` URL)
+  into `./media/` and register it. The stored `src` is always `/media/…`.
 - `fablecut_analyze_reference` — turn a reference video into an edit blueprint
   (shots, beats, BPM, energy, drop) + extract its music. See "Remake a reference video".
 - `fablecut_encode_profiles` — list export presets from `encoding-profiles.json` (each is a
@@ -90,7 +91,8 @@ Files: `index.html` + `style.css` + `app.js` (editor UI), `server.js` (API + hos
 ## How Claude Code edits a video
 
 1. Ensure the server is running (background: `node server.js`, or `fablecut_status`).
-2. Put source files in `./media/` (copy them in, or the user imports via the UI).
+2. Put source files in `./media/` (copy them in, import via the UI / **+ URL**,
+   or `fablecut_import_media` with a local path or HTTPS URL).
 3. Read `project.json`, modify `media` / `clips`, **increment `revision`**, write it back.
 4. The browser UI (if open) reloads instantly. The user previews/exports from the UI.
 
@@ -189,7 +191,7 @@ Examples in `library/svg/`: `sparkles.svg` (loop), `lower-third.svg`,
   "encodeProfile": "hq",  // optional — fast-export profile id (see encoding-profiles.json)
   "media": [
     { "id": "m_abc", "name": "intro.mp4", "kind": "video",  // video|audio|image|svg
-      "src": "/media/intro.mp4",             // path under ./media or ./library
+      "src": "/media/intro.mp4",             // path under ./media or ./library (never a raw https:// URL)
       "duration": 12.4, "width": 1920, "height": 1080,
       "folderId": null }                     // optional: id of a folders[] entry
   ],
@@ -427,6 +429,12 @@ obvious cuts were missed, raise it if motion is being misread as cuts.
   MP4/MOV/M4V uploads are auto-remuxed with `+faststart` (needs ffmpeg on PATH).
   Files copied straight into ./media by external tools skip this — remux big ones
   yourself (`ffmpeg -i in.mp4 -c copy -movflags +faststart out.mp4`) or playback stalls.
+- `POST /api/import-url` — body `{url:"https://…"}` downloads the file into
+  `./media/` and returns `{src,name}` (same-origin `/media/…`, like upload).
+  HTTPS only; rejects localhost, private/link-local/CGNAT addresses, and
+  redirects to those. Does not write `project.json` — register the media
+  afterwards (UI and `fablecut_import_media` do this). Do **not** put the
+  HTTPS URL in `media.src`: canvas CORS would break thumbs, FX and export.
 - `POST /api/analyze` — body `{src:"/media/ref.mp4", threshold?, music?}`: analyze a
   reference video into an edit blueprint (see "Remake a reference video"); extracts
   its music into ./media. `GET /api/analyze?src=…` returns the cached blueprint.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ same time.
 - Press <kbd>Alt+t</kbd> to add an in/out transition based on the playhead position over the selected clip. The last used transition is remembered as the default. Drag the overlay triangle to adjust duration; <kbd>Delete</kbd> clears the focused transition.
 - Real decoded audio waveforms on clips
 - **Project bin folders** — tree view with expand/collapse; drag media or folders to nest; right-click the **Project** tab → New folder; drop files onto a folder to import into it
+- **Import from URL** — **+ URL** downloads an HTTPS video/audio/image into
+  `./media/` (same-origin after import). Agents use `fablecut_import_media`
+  with an `https://` path. The URL is not kept as `media.src` — that would
+  taint the canvas and break export.
 - **Audio Hold** — timeline toolbar toggle: while paused, loops **one frame** of
   audio at the playhead (useful when stepping frame-by-frame). Scrubbing or
   frame-step retargets the held slice; meters stay live. **Play** / **Pause**
@@ -197,8 +201,8 @@ removal fetches its model from a CDN on first use.
 The server binds **127.0.0.1 only** (v1.3.1+). To use it from another device on
 your LAN, opt in explicitly: `HOST=0.0.0.0 FABLECUT_ALLOWED_HOSTS=<your-ip> node server.js`.
 
-Drop media into the window (or `./media/`), drag clips onto the timeline, edit,
-export.
+Drop media into the window (or `./media/`), paste an HTTPS URL via **+ URL**,
+drag clips onto the timeline, edit, export.
 
 To keep your work outside the checkout, set **`FABLECUT_DATA_DIR`** — it moves
 `project.json`, `media/`, `exports/`, `analysis/` and `library/` to a directory
@@ -286,8 +290,9 @@ Three equivalent control surfaces:
    they need (`fablecut_docs {section:"props"}`).
 2. **The file** — read `project.json`, modify, bump `revision`, write. The UI
    live-reloads.
-3. **REST** — `GET/PUT /api/project`, `POST /api/upload`, `GET /api/library`,
-   `GET /api/export/profiles`, SSE at `/api/events`. See CLAUDE.md for the full list.
+3. **REST** — `GET/PUT /api/project`, `POST /api/upload`, `POST /api/import-url`,
+   `GET /api/library`, `GET /api/export/profiles`, SSE at `/api/events`. See
+   CLAUDE.md for the full list.
 
 Example: ask Claude Code *"cut these six clips to the beat markers, add a
 teal-orange grade, put a word-pop caption on top and a whoosh on every cut"* —

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ same time.
 - Real decoded audio waveforms on clips
 - **Project bin folders** — tree view with expand/collapse; drag media or folders to nest; right-click the **Project** tab → New folder; drop files onto a folder to import into it
 - **Import from URL** — **+ URL** downloads an HTTPS video/audio/image into
-  `./media/` (same-origin after import). Agents use `fablecut_import_media`
-  with an `https://` path. The URL is not kept as `media.src` — that would
-  taint the canvas and break export.
+  `./media/` (same-origin after import). Remote SVG is refused. Agents use
+  `fablecut_import_media` with an `https://` path. The URL is not kept as
+  `media.src` — that would taint the canvas and break export.
 - **Audio Hold** — timeline toolbar toggle: while paused, loops **one frame** of
   audio at the playhead (useful when stepping frame-by-frame). Scrubbing or
   frame-step retargets the held slice; meters stay live. **Play** / **Pause**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,7 +45,10 @@ HTTP server intended for a single trusted user on their own machine. Since
   fetches a remote file into `./media/`. The fetch is **HTTPS-only** and
   refuses localhost, private, link-local and CGNAT destinations (including
   after DNS lookup and on redirects), so a crafted URL cannot turn the editor
-  into an SSRF proxy. The stored `src` is always a local `/media/…` path.
+  into an SSRF proxy. Remote SVG is refused: `/media/*.svg` is served
+  same-origin as `image/svg+xml`, and a scripted SVG opened as a document
+  would run on the editor origin. The stored `src` is always a local
+  `/media/…` path. Local `.svg` files (drop / library) are unchanged.
 
 It remains **not** hardened for untrusted networks or multi-tenant use:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,10 @@ HTTP server intended for a single trusted user on their own machine. Since
   same-origin as `image/svg+xml`, and a scripted SVG opened as a document
   would run on the editor origin. The stored `src` is always a local
   `/media/…` path. Local `.svg` files (drop / library) are unchanged.
+  **`FABLECUT_TEST_IMPORT_ALLOW_PRIVATE=1`** is a test-only switch: it additionally
+  allows **HTTP(S) to `127.0.0.1`** so the suite can pin a loopback fixture. It
+  does not open LAN, CGNAT, link-local, metadata, `localhost`, `::1`, or other
+  `127.0.0.0/8` addresses. Unset in production.
 
 It remains **not** hardened for untrusted networks or multi-tenant use:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,11 +41,17 @@ HTTP server intended for a single trusted user on their own machine. Since
   DNS-rebinding) and an **Origin allowlist** (anti cross-origin writes from
   malicious web pages).
 - The static server refuses dot-files/dot-directories (`.git/` etc.).
+- `POST /api/import-url` (and `fablecut_import_media` with an `https://` path)
+  fetches a remote file into `./media/`. The fetch is **HTTPS-only** and
+  refuses localhost, private, link-local and CGNAT destinations (including
+  after DNS lookup and on redirects), so a crafted URL cannot turn the editor
+  into an SSRF proxy. The stored `src` is always a local `/media/…` path.
 
 It remains **not** hardened for untrusted networks or multi-tenant use:
 
 - The REST API (`/api/*`) has no authentication — anyone who can reach the port
-  can read and overwrite `project.json` and upload files into `media/`.
+  can read and overwrite `project.json`, upload files, and ask the server to
+  fetch an HTTPS URL into `media/`.
 - The server reads and writes files under the project directory and spawns
   `ffmpeg` for export/remux. Fast-export profiles in `encoding-profiles.json`
   (hot-reloaded) are raw ffmpeg argument lists: the browser sends only a

--- a/app.js
+++ b/app.js
@@ -316,6 +316,7 @@ const runtime = {
   audio: null,          // {ctx, master, recDest, meter?, meterReady?}
   saveTimer: null, pendingSync: false,
   sfxPreview: null,     // <audio> element for library sound previews
+  importUrlAbort: null, // AbortController for an in-flight /api/import-url
   importFolderId: null, // Project-bin folder to place the next import into
   binDragFolderId: null, // folder id currently being dragged (cycle checks)
   binCtxMenu: null,     // Project-tab context menu element
@@ -347,6 +348,8 @@ const els = {
   exportProfileRow: $("exportProfileRow"),
   exportProfileSel: $("exportProfileSel"), exportProfileNote: $("exportProfileNote"),
   exportProfileHint: $("exportProfileHint"),
+  importUrlOverlay: $("importUrlOverlay"), importUrlInput: $("importUrlInput"),
+  importUrlStatus: $("importUrlStatus"), importUrlProgress: $("importUrlProgress"),
 };
 const ctx2d = els.preview.getContext("2d");
 
@@ -973,6 +976,76 @@ async function importFiles(fileList) {
   else if (skipped)
     toast(`Imported ${added}, skipped ${skipped}`);
   return addedMedia;
+}
+
+function setImportUrlBusy(busy) {
+  const input = els.importUrlInput;
+  const go = $("btnDoImportUrl");
+  if (input) input.disabled = busy;
+  if (go) go.disabled = busy;
+  els.importUrlStatus?.classList.toggle("hidden", !busy);
+  els.importUrlProgress?.classList.toggle("hidden", !busy);
+}
+
+function closeImportUrl() {
+  if (runtime.importUrlAbort) {
+    try { runtime.importUrlAbort.abort(); } catch { }
+    runtime.importUrlAbort = null;
+  }
+  setImportUrlBusy(false);
+  els.importUrlOverlay?.classList.add("hidden");
+}
+
+function openImportUrl() {
+  if (!state.connected) {
+    toast("Import from URL needs the editor server");
+    return;
+  }
+  if (!els.importUrlOverlay) return;
+  if (els.importUrlInput) els.importUrlInput.value = "";
+  setImportUrlBusy(false);
+  els.importUrlOverlay.classList.remove("hidden");
+  setTimeout(() => els.importUrlInput?.focus(), 0);
+}
+
+async function importFromUrl(url) {
+  const trimmed = String(url || "").trim();
+  if (!trimmed) { toast("Paste an HTTPS URL first"); return; }
+  if (!/^https:\/\//i.test(trimmed)) { toast("URL must start with https://"); return; }
+  if (!state.connected) { toast("Import from URL needs the editor server"); return; }
+  runtime.importUrlAbort = new AbortController();
+  setImportUrlBusy(true);
+  try {
+    const res = await fetch("/api/import-url", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: trimmed }),
+      signal: runtime.importUrlAbort.signal,
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(body.error || "import failed (" + res.status + ")");
+    const kind = libKind(body.name);
+    if (!kind) throw new Error("unsupported file type: " + (body.name || ""));
+    const folderId = runtime.importFolderId && getFolder(runtime.importFolderId)
+      ? runtime.importFolderId : null;
+    runtime.importFolderId = null;
+    const m = { id: "m_" + uid(), name: body.name, kind, src: body.src, folderId };
+    try {
+      await loadMediaMetadata(m);
+      if (kind === "video") grabThumb(m).catch(() => { });
+      ensureWave(m);
+    } catch { /* browser will retry via probeMissingMeta */ }
+    project.media.push(m);
+    renderBin(); scheduleSave();
+    closeImportUrl();
+    toast("Imported " + m.name);
+  } catch (e) {
+    if (e && e.name === "AbortError") return;
+    setImportUrlBusy(false);
+    toast(e && e.message ? e.message : "Couldn't import URL");
+  } finally {
+    runtime.importUrlAbort = null;
+  }
 }
 
 function renderBin() {
@@ -5691,6 +5764,15 @@ function finishExport(keep) {
 
 /* ═══════════════════════════ WIRING ═══════════════════════════ */
 els.fileInput.addEventListener("change", () => { importFiles(els.fileInput.files); els.fileInput.value = ""; });
+$("btnImportUrl")?.addEventListener("click", openImportUrl);
+$("btnCancelImportUrl")?.addEventListener("click", closeImportUrl);
+$("btnDoImportUrl")?.addEventListener("click", () => importFromUrl(els.importUrlInput?.value));
+els.importUrlInput?.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") { e.preventDefault(); importFromUrl(els.importUrlInput.value); }
+});
+els.importUrlOverlay?.addEventListener("click", (e) => {
+  if (e.target === els.importUrlOverlay) closeImportUrl();
+});
 $("btnTitle").addEventListener("click", addTitle);
 $("btnAdjust").addEventListener("click", addAdjust);
 $("btnSplit").addEventListener("click", splitAtPlayhead);
@@ -6249,6 +6331,11 @@ window.addEventListener("keydown", (e) => {
       e.preventDefault();
       return;
     }
+  }
+  if (k === "Escape" && els.importUrlOverlay && !els.importUrlOverlay.classList.contains("hidden")) {
+    e.preventDefault();
+    closeImportUrl();
+    return;
   }
   if (isTypingTarget(document.activeElement)) return;
   if (k === " ") { e.preventDefault(); state.playing ? pause() : play(); }

--- a/import-url.js
+++ b/import-url.js
@@ -1,0 +1,257 @@
+/* Download a remote HTTPS file into ./media with SSRF guards.
+   Used by POST /api/import-url and fablecut_import_media. The stored src is
+   always a local /media/… path — the URL is not kept as the playback source. */
+"use strict";
+const http = require("http");
+const https = require("https");
+const dns = require("dns");
+const net = require("net");
+const fs = require("fs");
+const path = require("path");
+const { spawnSync, execFile } = require("child_process");
+
+const MAX_BYTES = 2 * 1024 * 1024 * 1024; // 2 GiB
+const TIMEOUT_MS = 180_000;
+const MAX_REDIRECTS = 5;
+
+const KIND_BY_EXT = {
+  ".mp4": "video", ".webm": "video", ".mov": "video", ".mkv": "video", ".m4v": "video", ".avi": "video",
+  ".mp3": "audio", ".wav": "audio", ".ogg": "audio", ".m4a": "audio", ".aac": "audio", ".flac": "audio",
+  ".png": "image", ".jpg": "image", ".jpeg": "image", ".gif": "image", ".webp": "image", ".svg": "svg",
+};
+const EXT_BY_MIME = {
+  "video/mp4": ".mp4", "video/webm": ".webm", "video/quicktime": ".mov",
+  "video/x-matroska": ".mkv", "video/x-m4v": ".m4v",
+  "audio/mpeg": ".mp3", "audio/mp3": ".mp3", "audio/wav": ".wav", "audio/x-wav": ".wav",
+  "audio/ogg": ".ogg", "audio/mp4": ".m4a", "audio/aac": ".aac", "audio/flac": ".flac",
+  "image/png": ".png", "image/jpeg": ".jpg", "image/gif": ".gif", "image/webp": ".webp",
+  "image/svg+xml": ".svg",
+};
+const FASTSTART_EXT = new Set([".mp4", ".mov", ".m4v"]);
+
+function safeName(name) {
+  return String(name).replace(/[^\w.\- ()\[\]]+/g, "_").slice(0, 120) || "file";
+}
+function kindFromName(name) {
+  return KIND_BY_EXT[path.extname(name).toLowerCase()] || null;
+}
+function uniquePath(dir, name) {
+  let target = path.join(dir, name);
+  const ext = path.extname(name), base = path.basename(name, ext);
+  let i = 1;
+  while (fs.existsSync(target)) target = path.join(dir, `${base}_${i++}${ext}`);
+  return target;
+}
+
+function isBlockedIp(ip) {
+  if (!ip) return true;
+  let addr = String(ip).toLowerCase();
+  if (addr.startsWith("::ffff:")) addr = addr.slice(7);
+  if (net.isIPv4(addr)) {
+    const p = addr.split(".").map(Number);
+    if (p[0] === 0 || p[0] === 10 || p[0] === 127) return true;
+    if (p[0] === 169 && p[1] === 254) return true;
+    if (p[0] === 172 && p[1] >= 16 && p[1] <= 31) return true;
+    if (p[0] === 192 && p[1] === 168) return true;
+    if (p[0] === 100 && p[1] >= 64 && p[1] <= 127) return true;
+    if (p[0] >= 224) return true;
+    return false;
+  }
+  if (net.isIPv6(addr)) {
+    if (addr === "::1" || addr === "::") return true;
+    if (addr.startsWith("fe8") || addr.startsWith("fe9") ||
+        addr.startsWith("fea") || addr.startsWith("feb")) return true;
+    if (addr.startsWith("fc") || addr.startsWith("fd")) return true;
+    if (addr.startsWith("ff")) return true;
+    return false;
+  }
+  return true;
+}
+
+function isBlockedHostname(host) {
+  const h = String(host || "").replace(/^\[|\]$/g, "").toLowerCase();
+  if (!h) return true;
+  if (h === "localhost" || h.endsWith(".localhost") || h === "0.0.0.0") return true;
+  if (h.endsWith(".local") || h.endsWith(".internal") || h.endsWith(".lan")) return true;
+  if (h === "metadata.google.internal") return true;
+  if (net.isIP(h)) return isBlockedIp(h);
+  return false;
+}
+
+function parseImportUrl(raw, { allowPrivate = false } = {}) {
+  let u;
+  try { u = new URL(String(raw || "").trim()); } catch { throw new Error("invalid URL"); }
+  if (allowPrivate) {
+    if (u.protocol !== "https:" && u.protocol !== "http:")
+      throw new Error("URL must be http(s)");
+  } else if (u.protocol !== "https:") {
+    throw new Error("URL must be https");
+  }
+  if (u.username || u.password) throw new Error("URL must not include credentials");
+  if (!u.hostname) throw new Error("invalid URL");
+  if (!allowPrivate && isBlockedHostname(u.hostname))
+    throw new Error("blocked: local or private host");
+  return u;
+}
+
+async function assertPublicTarget(u, { allowPrivate = false } = {}) {
+  if (allowPrivate) return;
+  if (isBlockedHostname(u.hostname)) throw new Error("blocked: local or private host");
+  const host = u.hostname.replace(/^\[|\]$/g, "");
+  if (net.isIP(host)) {
+    if (isBlockedIp(host)) throw new Error("blocked: local or private address");
+    return;
+  }
+  let addrs;
+  try { addrs = await dns.promises.lookup(host, { all: true, verbatim: true }); }
+  catch { throw new Error("could not resolve host"); }
+  if (!addrs.length) throw new Error("could not resolve host");
+  for (const a of addrs) {
+    if (isBlockedIp(a.address)) throw new Error("blocked: host resolves to a private address");
+  }
+}
+
+function filenameFrom(u, headers) {
+  const cd = headers["content-disposition"] || "";
+  const star = /filename\*\s*=\s*(?:UTF-8''|utf-8'')([^;]+)/i.exec(cd);
+  if (star) {
+    try { return safeName(path.basename(decodeURIComponent(star[1].trim().replace(/^"+|"+$/g, "")))); }
+    catch { /* fall through */ }
+  }
+  const quoted = /filename\s*=\s*"((?:\\.|[^"])+)"/i.exec(cd);
+  if (quoted) return safeName(path.basename(quoted[1].replace(/\\"/g, '"')));
+  const bare = /filename\s*=\s*([^;]+)/i.exec(cd);
+  if (bare) return safeName(path.basename(bare[1].trim().replace(/^"+|"+$/g, "")));
+
+  let base = "";
+  try { base = path.basename(decodeURIComponent(u.pathname)); } catch { base = path.basename(u.pathname); }
+  if (base === "/" || base === "." || base === "..") base = "";
+  const mime = (headers["content-type"] || "").split(";")[0].trim().toLowerCase();
+  const mimeExt = EXT_BY_MIME[mime] || "";
+  if (!base) base = "download" + mimeExt;
+  else if (!path.extname(base) && mimeExt) base += mimeExt;
+  return safeName(base);
+}
+
+function requestOnce(u, { signal, allowPrivate, timeoutMs }) {
+  const lib = u.protocol === "https:" ? https : http;
+  const host = u.hostname.replace(/^\[|\]$/g, "");
+  const opts = {
+    protocol: u.protocol,
+    hostname: host,
+    port: u.port || undefined,
+    path: u.pathname + u.search,
+    method: "GET",
+    headers: { "User-Agent": "FableCut", Accept: "*/*" },
+  };
+  if (u.protocol === "https:" && !net.isIP(host)) opts.servername = host;
+  return new Promise((resolve, reject) => {
+    const req = lib.request(opts, resolve);
+    const fail = (err) => { try { req.destroy(); } catch {} reject(err); };
+    req.on("error", fail);
+    req.setTimeout(timeoutMs, () => fail(new Error("download timed out")));
+    if (signal) {
+      if (signal.aborted) return fail(Object.assign(new Error("aborted"), { code: "ABORT_ERR" }));
+      const onAbort = () => fail(Object.assign(new Error("aborted"), { code: "ABORT_ERR" }));
+      signal.addEventListener("abort", onAbort, { once: true });
+      req.on("close", () => signal.removeEventListener("abort", onAbort));
+    }
+    req.end();
+  });
+}
+
+function saveResponse(res, u, destDir, { signal, maxBytes }) {
+  const mime = (res.headers["content-type"] || "").split(";")[0].trim().toLowerCase();
+  if (mime === "text/html" || mime === "application/json") {
+    res.resume();
+    return Promise.reject(new Error("URL did not return a media file"));
+  }
+  const name = filenameFrom(u, res.headers);
+  if (!kindFromName(name)) {
+    res.resume();
+    return Promise.reject(new Error("unsupported media type (need a video, audio, image, or SVG URL)"));
+  }
+  const declared = parseInt(res.headers["content-length"], 10);
+  if (declared > maxBytes) {
+    res.resume();
+    return Promise.reject(new Error("file too large"));
+  }
+  fs.mkdirSync(destDir, { recursive: true });
+  const target = uniquePath(destDir, name);
+  const out = fs.createWriteStream(target);
+  return new Promise((resolve, reject) => {
+    let bytes = 0;
+    const cleanup = (err) => {
+      try { res.destroy(); } catch {}
+      try { out.destroy(); } catch {}
+      try { fs.rmSync(target, { force: true }); } catch {}
+      reject(err);
+    };
+    if (signal) {
+      if (signal.aborted) return cleanup(Object.assign(new Error("aborted"), { code: "ABORT_ERR" }));
+      signal.addEventListener("abort", () => cleanup(Object.assign(new Error("aborted"), { code: "ABORT_ERR" })), { once: true });
+    }
+    res.on("data", (chunk) => {
+      bytes += chunk.length;
+      if (bytes > maxBytes) cleanup(new Error("file too large"));
+    });
+    res.on("error", cleanup);
+    out.on("error", cleanup);
+    res.pipe(out);
+    out.on("finish", () => resolve({ target, name: path.basename(target) }));
+  });
+}
+
+async function downloadImportUrl(raw, destDir, opts = {}) {
+  const allowPrivate = !!opts.allowPrivate;
+  const maxBytes = opts.maxBytes || MAX_BYTES;
+  const timeoutMs = opts.timeoutMs || TIMEOUT_MS;
+  const signal = opts.signal;
+  let current = parseImportUrl(raw, { allowPrivate });
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    if (signal?.aborted) throw Object.assign(new Error("aborted"), { code: "ABORT_ERR" });
+    await assertPublicTarget(current, { allowPrivate });
+    const res = await requestOnce(current, { signal, allowPrivate, timeoutMs });
+    if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+      res.resume();
+      let next;
+      try { next = new URL(res.headers.location, current); }
+      catch { throw new Error("invalid redirect"); }
+      current = parseImportUrl(next.href, { allowPrivate });
+      continue;
+    }
+    if (res.statusCode !== 200) {
+      res.resume();
+      throw new Error("download failed: HTTP " + res.statusCode);
+    }
+    return saveResponse(res, current, destDir, { signal, maxBytes });
+  }
+  throw new Error("too many redirects");
+}
+
+let hasFfmpeg = null;
+function ffmpegAvailable() {
+  if (hasFfmpeg == null) {
+    try { hasFfmpeg = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status === 0; }
+    catch { hasFfmpeg = false; }
+  }
+  return hasFfmpeg;
+}
+function maybeFaststart(file) {
+  if (!ffmpegAvailable() || !FASTSTART_EXT.has(path.extname(file).toLowerCase()))
+    return Promise.resolve();
+  const tmp = file + ".fs" + path.extname(file);
+  return new Promise((resolve) => {
+    execFile("ffmpeg", ["-y", "-i", file, "-c", "copy", "-movflags", "+faststart", tmp],
+      { maxBuffer: 1 << 24 }, (err) => {
+        if (err) { try { fs.rmSync(tmp, { force: true }); } catch {} return resolve(); }
+        try { fs.rmSync(file); fs.renameSync(tmp, file); } catch { try { fs.rmSync(tmp, { force: true }); } catch {} }
+        resolve();
+      });
+  });
+}
+
+module.exports = {
+  downloadImportUrl, parseImportUrl, isBlockedIp, isBlockedHostname,
+  filenameFrom, kindFromName, KIND_BY_EXT, maybeFaststart, MAX_BYTES,
+};

--- a/import-url.js
+++ b/import-url.js
@@ -1,6 +1,7 @@
 /* Download a remote HTTPS file into ./media with SSRF guards.
    Used by POST /api/import-url and fablecut_import_media. The stored src is
-   always a local /media/… path — the URL is not kept as the playback source. */
+   always a local /media/… path — the URL is not kept as the playback source.
+   Remote SVG is refused (same-origin image/svg+xml would be a script sink). */
 "use strict";
 const http = require("http");
 const https = require("https");
@@ -167,9 +168,16 @@ function saveResponse(res, u, destDir, { signal, maxBytes }) {
     return Promise.reject(new Error("URL did not return a media file"));
   }
   const name = filenameFrom(u, res.headers);
-  if (!kindFromName(name)) {
+  const kind = kindFromName(name);
+  // /media/*.svg is served same-origin as image/svg+xml. A remote file with
+  // <script> opened as a document would run on the editor origin.
+  if (kind === "svg" || mime === "image/svg+xml" || mime === "image/svg") {
     res.resume();
-    return Promise.reject(new Error("unsupported media type (need a video, audio, image, or SVG URL)"));
+    return Promise.reject(new Error("unsupported media type (remote SVG is not imported)"));
+  }
+  if (!kind) {
+    res.resume();
+    return Promise.reject(new Error("unsupported media type (need a video, audio, or image URL)"));
   }
   const declared = parseInt(res.headers["content-length"], 10);
   if (declared > maxBytes) {

--- a/import-url.js
+++ b/import-url.js
@@ -37,12 +37,18 @@ function safeName(name) {
 function kindFromName(name) {
   return KIND_BY_EXT[path.extname(name).toLowerCase()] || null;
 }
-function uniquePath(dir, name) {
-  let target = path.join(dir, name);
+/** Create `name` under dir with exclusive `wx`. On EEXIST, try name_1, name_2, …
+ *  so two concurrent imports cannot both pick the same free path. */
+function openUniqueFile(dir, name) {
   const ext = path.extname(name), base = path.basename(name, ext);
-  let i = 1;
-  while (fs.existsSync(target)) target = path.join(dir, `${base}_${i++}${ext}`);
-  return target;
+  let i = 0;
+  for (;;) {
+    const file = i === 0 ? name : `${base}_${i}${ext}`;
+    i++;
+    const target = path.join(dir, file);
+    try { return { target, fd: fs.openSync(target, "wx") }; }
+    catch (e) { if (e.code === "EEXIST") continue; throw e; }
+  }
 }
 
 function isBlockedIp(ip) {
@@ -193,14 +199,25 @@ function saveResponse(res, u, destDir, { signal, maxBytes }) {
     return Promise.reject(new Error("file too large"));
   }
   fs.mkdirSync(destDir, { recursive: true });
-  const target = uniquePath(destDir, name);
-  const out = fs.createWriteStream(target);
+  let target, owned = false, out, fd;
+  try {
+    const opened = openUniqueFile(destDir, name);
+    target = opened.target;
+    fd = opened.fd;
+    owned = true;
+    out = fs.createWriteStream(target, { fd });
+  } catch (e) {
+    res.resume();
+    if (fd != null && !out) try { fs.closeSync(fd); } catch {}
+    if (owned) try { fs.rmSync(target, { force: true }); } catch {}
+    return Promise.reject(e);
+  }
   return new Promise((resolve, reject) => {
     let bytes = 0;
     const cleanup = (err) => {
       try { res.destroy(); } catch {}
       try { out.destroy(); } catch {}
-      try { fs.rmSync(target, { force: true }); } catch {}
+      if (owned) try { fs.rmSync(target, { force: true }); } catch {}
       reject(err);
     };
     if (signal) {
@@ -214,7 +231,10 @@ function saveResponse(res, u, destDir, { signal, maxBytes }) {
     res.on("error", cleanup);
     out.on("error", cleanup);
     res.pipe(out);
-    out.on("finish", () => resolve({ target, name: path.basename(target) }));
+    out.on("finish", () => {
+      owned = false; // complete file belongs to the caller now
+      resolve({ target, name: path.basename(target) });
+    });
   });
 }
 

--- a/import-url.js
+++ b/import-url.js
@@ -1,7 +1,8 @@
 /* Download a remote HTTPS file into ./media with SSRF guards.
    Used by POST /api/import-url and fablecut_import_media. The stored src is
    always a local /media/… path — the URL is not kept as the playback source.
-   Remote SVG is refused (same-origin image/svg+xml would be a script sink). */
+   Remote SVG is refused (same-origin image/svg+xml would be a script sink).
+   allowLoopback is a test-only carve-out for HTTP(S) to 127.0.0.1. */
 "use strict";
 const http = require("http");
 const https = require("https");
@@ -79,10 +80,17 @@ function isBlockedHostname(host) {
   return false;
 }
 
-function parseImportUrl(raw, { allowPrivate = false } = {}) {
+/* Test hook: HTTP(S) to 127.0.0.1 only. Does not open LAN, CGNAT, metadata, or
+   other loopback addresses (127.0.0.2, ::1, localhost). */
+function isTestLoopback(host) {
+  return String(host || "").replace(/^\[|\]$/g, "").toLowerCase() === "127.0.0.1";
+}
+
+function parseImportUrl(raw, { allowLoopback = false } = {}) {
   let u;
   try { u = new URL(String(raw || "").trim()); } catch { throw new Error("invalid URL"); }
-  if (allowPrivate) {
+  const loopback = allowLoopback && isTestLoopback(u.hostname);
+  if (loopback) {
     if (u.protocol !== "https:" && u.protocol !== "http:")
       throw new Error("URL must be http(s)");
   } else if (u.protocol !== "https:") {
@@ -90,15 +98,15 @@ function parseImportUrl(raw, { allowPrivate = false } = {}) {
   }
   if (u.username || u.password) throw new Error("URL must not include credentials");
   if (!u.hostname) throw new Error("invalid URL");
-  if (!allowPrivate && isBlockedHostname(u.hostname))
+  if (!loopback && isBlockedHostname(u.hostname))
     throw new Error("blocked: local or private host");
   return u;
 }
 
-async function assertPublicTarget(u, { allowPrivate = false } = {}) {
-  if (allowPrivate) return;
-  if (isBlockedHostname(u.hostname)) throw new Error("blocked: local or private host");
+async function assertPublicTarget(u, { allowLoopback = false } = {}) {
   const host = u.hostname.replace(/^\[|\]$/g, "");
+  if (allowLoopback && isTestLoopback(host)) return;
+  if (isBlockedHostname(u.hostname)) throw new Error("blocked: local or private host");
   if (net.isIP(host)) {
     if (isBlockedIp(host)) throw new Error("blocked: local or private address");
     return;
@@ -134,7 +142,7 @@ function filenameFrom(u, headers) {
   return safeName(base);
 }
 
-function requestOnce(u, { signal, allowPrivate, timeoutMs }) {
+function requestOnce(u, { signal, timeoutMs }) {
   const lib = u.protocol === "https:" ? https : http;
   const host = u.hostname.replace(/^\[|\]$/g, "");
   const opts = {
@@ -211,21 +219,21 @@ function saveResponse(res, u, destDir, { signal, maxBytes }) {
 }
 
 async function downloadImportUrl(raw, destDir, opts = {}) {
-  const allowPrivate = !!opts.allowPrivate;
+  const allowLoopback = !!opts.allowLoopback;
   const maxBytes = opts.maxBytes || MAX_BYTES;
   const timeoutMs = opts.timeoutMs || TIMEOUT_MS;
   const signal = opts.signal;
-  let current = parseImportUrl(raw, { allowPrivate });
+  let current = parseImportUrl(raw, { allowLoopback });
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
     if (signal?.aborted) throw Object.assign(new Error("aborted"), { code: "ABORT_ERR" });
-    await assertPublicTarget(current, { allowPrivate });
-    const res = await requestOnce(current, { signal, allowPrivate, timeoutMs });
+    await assertPublicTarget(current, { allowLoopback });
+    const res = await requestOnce(current, { signal, timeoutMs });
     if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
       res.resume();
       let next;
       try { next = new URL(res.headers.location, current); }
       catch { throw new Error("invalid redirect"); }
-      current = parseImportUrl(next.href, { allowPrivate });
+      current = parseImportUrl(next.href, { allowLoopback });
       continue;
     }
     if (res.statusCode !== 200) {

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
           <button type="button" class="btn tiny" id="btnTitle" title="Add a title card at the playhead">+ Title</button>
           <button type="button" class="btn tiny" id="btnAdjust" title="Add an adjustment layer (grades everything below it)">+ Adjust</button>
           <label class="btn tiny accent" id="btnImport" for="fileInput" title="Import media files">+ Import</label>
+          <button type="button" class="btn tiny" id="btnImportUrl" title="Download media from an HTTPS URL into the project">+ URL</button>
         </span>
       </div>
       <div class="bin-tabs" id="binTabs">
@@ -58,7 +59,7 @@
       <div class="bin-list" id="binList">
         <div class="bin-empty" id="binEmpty">
           <div class="bin-empty-icon">🎬</div>
-          <p>Drop video, audio or images here<br>or click <b>+ Import</b></p>
+          <p>Drop video, audio or images here<br>or click <b>+ Import</b> / <b>+ URL</b></p>
           <p class="hint">Then drag media onto the timeline below.</p>
         </div>
       </div>
@@ -160,6 +161,24 @@
       </div>
     </div>
   </section>
+</div>
+
+<!-- ══════════ IMPORT URL ══════════ -->
+<div class="overlay hidden" id="importUrlOverlay">
+  <div class="dialog" id="importUrlDialog" role="dialog" aria-modal="true" aria-labelledby="importUrlTitle">
+    <h2 id="importUrlTitle">Import from URL</h2>
+    <p class="dim">Downloads an HTTPS video, audio, image or SVG into the project media folder. The file is stored locally — the URL is not used as the playback source.</p>
+    <label class="import-url-field">
+      <span class="sr-only">Media URL</span>
+      <input type="url" id="importUrlInput" placeholder="https://…" autocomplete="off" spellcheck="false">
+    </label>
+    <p class="dim import-url-status hidden" id="importUrlStatus">Downloading…</p>
+    <div class="progress hidden" id="importUrlProgress"><div class="progress-fill indeterminate"></div></div>
+    <div class="dialog-actions">
+      <button class="btn" id="btnCancelImportUrl">Cancel</button>
+      <button class="btn primary" id="btnDoImportUrl">Import</button>
+    </div>
+  </div>
 </div>
 
 <!-- ══════════ EXPORT SETUP ══════════ -->

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
 <div class="overlay hidden" id="importUrlOverlay">
   <div class="dialog" id="importUrlDialog" role="dialog" aria-modal="true" aria-labelledby="importUrlTitle">
     <h2 id="importUrlTitle">Import from URL</h2>
-    <p class="dim">Downloads an HTTPS video, audio, image or SVG into the project media folder. The file is stored locally — the URL is not used as the playback source.</p>
+    <p class="dim">Downloads an HTTPS video, audio or image into the project media folder. The file is stored locally — the URL is not used as the playback source. Remote SVGs are not imported (they can run script if opened as a document).</p>
     <label class="import-url-field">
       <span class="sr-only">Media URL</span>
       <input type="url" id="importUrlInput" placeholder="https://…" autocomplete="off" spellcheck="false">

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -19,6 +19,7 @@ const { loadEncodeProfiles, listProfilesPublic, resolveProfile, profileSummary }
 const {
   APP_DIR, DATA_DIR, MEDIA_DIR, ANALYSIS_DIR, LIBRARY_DIR, PROJECT_FILE, ensureDirs,
 } = require("./paths");
+const { downloadImportUrl, kindFromName, maybeFaststart } = require("./import-url");
 
 /* ROOT is where the code lives (server.js, CLAUDE.md); the user's timeline and
    media live under DATA_DIR. Identical unless FABLECUT_DATA_DIR is set. */
@@ -149,10 +150,10 @@ const TOOLS = [
   },
   {
     name: "fablecut_import_media",
-    description: "Copy a local media file (video/audio/image) into FableCut's media library and register it in the project. Returns the created media entry (use its id in clips).",
+    description: "Import a media file into FableCut's media library and register it in the project. Pass a local absolute path (copied) or an https:// URL (downloaded into ./media/, never kept as the playback src — CORS would break export). Returns the created media entry (use its id in clips).",
     inputSchema: {
       type: "object",
-      properties: { path: { type: "string", description: "Absolute path to the source file on disk" } },
+      properties: { path: { type: "string", description: "Absolute path to a local file, or an https:// URL to download" } },
       required: ["path"],
     },
   },
@@ -446,24 +447,35 @@ async function callTool(name, args) {
     }
     case "fablecut_import_media": {
       const src = args.path;
-      if (!src || !fs.existsSync(src) || !fs.statSync(src).isFile())
-        throw new Error("File not found: " + src);
-      const ext = path.extname(src).toLowerCase();
-      const kind = KIND_BY_EXT[ext];
-      if (!kind) throw new Error(`Unsupported extension ${ext}`);
-      if (!fs.existsSync(MEDIA_DIR)) fs.mkdirSync(MEDIA_DIR);
-      let base = path.basename(src).replace(/[^\w.\- ()\[\]]+/g, "_");
-      let target = path.join(MEDIA_DIR, base);
-      let i = 1;
-      const stem = path.basename(base, ext);
-      while (fs.existsSync(target)) target = path.join(MEDIA_DIR, `${stem}_${i++}${ext}`);
-      fs.copyFileSync(src, target);
+      if (!src) throw new Error("path is required");
+      let target, kind;
+      if (/^https?:\/\//i.test(src)) {
+        if (!/^https:\/\//i.test(src)) throw new Error("URL must be https");
+        const got = await downloadImportUrl(src, MEDIA_DIR);
+        target = got.target;
+        kind = kindFromName(got.name);
+        await maybeFaststart(target);
+      } else {
+        if (!fs.existsSync(src) || !fs.statSync(src).isFile())
+          throw new Error("File not found: " + src);
+        const ext = path.extname(src).toLowerCase();
+        kind = KIND_BY_EXT[ext];
+        if (!kind) throw new Error(`Unsupported extension ${ext}`);
+        if (!fs.existsSync(MEDIA_DIR)) fs.mkdirSync(MEDIA_DIR);
+        let base = path.basename(src).replace(/[^\w.\- ()\[\]]+/g, "_");
+        target = path.join(MEDIA_DIR, base);
+        let i = 1;
+        const stem = path.basename(base, ext);
+        while (fs.existsSync(target)) target = path.join(MEDIA_DIR, `${stem}_${i++}${ext}`);
+        fs.copyFileSync(src, target);
+      }
+      if (!kind) throw new Error("Unsupported media type");
       const entry = {
         id: "m_" + uid(),
         name: path.basename(target),
         kind,
         src: "/media/" + encodeURIComponent(path.basename(target)),
-        duration: kind === "image" ? undefined : ffprobeDuration(target),
+        duration: kind === "image" || kind === "svg" ? undefined : ffprobeDuration(target),
       };
       const proj = readProject();
       // import only appends a media entry (never touches clips), so it merges

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -150,7 +150,7 @@ const TOOLS = [
   },
   {
     name: "fablecut_import_media",
-    description: "Import a media file into FableCut's media library and register it in the project. Pass a local absolute path (copied) or an https:// URL (downloaded into ./media/, never kept as the playback src — CORS would break export). Returns the created media entry (use its id in clips).",
+    description: "Import a media file into FableCut's media library and register it in the project. Pass a local absolute path (copied, including .svg) or an https:// URL (downloaded into ./media/; video/audio/image only — remote SVG is refused). The URL is never kept as the playback src — CORS would break export. Returns the created media entry (use its id in clips).",
     inputSchema: {
       type: "object",
       properties: { path: { type: "string", description: "Absolute path to a local file, or an https:// URL to download" } },

--- a/server.js
+++ b/server.js
@@ -398,8 +398,9 @@ const server = http.createServer(async (req, res) => {
       res.on("close", () => { if (!res.writableEnded) ac.abort(); });
       const { target, name } = await downloadImportUrl(opts.url, MEDIA_DIR, {
         signal: ac.signal,
-        // test/rest-api.test.js sets this so a loopback fixture can pin success
-        allowPrivate: process.env.FABLECUT_TEST_IMPORT_ALLOW_PRIVATE === "1",
+        // test/rest-api.test.js: HTTP to 127.0.0.1 only (loopback fixture).
+        // Does not disable SSRF for LAN / metadata / other private ranges.
+        allowLoopback: process.env.FABLECUT_TEST_IMPORT_ALLOW_PRIVATE === "1",
       });
       await faststart(target);
       sendJSON(res, 200, { ok: true, src: "/media/" + encodeURIComponent(name), name });

--- a/server.js
+++ b/server.js
@@ -113,15 +113,17 @@ function onProfilesChange() {
 }
 /* watch the directory, not the file — atomic tmp+rename writes would detach a
    direct file watcher on Windows */
-try { fs.watch(DATA_DIR, (ev, f) => { if (f === "project.json") onFsChange(); }); } catch {}
-try {
-  fs.watch(ROOT, (ev, f) => {
-    if (f === path.basename(PROFILES_FILE)) onProfilesChange();
-  });
-} catch {}
-try { fs.watch(MEDIA_DIR, onFsChange); } catch {}
-for (const d of LIBRARY_SUBDIRS) {
-  try { fs.watch(path.join(LIBRARY_DIR, d), onFsChange); } catch {}
+if (process.env.FABLECUT_NO_FS_WATCH !== "1") {
+  try { fs.watch(DATA_DIR, (ev, f) => { if (f === "project.json") onFsChange(); }); } catch {}
+  try {
+    fs.watch(ROOT, (ev, f) => {
+      if (f === path.basename(PROFILES_FILE)) onProfilesChange();
+    });
+  } catch {}
+  try { fs.watch(MEDIA_DIR, onFsChange); } catch {}
+  for (const d of LIBRARY_SUBDIRS) {
+    try { fs.watch(path.join(LIBRARY_DIR, d), onFsChange); } catch {}
+  }
 }
 
 /* ── Helpers ── */
@@ -384,8 +386,15 @@ const server = http.createServer(async (req, res) => {
     try {
       const opts = JSON.parse((await readBody(req)).toString("utf8") || "{}");
       const ac = new AbortController();
-      req.on("close", () => { if (!res.writableEnded) ac.abort(); });
-      const { target, name } = await downloadImportUrl(opts.url, MEDIA_DIR, { signal: ac.signal });
+      // IncomingMessage "close" also fires when the request body finishes, which
+      // would abort a successful download. ServerResponse "close" with
+      // writableEnded still false means the client dropped the connection.
+      res.on("close", () => { if (!res.writableEnded) ac.abort(); });
+      const { target, name } = await downloadImportUrl(opts.url, MEDIA_DIR, {
+        signal: ac.signal,
+        // test/rest-api.test.js sets this so a loopback fixture can pin success
+        allowPrivate: process.env.FABLECUT_TEST_IMPORT_ALLOW_PRIVATE === "1",
+      });
       await faststart(target);
       sendJSON(res, 200, { ok: true, src: "/media/" + encodeURIComponent(name), name });
     } catch (e) {

--- a/server.js
+++ b/server.js
@@ -4,7 +4,8 @@
 
    Adds to the browser editor:
      • persistent project      ./project.json      (GET/PUT /api/project)
-     • media library folder    ./media/            (served at /media/*, POST /api/upload)
+     • media library folder    ./media/            (served at /media/*, POST /api/upload,
+                                                    POST /api/import-url)
      • live reload             GET /api/events     (SSE: event "change" for
                                                     project/media/library;
                                                     event "profiles" for
@@ -31,6 +32,7 @@ const {
   buildExportArgs,
   dryRunProfile,
 } = require("./encode-profiles");
+const { downloadImportUrl, maybeFaststart } = require("./import-url");
 
 const {
   APP_DIR, DATA_DIR, MEDIA_DIR, EXPORTS_DIR, ANALYSIS_DIR, LIBRARY_DIR,
@@ -172,16 +174,7 @@ function run(cmd, args) {
 
 /* Remux MP4-family uploads with `+faststart` so the moov atom leads the file —
    without it <video> stalls for seconds probing over Range requests. */
-const FASTSTART_EXT = new Set([".mp4", ".mov", ".m4v"]);
-async function faststart(file) {
-  if (!HAS_FFMPEG || !FASTSTART_EXT.has(path.extname(file).toLowerCase())) return;
-  const tmp = file + ".fs" + path.extname(file);
-  try {
-    await run("ffmpeg", ["-y", "-i", file, "-c", "copy", "-movflags", "+faststart", tmp]);
-    fs.rmSync(file);
-    fs.renameSync(tmp, file);
-  } catch { try { fs.rmSync(tmp); } catch {} }
-}
+function faststart(file) { return maybeFaststart(file); }
 
 /* ── Fast export sessions ──
    The browser renders frames with its own compositor and streams them here as
@@ -381,6 +374,26 @@ const server = http.createServer(async (req, res) => {
       await faststart(target);
       sendJSON(res, 200, { ok: true, src: "/media/" + encodeURIComponent(path.basename(target)) });
     } catch (e) { sendJSON(res, 500, { error: String(e) }); }
+    return;
+  }
+
+  /* API: download an HTTPS URL into ./media (same-origin src after import).
+     Body {url}. Rejects http/file/local/private targets. Does not register
+     project media — the client / MCP tool does that, matching /api/upload. */
+  if (p === "/api/import-url" && req.method === "POST") {
+    try {
+      const opts = JSON.parse((await readBody(req)).toString("utf8") || "{}");
+      const ac = new AbortController();
+      req.on("close", () => { if (!res.writableEnded) ac.abort(); });
+      const { target, name } = await downloadImportUrl(opts.url, MEDIA_DIR, { signal: ac.signal });
+      await faststart(target);
+      sendJSON(res, 200, { ok: true, src: "/media/" + encodeURIComponent(name), name });
+    } catch (e) {
+      if (e && e.code === "ABORT_ERR") { try { res.end(); } catch {} return; }
+      const msg = e && e.message ? e.message : String(e);
+      const code = /must be https|invalid URL|blocked:|credentials|unsupported|too large|did not return/i.test(msg) ? 400 : 502;
+      sendJSON(res, code, { error: msg });
+    }
     return;
   }
 

--- a/server.js
+++ b/server.js
@@ -265,7 +265,13 @@ function cleanupExport(id) {
 function serveFile(req, res, filePath) {
   fs.stat(filePath, (err, st) => {
     if (err || !st.isFile()) { res.writeHead(404); res.end("Not found"); return; }
-    const type = MIME[path.extname(filePath).toLowerCase()] || "application/octet-stream";
+    const ext = path.extname(filePath).toLowerCase();
+    const type = MIME[ext] || "application/octet-stream";
+    const extra = {};
+    if (ext === ".svg") {
+      extra["Content-Security-Policy"] = "sandbox; default-src 'none'; style-src 'unsafe-inline'";
+      extra["X-Content-Type-Options"] = "nosniff";
+    }
     const range = req.headers.range;
     if (range) {
       const m = /bytes=(\d*)-(\d*)/.exec(range);
@@ -275,13 +281,13 @@ function serveFile(req, res, filePath) {
       res.writeHead(206, {
         "Content-Type": type, "Accept-Ranges": "bytes",
         "Content-Range": `bytes ${start}-${end}/${st.size}`,
-        "Content-Length": end - start + 1,
+        "Content-Length": end - start + 1, ...extra,
       });
       fs.createReadStream(filePath, { start, end }).pipe(res);
     } else {
       res.writeHead(200, {
         "Content-Type": type, "Content-Length": st.size,
-        "Accept-Ranges": "bytes", "Cache-Control": "no-cache",
+        "Accept-Ranges": "bytes", "Cache-Control": "no-cache", ...extra,
       });
       fs.createReadStream(filePath).pipe(res);
     }

--- a/style.css
+++ b/style.css
@@ -1754,6 +1754,42 @@ body.track-size-s .clip .clip-kf-n {
   transition: width .2s;
 }
 
+.import-url-field {
+  display: block;
+  margin-bottom: 14px;
+}
+
+.import-url-field input {
+  width: 100%;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font: inherit;
+  user-select: text;
+}
+
+.import-url-field input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.import-url-status {
+  margin: -6px 0 12px;
+}
+
+.progress-fill.indeterminate {
+  width: 36%;
+  transition: none;
+  animation: import-url-slide 1.15s ease-in-out infinite;
+}
+
+@keyframes import-url-slide {
+  0% { transform: translateX(-120%); }
+  100% { transform: translateX(280%); }
+}
+
 .dialog-actions {
   display: flex;
   justify-content: flex-end;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -51,12 +51,15 @@ function freePort() {
 
 /* Start server.js on its own port + data dir and wait until it actually
    answers. Rejects fast if the child dies instead of hanging until timeout. */
-async function startServer(t, dataDir) {
+async function startServer(t, dataDir, extraEnv = {}) {
   for (let attempt = 0; attempt < 3; attempt++) {
     const port = await freePort();
     const child = spawn(process.execPath, [path.join(ROOT, "server.js")], {
       cwd: ROOT,
-      env: { ...process.env, PORT: String(port), HOST: "127.0.0.1", FABLECUT_DATA_DIR: dataDir },
+      env: {
+        ...process.env, PORT: String(port), HOST: "127.0.0.1",
+        FABLECUT_DATA_DIR: dataDir, ...extraEnv,
+      },
       stdio: ["ignore", "pipe", "pipe"],
     });
     let exited = null;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,8 +57,9 @@ async function startServer(t, dataDir, extraEnv = {}) {
     const child = spawn(process.execPath, [path.join(ROOT, "server.js")], {
       cwd: ROOT,
       env: {
-        ...process.env, PORT: String(port), HOST: "127.0.0.1",
-        FABLECUT_DATA_DIR: dataDir, ...extraEnv,
+        ...process.env, ...extraEnv,
+        PORT: String(port), HOST: "127.0.0.1",
+        FABLECUT_DATA_DIR: dataDir,
       },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/test/import-url.test.js
+++ b/test/import-url.test.js
@@ -118,6 +118,11 @@ test("downloadImportUrl enforces maxBytes and rejects HTML", async (t) => {
       res.end("<html>nope</html>");
       return;
     }
+    if (req.url === "/sticker.svg") {
+      res.writeHead(200, { "Content-Type": "image/svg+xml" });
+      res.end('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+      return;
+    }
     res.writeHead(404); res.end();
   });
   t.after(() => server.close());
@@ -128,6 +133,9 @@ test("downloadImportUrl enforces maxBytes and rejects HTML", async (t) => {
   await assert.rejects(
     downloadImportUrl(url + "/page.mp4", dir, { allowPrivate: true }),
     /did not return a media file/);
+  await assert.rejects(
+    downloadImportUrl(url + "/sticker.svg", dir, { allowPrivate: true }),
+    /remote SVG/i);
   assert.equal(fs.readdirSync(dir).length, 0, "failed downloads must not leave a file");
 });
 

--- a/test/import-url.test.js
+++ b/test/import-url.test.js
@@ -1,0 +1,138 @@
+/* import-url.js: SSRF guards and the download-to-disk path used by
+   /api/import-url and fablecut_import_media. Happy-path download uses a local
+   HTTP server with allowPrivate — production callers never pass that flag. */
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  parseImportUrl, isBlockedIp, isBlockedHostname, filenameFrom,
+  kindFromName, downloadImportUrl,
+} = require("../import-url");
+
+test("parseImportUrl accepts https and rejects everything else", () => {
+  const u = parseImportUrl("https://cdn.example.com/a.mp4");
+  assert.equal(u.hostname, "cdn.example.com");
+  assert.equal(u.pathname, "/a.mp4");
+
+  for (const raw of ["http://cdn.example.com/a.mp4", "file:///etc/passwd",
+    "ftp://cdn.example.com/a.mp4", "not a url", "", "https://user:pass@cdn.example.com/a.mp4"]) {
+    assert.throws(() => parseImportUrl(raw), /https|invalid URL|credentials/i, raw);
+  }
+});
+
+test("localhost and private hosts are blocked before any fetch", () => {
+  for (const host of ["localhost", "foo.localhost", "metadata.google.internal",
+    "box.local", "nas.internal", "127.0.0.1", "10.0.0.5", "192.168.1.9",
+    "172.16.4.1", "169.254.169.254", "100.64.1.2", "[::1]"]) {
+    assert.throws(() => parseImportUrl(`https://${host}/x.mp4`), /blocked/i, host);
+  }
+  assert.equal(isBlockedHostname("cdn.example.com"), false);
+});
+
+test("isBlockedIp covers IPv4 private, loopback, link-local, CGNAT, multicast", () => {
+  for (const ip of ["127.0.0.1", "10.1.2.3", "192.168.0.1", "172.16.0.1",
+    "172.31.255.1", "169.254.169.254", "100.64.0.1", "0.0.0.0", "224.0.0.1",
+    "::1", "::ffff:127.0.0.1", "::ffff:10.0.0.1", "fe80::1", "fc00::1", "fd12::1"]) {
+    assert.equal(isBlockedIp(ip), true, ip);
+  }
+  assert.equal(isBlockedIp("1.1.1.1"), false);
+  assert.equal(isBlockedIp("8.8.8.8"), false);
+  assert.equal(isBlockedIp("2001:4860:4860::8888"), false);
+  assert.equal(isBlockedIp("172.32.0.1"), false, "172.32 is public");
+  assert.equal(isBlockedIp("100.63.255.1"), false, "below CGNAT");
+});
+
+test("filenameFrom prefers Content-Disposition then the URL path", () => {
+  const u = new URL("https://cdn.example.com/guid/clip.mp4?sig=1");
+  assert.equal(filenameFrom(u, {}), "clip.mp4");
+  assert.equal(filenameFrom(u, { "content-disposition": 'attachment; filename="hero.mov"' }), "hero.mov");
+  assert.equal(filenameFrom(new URL("https://cdn.example.com/guid"), {
+    "content-type": "video/mp4",
+  }), "guid.mp4");
+  assert.equal(kindFromName("hero.mov"), "video");
+  assert.equal(kindFromName("whoosh.mp3"), "audio");
+  assert.equal(kindFromName("sticker.svg"), "svg");
+  assert.equal(kindFromName("notes.txt"), null);
+});
+
+function listen(handler) {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, port, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+test("downloadImportUrl streams a file when allowPrivate is set (test hook)", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-import-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const { server, url } = await listen((req, res) => {
+    if (req.url === "/clip.mp4") {
+      res.writeHead(200, { "Content-Type": "video/mp4" });
+      res.end("fake-mp4-bytes");
+      return;
+    }
+    if (req.url === "/go") {
+      res.writeHead(302, { Location: "/renamed.bin" });
+      res.end();
+      return;
+    }
+    if (req.url === "/renamed.bin") {
+      res.writeHead(200, {
+        "Content-Type": "video/webm",
+        "Content-Disposition": 'attachment; filename="from-header.webm"',
+      });
+      res.end("webm-bytes");
+      return;
+    }
+    res.writeHead(404); res.end();
+  });
+  t.after(() => server.close());
+
+  const a = await downloadImportUrl(url + "/clip.mp4", dir, { allowPrivate: true });
+  assert.equal(a.name, "clip.mp4");
+  assert.equal(fs.readFileSync(a.target, "utf8"), "fake-mp4-bytes");
+
+  const b = await downloadImportUrl(url + "/go", dir, { allowPrivate: true });
+  assert.equal(b.name, "from-header.webm");
+  assert.equal(fs.readFileSync(b.target, "utf8"), "webm-bytes");
+});
+
+test("downloadImportUrl enforces maxBytes and rejects HTML", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-import-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const { server, url } = await listen((req, res) => {
+    if (req.url === "/big.mp4") {
+      res.writeHead(200, { "Content-Type": "video/mp4", "Content-Length": "100" });
+      res.end("0123456789");
+      return;
+    }
+    if (req.url === "/page.mp4") {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<html>nope</html>");
+      return;
+    }
+    res.writeHead(404); res.end();
+  });
+  t.after(() => server.close());
+
+  await assert.rejects(
+    downloadImportUrl(url + "/big.mp4", dir, { allowPrivate: true, maxBytes: 4 }),
+    /too large/);
+  await assert.rejects(
+    downloadImportUrl(url + "/page.mp4", dir, { allowPrivate: true }),
+    /did not return a media file/);
+  assert.equal(fs.readdirSync(dir).length, 0, "failed downloads must not leave a file");
+});
+
+test("downloadImportUrl without allowPrivate still refuses http and loopback", async () => {
+  await assert.rejects(downloadImportUrl("http://example.com/a.mp4", os.tmpdir()), /https/i);
+  await assert.rejects(downloadImportUrl("https://127.0.0.1/a.mp4", os.tmpdir()), /blocked/i);
+  await assert.rejects(downloadImportUrl("https://localhost/a.mp4", os.tmpdir()), /blocked/i);
+});

--- a/test/import-url.test.js
+++ b/test/import-url.test.js
@@ -120,6 +120,10 @@ test("downloadImportUrl streams a file when allowLoopback is set (test hook)", a
   assert.equal(a.name, "clip.mp4");
   assert.equal(fs.readFileSync(a.target, "utf8"), "fake-mp4-bytes");
 
+  const a2 = await downloadImportUrl(url + "/clip.mp4", dir, { allowLoopback: true });
+  assert.equal(a2.name, "clip_1.mp4");
+  assert.equal(fs.readFileSync(a2.target, "utf8"), "fake-mp4-bytes");
+
   const b = await downloadImportUrl(url + "/go", dir, { allowLoopback: true });
   assert.equal(b.name, "from-header.webm");
   assert.equal(fs.readFileSync(b.target, "utf8"), "webm-bytes");

--- a/test/import-url.test.js
+++ b/test/import-url.test.js
@@ -1,6 +1,7 @@
 /* import-url.js: SSRF guards and the download-to-disk path used by
    /api/import-url and fablecut_import_media. Happy-path download uses a local
-   HTTP server with allowPrivate — production callers never pass that flag. */
+   HTTP server with allowLoopback (127.0.0.1 only) — production callers never
+   pass that flag. */
 "use strict";
 const test = require("node:test");
 const assert = require("node:assert/strict");
@@ -69,7 +70,22 @@ function listen(handler) {
   });
 }
 
-test("downloadImportUrl streams a file when allowPrivate is set (test hook)", async (t) => {
+test("allowLoopback is 127.0.0.1 only, not a private-range bypass", () => {
+  const u = parseImportUrl("http://127.0.0.1/clip.mp4", { allowLoopback: true });
+  assert.equal(u.hostname, "127.0.0.1");
+  parseImportUrl("https://127.0.0.1/clip.mp4", { allowLoopback: true });
+
+  for (const raw of [
+    "http://10.0.0.5/x.mp4", "https://10.0.0.5/x.mp4",
+    "https://192.168.1.9/x.mp4", "https://169.254.169.254/latest/meta-data",
+    "http://localhost/x.mp4", "https://localhost/x.mp4",
+    "https://127.0.0.2/x.mp4", "https://[::1]/x.mp4",
+  ]) {
+    assert.throws(() => parseImportUrl(raw, { allowLoopback: true }), /https|blocked/i, raw);
+  }
+});
+
+test("downloadImportUrl streams a file when allowLoopback is set (test hook)", async (t) => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fablecut-import-"));
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const { server, url } = await listen((req, res) => {
@@ -91,17 +107,26 @@ test("downloadImportUrl streams a file when allowPrivate is set (test hook)", as
       res.end("webm-bytes");
       return;
     }
+    if (req.url === "/away") {
+      res.writeHead(302, { Location: "https://192.168.1.9/secret.mp4" });
+      res.end();
+      return;
+    }
     res.writeHead(404); res.end();
   });
   t.after(() => server.close());
 
-  const a = await downloadImportUrl(url + "/clip.mp4", dir, { allowPrivate: true });
+  const a = await downloadImportUrl(url + "/clip.mp4", dir, { allowLoopback: true });
   assert.equal(a.name, "clip.mp4");
   assert.equal(fs.readFileSync(a.target, "utf8"), "fake-mp4-bytes");
 
-  const b = await downloadImportUrl(url + "/go", dir, { allowPrivate: true });
+  const b = await downloadImportUrl(url + "/go", dir, { allowLoopback: true });
   assert.equal(b.name, "from-header.webm");
   assert.equal(fs.readFileSync(b.target, "utf8"), "webm-bytes");
+
+  await assert.rejects(
+    downloadImportUrl(url + "/away", dir, { allowLoopback: true }),
+    /blocked/i);
 });
 
 test("downloadImportUrl enforces maxBytes and rejects HTML", async (t) => {
@@ -128,18 +153,18 @@ test("downloadImportUrl enforces maxBytes and rejects HTML", async (t) => {
   t.after(() => server.close());
 
   await assert.rejects(
-    downloadImportUrl(url + "/big.mp4", dir, { allowPrivate: true, maxBytes: 4 }),
+    downloadImportUrl(url + "/big.mp4", dir, { allowLoopback: true, maxBytes: 4 }),
     /too large/);
   await assert.rejects(
-    downloadImportUrl(url + "/page.mp4", dir, { allowPrivate: true }),
+    downloadImportUrl(url + "/page.mp4", dir, { allowLoopback: true }),
     /did not return a media file/);
   await assert.rejects(
-    downloadImportUrl(url + "/sticker.svg", dir, { allowPrivate: true }),
+    downloadImportUrl(url + "/sticker.svg", dir, { allowLoopback: true }),
     /remote SVG/i);
   assert.equal(fs.readdirSync(dir).length, 0, "failed downloads must not leave a file");
 });
 
-test("downloadImportUrl without allowPrivate still refuses http and loopback", async () => {
+test("downloadImportUrl without allowLoopback still refuses http and loopback", async () => {
   await assert.rejects(downloadImportUrl("http://example.com/a.mp4", os.tmpdir()), /https/i);
   await assert.rejects(downloadImportUrl("https://127.0.0.1/a.mp4", os.tmpdir()), /blocked/i);
   await assert.rejects(downloadImportUrl("https://localhost/a.mp4", os.tmpdir()), /blocked/i);

--- a/test/mcp-tools.test.js
+++ b/test/mcp-tools.test.js
@@ -5,6 +5,8 @@
 "use strict";
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const { makeDataDir, readProject, writeProject, seedProject, startMcp } = require("./helpers");
 
 const boot = async (t, project) => {
@@ -192,4 +194,30 @@ test("fablecut_set_project validates the document before writing it", async (t) 
     assert.match(text, expected);
   }
   assert.deepEqual(readProject(dir), before, "an invalid save must leave the file untouched");
+});
+
+test("fablecut_import_media copies a local file and registers it", async (t) => {
+  const { dir, mcp } = await boot(t);
+  const src = path.join(dir, "take.mp4");
+  fs.writeFileSync(src, "clip-bytes");
+  const { text, isError } = await mcp.callTool("fablecut_import_media", { path: src });
+  assert.equal(isError, false, text);
+  const entry = JSON.parse(text.replace(/^Imported → /, "").split("\n")[0]);
+  assert.equal(entry.kind, "video");
+  assert.equal(entry.src, "/media/take.mp4");
+  assert.ok(fs.existsSync(path.join(dir, "media", "take.mp4")));
+  const doc = readProject(dir);
+  assert.equal(doc.media.some((m) => m.id === entry.id && m.src === entry.src), true);
+  assert.equal(doc.revision, 2);
+});
+
+test("fablecut_import_media rejects http and loopback https URLs", async (t) => {
+  const { dir, mcp } = await boot(t);
+  const http = await mcp.callTool("fablecut_import_media", { path: "http://example.com/a.mp4" });
+  assert.ok(http.isError);
+  assert.match(http.text, /https/i);
+  const loop = await mcp.callTool("fablecut_import_media", { path: "https://127.0.0.1/a.mp4" });
+  assert.ok(loop.isError);
+  assert.match(loop.text, /blocked/i);
+  assert.equal(readProject(dir).media.length, 1, "a rejected import must not add media");
 });

--- a/test/rest-api.test.js
+++ b/test/rest-api.test.js
@@ -6,6 +6,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const http = require("node:http");
 const os = require("node:os");
 const path = require("node:path");
 const { makeDataDir, readProject, seedProject, startServer, rawGet } = require("./helpers");
@@ -107,6 +108,41 @@ test("POST /api/import-url rejects non-https and private targets", async (t) => 
   await reject("https://192.168.1.9/a.mp4", /blocked/i);
   await reject("https://169.254.169.254/latest/meta-data", /blocked/i);
   assert.equal(fs.readdirSync(path.join(dir, "media")).length, 0);
+});
+
+test("POST /api/import-url downloads into media and returns a same-origin src", async (t) => {
+  const dir = makeDataDir(t);
+  const fixture = await new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      if (req.url === "/clip.mp4") {
+        res.writeHead(200, { "Content-Type": "video/mp4" });
+        res.end("fake-mp4-bytes");
+        return;
+      }
+      res.writeHead(404); res.end();
+    });
+    server.listen(0, "127.0.0.1", () => {
+      resolve({ server, url: `http://127.0.0.1:${server.address().port}` });
+    });
+  });
+  t.after(() => fixture.server.close());
+  const { base } = await startServer(t, dir, {
+    FABLECUT_TEST_IMPORT_ALLOW_PRIVATE: "1",
+    // libuv fs.watch on Windows aborts the process when a file is created under
+    // a Temp data dir (uv assertion in fs-event.c). This test only needs the
+    // HTTP handler to finish writing the file.
+    FABLECUT_NO_FS_WATCH: "1",
+  });
+  const res = await fetch(base + "/api/import-url", {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url: fixture.url + "/clip.mp4" }),
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.name, "clip.mp4");
+  assert.equal(body.src, "/media/clip.mp4");
+  assert.equal(fs.readFileSync(path.join(dir, "media", "clip.mp4"), "utf8"), "fake-mp4-bytes");
 });
 
 test("GET /api/media lists the media folder", async (t) => {

--- a/test/rest-api.test.js
+++ b/test/rest-api.test.js
@@ -89,6 +89,26 @@ test("GET /api/library lists assets and validates the dir argument", async (t) =
   }
 });
 
+test("POST /api/import-url rejects non-https and private targets", async (t) => {
+  const { dir, base } = await boot(t);
+  const reject = async (url, expect) => {
+    const res = await fetch(base + "/api/import-url", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url }),
+    });
+    assert.equal(res.status, 400, url);
+    const body = await res.json();
+    assert.match(body.error, expect, url);
+  };
+  await reject("http://example.com/a.mp4", /https/i);
+  await reject("file:///etc/passwd", /https|invalid/i);
+  await reject("https://127.0.0.1/a.mp4", /blocked/i);
+  await reject("https://localhost/a.mp4", /blocked/i);
+  await reject("https://192.168.1.9/a.mp4", /blocked/i);
+  await reject("https://169.254.169.254/latest/meta-data", /blocked/i);
+  assert.equal(fs.readdirSync(path.join(dir, "media")).length, 0);
+});
+
 test("GET /api/media lists the media folder", async (t) => {
   const { base } = await boot(t);
   const res = await fetch(base + "/api/media");

--- a/test/rest-api.test.js
+++ b/test/rest-api.test.js
@@ -82,6 +82,8 @@ test("GET /api/library lists assets and validates the dir argument", async (t) =
   // A served src must actually resolve — a listing that links to 404s is useless.
   const one = await fetch(base + items[0].src);
   assert.equal(one.status, 200);
+  assert.match(one.headers.get("content-security-policy") || "", /sandbox/);
+  await one.arrayBuffer();
 
   for (const bad of ["", "bogus", "../..", "sfx/../../.."]) {
     const r = await fetch(base + "/api/library?dir=" + encodeURIComponent(bad));

--- a/test/rest-api.test.js
+++ b/test/rest-api.test.js
@@ -129,6 +129,7 @@ test("POST /api/import-url downloads into media and returns a same-origin src", 
   });
   t.after(() => fixture.server.close());
   const { base } = await startServer(t, dir, {
+    // HTTP to 127.0.0.1 only — LAN / metadata stay blocked (see SECURITY.md).
     FABLECUT_TEST_IMPORT_ALLOW_PRIVATE: "1",
     // libuv fs.watch on Windows aborts the process when a file is created under
     // a Temp data dir (uv assertion in fs-event.c). This test only needs the
@@ -145,6 +146,13 @@ test("POST /api/import-url downloads into media and returns a same-origin src", 
   assert.equal(body.name, "clip.mp4");
   assert.equal(body.src, "/media/clip.mp4");
   assert.equal(fs.readFileSync(path.join(dir, "media", "clip.mp4"), "utf8"), "fake-mp4-bytes");
+
+  const lan = await fetch(base + "/api/import-url", {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url: "https://192.168.1.9/a.mp4" }),
+  });
+  assert.equal(lan.status, 400);
+  assert.match((await lan.json()).error, /blocked/i);
 });
 
 test("GET /api/media lists the media folder", async (t) => {


### PR DESCRIPTION
Download a video from url; no authentication supported


## What does this PR do?

Add `URL` asset - to avoid CORS problems, a video/image is downloaded to `/.media/` directory

## Type of change

- [ ] Bug fix
- [X] New feature (transition / preset / text anim / effect / API)
- [X] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `npm test` passes (CI runs it on Node 18 / 20 / 22)
- [ ] Added or updated a test in `test/` if this touches the MCP surface, the REST API, or the SVG library
- [ ] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [X] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Import from URL** option for media assets.
  * Paste an HTTPS video, audio, or image URL using the **+ URL** button.
  * Added download progress, validation, and clear import error feedback.
  * Imported files are saved locally for reliable editing and export.
  * Added configurable encoding profiles for fast exports, including profile selection and validation.

* **Security**
  * Restricted imports to HTTPS and blocked unsafe private or local network destinations.
  * Remote SVG files are refused to prevent scripts from running in the editor.

* **Documentation**
  * Updated usage, API, export, and security documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->