### PR TITLE
Frame export view crop mode added

### DIFF
--- a/app.js
+++ b/app.js
@@ -256,7 +256,8 @@ const state = {
   connected: false, exporting: false,
   rendering: false,      // fast (server/ffmpeg) export in progress
   guides: false,         // safe-area overlay on the monitor
-  exportFrameView: true, // dimmed overscan + export frame overlay
+  exportFrameView: true, // export frame overlay (border + overscan dim)
+  exportFrameCrop: false, // clip preview to the export frame (hide overscan)
   viewZoom: 1,           // program-monitor display zoom (1 = fit stage)
   audioHold: false,      // while paused, loop one frame of audio at the playhead
   ffmpeg: false,         // server reports ffmpeg available
@@ -334,6 +335,7 @@ const els = {
   projectName: $("projectName"), monitorRes: $("monitorRes"),
   aspectSel: $("aspectSel"), fpsSel: $("fpsSel"),
   btnGuides: $("btnGuides"), btnExportFrame: $("btnExportFrame"),
+  btnExportFrameDim: $("btnExportFrameDim"),
   exportFrameSel: $("exportFrameSel"), exportFrameOverlay: $("exportFrameOverlay"),
   btnZoom100: $("btnZoom100"),
   safeOverlay: $("safeOverlay"), btnSpeed: $("btnSpeed"),
@@ -5779,6 +5781,10 @@ els.btnExportFrame?.addEventListener("click", () => {
   els.btnExportFrame.classList.toggle("on", state.exportFrameView && !!getExportFrame());
   updateExportFrameOverlay();
 });
+els.btnExportFrameDim?.addEventListener("click", () => {
+  state.exportFrameCrop = !state.exportFrameCrop;
+  updateExportFrameOverlay();
+});
 els.btnGuides.addEventListener("click", () => {
   state.guides = !state.guides;
   els.btnGuides.classList.toggle("on", state.guides);
@@ -5978,12 +5984,41 @@ function layoutExportFrameOverlayPart(el, left, top, w, h) {
   el.style.width = w + "px";
   el.style.height = h + "px";
 }
+function applyExportFrameClip(ef, show) {
+  const inner = els.monitorZoomInner;
+  if (!inner) return;
+  if (!(show && state.exportFrameCrop && ef && els.preview)) {
+    inner.style.clipPath = "";
+    return;
+  }
+  const cv = els.preview;
+  const ir = inner.getBoundingClientRect();
+  const cr = cv.getBoundingClientRect();
+  if (!ir.width || !cr.width) { inner.style.clipPath = ""; return; }
+  const sx = cr.width / project.width, sy = cr.height / project.height;
+  const left = cr.left - ir.left + ef.x * sx;
+  const top = cr.top - ir.top + ef.y * sy;
+  const right = ir.right - (cr.left + (ef.x + ef.w) * sx);
+  const bottom = ir.bottom - (cr.top + (ef.y + ef.h) * sy);
+  inner.style.clipPath = `inset(${Math.max(0, top)}px ${Math.max(0, right)}px ${Math.max(0, bottom)}px ${Math.max(0, left)}px)`;
+}
 function updateExportFrameOverlay() {
   const ov = els.exportFrameOverlay;
   if (!ov) return;
   const ef = getExportFrame();
   const show = state.exportFrameView && ef;
   ov.classList.toggle("hidden", !show);
+  ov.classList.toggle("is-crop", !!(show && state.exportFrameCrop));
+  const dimBtn = els.btnExportFrameDim;
+  if (dimBtn) {
+    dimBtn.classList.toggle("hidden", !show);
+    dimBtn.classList.toggle("on", !!(show && !state.exportFrameCrop));
+    dimBtn.setAttribute("aria-pressed", show && !state.exportFrameCrop ? "true" : "false");
+    dimBtn.title = state.exportFrameCrop
+      ? "Lights on — show canvas outside the export frame"
+      : "Lights off — crop to the export frame";
+  }
+  applyExportFrameClip(ef, show);
   if (!show) return;
   const cv = els.preview;
   const root = ov.style;

--- a/app.js
+++ b/app.js
@@ -6037,7 +6037,12 @@ function updateExportFrameOverlay() {
   if (!hole) return;
   const left = ef.x * sx, top = ef.y * sy, w = ef.w * sx, h = ef.h * sy;
   layoutExportFrameOverlayPart(hole, left, top, w, h);
-  if (handle) layoutExportFrameOverlayPart(handle, left + 6, top + 6, Math.min(w - 12, 120), 22);
+  if (handle) {
+    handle.style.left = (left + 6) + "px";
+    handle.style.top = (top + 6) + "px";
+    handle.style.width = "auto";
+    handle.style.maxWidth = Math.max(0, w - 12) + "px";
+  }
   if (edgeT) layoutExportFrameOverlayPart(edgeT, left, top, w, EF_EDGE);
   if (edgeB) layoutExportFrameOverlayPart(edgeB, left, top + h - EF_EDGE, w, EF_EDGE);
   if (edgeL) layoutExportFrameOverlayPart(edgeL, left, top + EF_EDGE, EF_EDGE, Math.max(0, h - EF_EDGE * 2));

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
           <select id="fpsSel" class="head-select" title="Project frame rate"></select>
           <select id="exportFrameSel" class="head-select" title="Delivery export frame — crop inside the canvas for reframing"></select>
           <button class="btn tiny toggle" id="btnExportFrame" title="Toggle export frame overlay (drag handle to reframe)">⬒ Frame</button>
+          <button type="button" class="btn tiny toggle hidden" id="btnExportFrameDim" aria-pressed="true" title="Lights off — crop to the export frame"><svg class="ico" viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><g class="ef-bulb-rays" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><path d="M8 .4v1.05M1.7 3.45l.85.65M14.3 3.45l-.85.65"/></g><path class="ef-bulb-glass" fill="none" stroke="currentColor" stroke-width="1.55" stroke-linejoin="round" d="M8 1.7A4.1 4.1 0 0 0 3.9 5.8c0 1.62.86 2.72 1.8 3.5.38.32.62.68.62 1.15v.35h4.36v-.35c0-.47.24-.83.62-1.15.94-.78 1.8-1.88 1.8-3.5A4.1 4.1 0 0 0 8 1.7z"/><path fill="none" stroke="currentColor" stroke-width="1.45" stroke-linecap="square" d="M6.25 12.85h3.5M6.7 14.35h2.6"/></svg></button>
           <button class="btn tiny toggle" id="btnGuides" title="Toggle safe-area guides">▦ Safe</button>
           <span class="dim" id="monitorRes">1280 × 720 · 30fps</span>
         </span>

--- a/style.css
+++ b/style.css
@@ -981,6 +981,13 @@ body.track-size-s .clip.selected {
   box-sizing: border-box;
   pointer-events: none;
 }
+#exportFrameOverlay.is-crop .ef-shade {
+  box-shadow: 0 0 0 9999px #000;
+}
+#btnExportFrameDim .ico { margin-right: 0; }
+#btnExportFrameDim .ef-bulb-rays { opacity: 0; }
+#btnExportFrameDim.on .ef-bulb-rays { opacity: 1; }
+#btnExportFrameDim.on .ef-bulb-glass { fill: currentColor; fill-opacity: .22; }
 #exportFrameOverlay .ef-handle {
   position: absolute;
   display: flex;

--- a/style.css
+++ b/style.css
@@ -976,9 +976,8 @@ body.track-size-s .clip.selected {
 }
 #exportFrameOverlay .ef-shade {
   position: absolute;
-  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.58);
-  border: 2px solid rgba(255, 255, 255, 0.88);
-  box-sizing: border-box;
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.88);
   pointer-events: none;
 }
 #exportFrameOverlay.is-crop .ef-shade {
@@ -990,27 +989,30 @@ body.track-size-s .clip.selected {
 #btnExportFrameDim.on .ef-bulb-glass { fill: currentColor; fill-opacity: .22; }
 #exportFrameOverlay .ef-handle {
   position: absolute;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: flex-start;
-  height: 22px;
+  width: auto;
+  min-width: 0;
+  height: 20px;
   box-sizing: border-box;
   margin: 0;
-  padding: 0 8px;
-  font: 600 10px/1 "Segoe UI", sans-serif;
+  padding: 0 6px;
+  font: 600 10px/1 ui-sans-serif, system-ui, sans-serif;
   font-family: inherit;
-  letter-spacing: 0.04em;
   text-transform: uppercase;
   color: #fff;
-  background: rgba(79, 140, 255, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: color-mix(in srgb, var(--accent) 62%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, #fff);
   border-radius: 4px;
   cursor: move;
   pointer-events: auto;
   touch-action: none;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   user-select: none;
-  transition: background 0.12s ease;
+  transition: background 0.12s ease, filter 0.12s ease;
   appearance: none;
   -webkit-appearance: none;
 }
@@ -1019,11 +1021,11 @@ body.track-size-s .clip.selected {
   outline-offset: 2px;
 }
 #exportFrameOverlay .ef-handle:hover {
-  background: rgba(79, 140, 255, 1);
+  background: color-mix(in srgb, var(--accent) 82%, transparent);
 }
 #exportFrameOverlay.is-dragging .ef-handle,
 #exportFrameOverlay .ef-handle:active {
-  background: rgba(79, 140, 255, 0.9);
+  background: color-mix(in srgb, var(--accent) 72%, transparent);
 }
 #exportFrameOverlay .ef-edge {
   position: absolute;


### PR DESCRIPTION
## What does this PR do?

There is a 'lightbulb' icon when the export frame is active that toggles the current 'dimmed outside' view to plain crop.

<img width="800" height="202" alt="image" src="https://github.com/user-attachments/assets/183a3dba-babf-44ba-89fa-11d1a715e748" />


## Type of change

- [ ] Bug fix
- [X] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `npm test` passes (CI runs it on Node 18 / 20 / 22)
- [ ] Added or updated a test in `test/` if this touches the MCP surface, the REST API, or the SVG library
- [X] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an export-frame toggle to switch between clipped content and a dimmed view of the surrounding canvas.
  * The toggle includes an accessible label, pressed state, and visual lightbulb indicator.
  * Export-frame controls now adapt to the available frame width.

* **Style**
  * Updated export-frame shading, borders, handles, and accent colors for clearer visual feedback during hovering and dragging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->