### PR TITLE
feat: add more segments to uv meter

### DIFF
--- a/app.js
+++ b/app.js
@@ -3557,19 +3557,15 @@ function routeClipGain(c) {
 }
 
 /* ── Per-track meters: RMS / LUFS-M / Peak (AudioWorklet) ── */
-const METER_SEGS = 16;
+const METER_SEGS = 20;
 const METER_DB_MIN = -48;
 const METER_DB_MAX = 0;
 /** Scale tick marks shown beside the meter bars (dBFS). */
 const METER_DB_MARKS = [0, -6, -12, -24, -36, -48];
 const METER_MODES = ["rms", "lufs", "peak"];
 const METER_MODE_LABEL = { rms: "RMS", lufs: "LUFS", peak: "PEAK" };
-/* Each channel's segment ladder is one <canvas> instead of METER_SEGS separate
-   DOM nodes (was up to 16 tracks × 16 <div>s = 256 live elements, all touched
-   via classList every time the reading changed). Geometry matches the old
-   flex layout: 16 × 12px segments, 2px gaps, column-reverse (index 0 = bottom
-   = quietest). */
-const METER_SEG_W = 8, METER_SEG_H = 12, METER_SEG_GAP = 2;
+/* Each channel's segment ladder is one <canvas>  - index 0 = bottom = quietest. */
+const METER_SEG_W = 10, METER_SEG_H = 10, METER_SEG_GAP = 1;
 const METER_COL_W = METER_SEG_W;
 const METER_COL_H = METER_SEGS * METER_SEG_H + (METER_SEGS - 1) * METER_SEG_GAP;
 function makeMeterCanvas(cv) {
@@ -3782,29 +3778,37 @@ function updateMeterUI(dt) {
   const attack = 1 - Math.exp(-dt / atkMs);
   const release = 1 - Math.exp(-dt / relMs);
   const now = performance.now();
+  const floorEps = (METER_DB_MAX - METER_DB_MIN) / (METER_SEGS * 2);
   for (const id of ids) {
     const target = metering ? meterReadingDb(id) : METER_DB_MIN;
     const cur = meterState.disp[id] ?? METER_DB_MIN;
     const a = target > cur ? attack : release;
-    const next = cur + (target - cur) * a;
+    let next = cur + (target - cur) * a;
+    if (next <= METER_DB_MIN + floorEps) next = METER_DB_MIN;
     meterState.disp[id] = next;
 
     // Hold tip follows the active mode reading (not always sample-peak)
     const pk = target;
-    if (pk >= (meterState.peakHold[id] ?? METER_DB_MIN)) {
+    if (pk > (meterState.peakHold[id] ?? METER_DB_MIN)) {
       meterState.peakHold[id] = pk;
       meterState.peakHoldT[id] = now;
     } else if (now - (meterState.peakHoldT[id] || 0) > 800) {
       meterState.peakHold[id] += (METER_DB_MIN - meterState.peakHold[id]) * release;
+      if (meterState.peakHold[id] <= METER_DB_MIN + floorEps)
+        meterState.peakHold[id] = METER_DB_MIN;
     }
 
     const segs = meterState.segs[id];
     if (!segs) continue;
     const level = (next - METER_DB_MIN) / (METER_DB_MAX - METER_DB_MIN);
-    const lit = Math.round(clamp(level, 0, 1) * METER_SEGS);
-    const hold = Math.round(clamp(
+    const lit = next <= METER_DB_MIN ? 0 : Math.round(clamp(level, 0, 1) * METER_SEGS);
+    const holdN = clamp(
       ((meterState.peakHold[id] ?? METER_DB_MIN) - METER_DB_MIN) / (METER_DB_MAX - METER_DB_MIN), 0, 1
-    ) * (METER_SEGS - 1));
+    );
+    // Floor / empty bar → no hold tick. Exponential decay never quite hits
+    // MIN, so round(ε) kept segment 0 lit after falloff.
+    let hold = holdN <= 0 ? -1 : Math.round(holdN * (METER_SEGS - 1));
+    if (lit === 0 && hold <= 0) hold = -1;
     // The ballistics above still run every frame (needed for smooth decay),
     // but the canvas only needs repainting when the result actually differs —
     // skips a redraw for most tracks most frames.

--- a/app.js
+++ b/app.js
@@ -3805,10 +3805,9 @@ function updateMeterUI(dt) {
     const holdN = clamp(
       ((meterState.peakHold[id] ?? METER_DB_MIN) - METER_DB_MIN) / (METER_DB_MAX - METER_DB_MIN), 0, 1
     );
-    // Floor / empty bar → no hold tick. Exponential decay never quite hits
-    // MIN, so round(ε) kept segment 0 lit after falloff.
+    // Empty bar → no hold tick (including a leftover positive hold index).
     let hold = holdN <= 0 ? -1 : Math.round(holdN * (METER_SEGS - 1));
-    if (lit === 0 && hold <= 0) hold = -1;
+    if (lit === 0) hold = -1;
     // The ballistics above still run every frame (needed for smooth decay),
     // but the canvas only needs repainting when the result actually differs —
     // skips a redraw for most tracks most frames.

--- a/style.css
+++ b/style.css
@@ -722,6 +722,9 @@ body.track-size-s .clip.selected {
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  /* Below monitor chrome (VU, keyframe graphs) so the export-frame shade
+     cannot dim them. Flex item z-index is enough — no position needed. */
+  z-index: 1;
 }
 
 .monitor-scroll.is-zoomed {
@@ -848,7 +851,7 @@ body.track-size-s .clip.selected {
   flex-direction: column;
   align-items: stretch;
   gap: 4px;
-  z-index: 4;
+  z-index: 7;
   pointer-events: auto;
   padding: 5px 5px 4px;
   background: #000a;


### PR DESCRIPTION
## What does this PR do?

Restyles the UV meter, more segments, better silence handling

## Type of change

- [ ] Bug fix
- [ ] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [X] Refactor / internal

## How was it verified?

- [X] `npm test` passes (CI runs it on Node 18 / 20 / 22)
- [ ] Added or updated a test in `test/` if this touches the MCP surface, the REST API, or the SVG library
- [X] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio meter accuracy and responsiveness with finer segments.
  * Prevented residual illuminated segments after audio levels decay.
  * Ensured silence is displayed cleanly and peak indicators appear only when audio is present.
  * Prevented overlay shading from dimming VU meters and keyframe graphs, keeping monitoring visuals clear during export-related views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->