### PR TITLE
fix: fix master audio meter readings

### DIFF
--- a/app.js
+++ b/app.js
@@ -4095,6 +4095,7 @@ function resetMasterMeterBallistics() {
   meterState.master.dispL = meterState.master.dispR = METER_DB_MIN;
   meterState.master.peakHoldL = meterState.master.peakHoldR = METER_DB_MIN;
   meterState.master.peakHoldTL = meterState.master.peakHoldTR = 0;
+  meterState.master.lufs = -70;
   meterState.lastLit[MASTER_METER_L] = meterState.lastLit[MASTER_METER_R] = -1;
   meterState.lastHold[MASTER_METER_L] = meterState.lastHold[MASTER_METER_R] = -1;
 }
@@ -4241,7 +4242,7 @@ async function installMeterWorklet(audio) {
   const nInputs = Math.max(1, nAudio + 1); // +1 = video/other spill on master
   let meter = null;
   try {
-    await audio.ctx.audioWorklet.addModule("meter-worklet.js?v=7");
+    await audio.ctx.audioWorklet.addModule("meter-worklet.js?v=8");
     // Aborted by syncAudioGraphTracks while we were loading — retry fresh.
     if (meterState._reloadMeter) return;
     meter = new AudioWorkletNode(audio.ctx, "fablecut-meter", {
@@ -4263,6 +4264,7 @@ async function installMeterWorklet(audio) {
         meterState.peak[id] = msg.peak[i] || 0;
         meterState.lufs[id] = msg.lufs[i] != null ? msg.lufs[i] : -70;
       }
+      if (msg.masterLufs != null) meterState.master.lufs = msg.masterLufs;
     };
 
     // Connect outputs first so a wiring error never leaves the graph silent.
@@ -4437,8 +4439,9 @@ function meterReadingDb(id) {
     const isL = id === MASTER_METER_L;
     if (mode === "peak") return rmsToDb(isL ? m.peakL : m.peakR);
     if (mode === "lufs") {
-      // Per-channel level for stereo master bars (worklet stereo LUFS is one combined value).
-      return rmsToDb(isL ? m.rmsL : m.rmsR);
+      // Master LUFS is a single program value; both L/R bars display it.
+      const v = m.lufs;
+      return v == null || v < METER_DB_MIN ? METER_DB_MIN : Math.min(METER_DB_MAX, v);
     }
     return rmsToDb(isL ? m.rmsL : m.rmsR);
   }

--- a/meter-worklet.js
+++ b/meter-worklet.js
@@ -1,7 +1,8 @@
 /* FableCut per-track meter worklet + stereo program sum pass-through.
    Inputs 0…nAudio−1 = A-track buses; input nAudio = video/other spill on master.
    Pass-through sum → stereo out. Per-track RMS/LUFS/Peak via port; master L/R
-   is metered on the main thread (AnalyserNodes on the worklet output). */
+   RMS/Peak is metered on the main thread (AnalyserNodes on the worklet output),
+   while master LUFS is computed here on the true summed program output. */
 function shelfCoeffs(fs) {
   const f0 = 1681.974450955533;
   const G = 3.999843853973347;
@@ -49,7 +50,8 @@ class FableCutMeterProcessor extends AudioWorkletProcessor {
     this._nTracks = Math.max(1, opts.nTracks || 1);
     this._nAudio = Math.max(0, opts.nAudioTracks ?? opts.nTracks ?? 1);
     this._block = 0;
-    this._sumSq = new Float64Array(this._nTracks);
+    this._sumSqL = new Float64Array(this._nTracks);
+    this._sumSqR = new Float64Array(this._nTracks);
     this._peak = new Float64Array(this._nTracks);
     this._sumSqK = new Float64Array(this._nTracks);
     this._frames = 0;
@@ -67,8 +69,15 @@ class FableCutMeterProcessor extends AudioWorkletProcessor {
       this._hpfR.push(makeBiquad(hpf));
     }
 
-    // Momentary = 400 ms of block mean-squares (BS.1770) — per A-track only;
-    // master L/R is sampled via AnalyserNodes on the post-meter output in app.js.
+    // Filters for the summed program output so the master LUFS is the true
+    // post-mix reading, not an approximation from per-track values.
+    this._shelfOutL = makeBiquad(shelf);
+    this._hpfOutL = makeBiquad(hpf);
+    this._shelfOutR = makeBiquad(shelf);
+    this._hpfOutR = makeBiquad(hpf);
+    this._sumSqKOut = 0;
+
+    // Momentary = 400 ms of block mean-squares (BS.1770) — per A-track + program.
     const hopFrames = 128 * this._hopBlocks;
     this._lufsLen = Math.max(1, Math.round(0.4 * sampleRate / hopFrames));
     this._lufsRing = [];
@@ -79,6 +88,9 @@ class FableCutMeterProcessor extends AudioWorkletProcessor {
       this._lufsIdx.push(0);
       this._lufsFilled.push(0);
     }
+    this._lufsRingOut = new Float64Array(this._lufsLen);
+    this._lufsIdxOut = 0;
+    this._lufsFilledOut = 0;
   }
 
   process(inputs, outputs) {
@@ -99,7 +111,8 @@ class FableCutMeterProcessor extends AudioWorkletProcessor {
       const n = L ? L.length : (outL ? outL.length : 128);
       frames = n;
 
-      let sum = this._sumSq[t];
+      let sumL = this._sumSqL[t];
+      let sumR = this._sumSqR[t];
       let peak = this._peak[t];
       let sumK = this._sumSqK[t];
       const sL = this._shelfL[t], hL = this._hpfL[t];
@@ -108,8 +121,8 @@ class FableCutMeterProcessor extends AudioWorkletProcessor {
       for (let i = 0; i < n; i++) {
         const l = L ? L[i] : 0;
         const r = R ? R[i] : 0;
-        const mono = R ? (l + r) * 0.5 : l;
-        sum += mono * mono;
+        sumL += l * l;
+        sumR += r * r;
         const aL = l >= 0 ? l : -l;
         const aR = r >= 0 ? r : -r;
         if (aL > peak) peak = aL;
@@ -122,9 +135,23 @@ class FableCutMeterProcessor extends AudioWorkletProcessor {
         if (outL) outL[i] += l;
         if (outR) outR[i] += r;
       }
-      this._sumSq[t] = sum;
+      this._sumSqL[t] = sumL;
+      this._sumSqR[t] = sumR;
       this._peak[t] = peak;
       this._sumSqK[t] = sumK;
+    }
+
+    // Filter the summed program output for a true master LUFS reading.
+    if (outL && outR && frames > 0) {
+      const sL = this._shelfOutL, hL = this._hpfOutL;
+      const sR = this._shelfOutR, hR = this._hpfOutR;
+      let sumK = this._sumSqKOut;
+      for (let i = 0; i < frames; i++) {
+        const fl = biquadStep(hL, biquadStep(sL, outL[i]));
+        const fr = biquadStep(hR, biquadStep(sR, outR[i]));
+        sumK += fl * fl + fr * fr;
+      }
+      this._sumSqKOut = sumK;
     }
 
     if (frames) this._frames += frames;
@@ -136,7 +163,11 @@ class FableCutMeterProcessor extends AudioWorkletProcessor {
       const peak = new Array(this._nAudio);
       const lufs = new Array(this._nAudio);
       for (let t = 0; t < this._nAudio; t++) {
-        rms[t] = Math.sqrt(this._sumSq[t] / n);
+        // Track bar follows the louder channel so a mono stem panned hard L/R
+        // (or any stereo track) stays in sync with the per-channel master meters.
+        const rmsL = Math.sqrt(this._sumSqL[t] / n);
+        const rmsR = Math.sqrt(this._sumSqR[t] / n);
+        rms[t] = Math.max(rmsL, rmsR);
         peak[t] = this._peak[t];
 
         // Channel-weighted mean square for this hop (L+R, G=1 each)
@@ -152,9 +183,26 @@ class FableCutMeterProcessor extends AudioWorkletProcessor {
         const meanMs = acc / Math.max(1, filled);
         lufs[t] = meanMs > 1e-12 ? -0.691 + 10 * Math.log10(meanMs) : -70;
 
-        this._sumSq[t] = 0;
+        this._sumSqL[t] = 0;
+        this._sumSqR[t] = 0;
         this._peak[t] = 0;
         this._sumSqK[t] = 0;
+      }
+
+      // Program LUFS from the actual summed output (includes video spill).
+      let masterLufs = -70;
+      if (outL && outR) {
+        const blockMs = this._sumSqKOut / n;
+        const ring = this._lufsRingOut;
+        const idx = this._lufsIdxOut;
+        ring[idx] = blockMs;
+        this._lufsIdxOut = (idx + 1) % this._lufsLen;
+        if (this._lufsFilledOut < this._lufsLen) this._lufsFilledOut++;
+        let acc = 0;
+        for (let i = 0; i < this._lufsFilledOut; i++) acc += ring[i];
+        const meanMs = acc / Math.max(1, this._lufsFilledOut);
+        masterLufs = meanMs > 1e-12 ? -0.691 + 10 * Math.log10(meanMs) : -70;
+        this._sumSqKOut = 0;
       }
 
       this.port.postMessage({
@@ -162,6 +210,7 @@ class FableCutMeterProcessor extends AudioWorkletProcessor {
         rms,
         peak,
         lufs,
+        masterLufs,
         frames: n,
       });
       this._block = 0;

--- a/test/meter-worklet.test.js
+++ b/test/meter-worklet.test.js
@@ -1,0 +1,104 @@
+/* Unit tests for the meter worklet. We mock the AudioWorkletProcessor base
+   class and registerProcessor so the worklet can run in Node. */
+"use strict";
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const path = require("node:path");
+const fs = require("node:fs");
+const vm = require("node:vm");
+const { ROOT } = require("./helpers");
+
+class FakeAudioWorkletProcessor {
+  constructor() {}
+}
+
+let RegisteredProcessor = null;
+function fakeRegisterProcessor(name, cls) {
+  cls.registeredName = name;
+  RegisteredProcessor = cls;
+}
+
+const workletPath = path.join(ROOT, "meter-worklet.js");
+const workletCode = fs.readFileSync(workletPath, "utf8");
+vm.runInNewContext(workletCode, {
+  AudioWorkletProcessor: FakeAudioWorkletProcessor,
+  registerProcessor: fakeRegisterProcessor,
+  sampleRate: 48000,
+  Math, Float32Array, Float64Array, Array, console,
+});
+
+function makeProcessor(opts = {}) {
+  return new RegisteredProcessor({
+    processorOptions: {
+      hopBlocks: 1,
+      nTracks: 2,
+      nAudioTracks: 1,
+      trackIds: ["A1"],
+      ...opts,
+    },
+  });
+}
+
+function runHop(p, { L, R, spillL, spillR }) {
+  const size = 128;
+  const l = L || new Float32Array(size);
+  const r = R || new Float32Array(size);
+  const sl = spillL || new Float32Array(size);
+  const sr = spillR || new Float32Array(size);
+  const outL = new Float32Array(size);
+  const outR = new Float32Array(size);
+  const messages = [];
+  p.port = { postMessage: (msg) => messages.push(msg) };
+  p.process([[l, r], [sl, sr]], [[outL, outR]]);
+  return { messages, outL, outR };
+}
+
+test("mono stem panned left: track RMS matches active channel", () => {
+  const p = makeProcessor();
+  const size = 128;
+  const L = new Float32Array(size).fill(0.5);
+  const R = new Float32Array(size); // silent
+  const { messages } = runHop(p, { L, R });
+  assert.equal(messages.length, 1);
+  const msg = messages[0];
+  // Old mono mixdown would give 0.25 (-12 dBFS). New max(L,R) gives 0.5 (-6 dBFS).
+  assert.ok(Math.abs(msg.rms[0] - 0.5) < 0.001, `rms was ${msg.rms[0]}`);
+  assert.ok(Math.abs(msg.peak[0] - 0.5) < 0.001, `peak was ${msg.peak[0]}`);
+});
+
+test("stereo centered track: track RMS matches per-channel master", () => {
+  const p = makeProcessor();
+  const size = 128;
+  const L = new Float32Array(size).fill(0.5);
+  const R = new Float32Array(size).fill(-0.5); // anti-phase, same amplitude
+  const { messages } = runHop(p, { L, R });
+  const msg = messages[0];
+  // Mono mixdown would cancel to 0. Track meter should follow the louder channel.
+  assert.ok(Math.abs(msg.rms[0] - 0.5) < 0.001, `rms was ${msg.rms[0]}`);
+  assert.ok(Math.abs(msg.peak[0] - 0.5) < 0.001, `peak was ${msg.peak[0]}`);
+});
+
+test("single track: master LUFS equals per-track LUFS", () => {
+  const p = makeProcessor();
+  const size = 128;
+  const L = new Float32Array(size).fill(0.5);
+  const R = new Float32Array(size).fill(-0.3);
+  const { messages } = runHop(p, { L, R });
+  const msg = messages[0];
+  assert.ok(Number.isFinite(msg.lufs[0]), `track lufs was ${msg.lufs[0]}`);
+  assert.ok(Number.isFinite(msg.masterLufs), `master lufs was ${msg.masterLufs}`);
+  assert.ok(Math.abs(msg.lufs[0] - msg.masterLufs) < 0.1,
+    `track lufs ${msg.lufs[0]} vs master lufs ${msg.masterLufs}`);
+});
+
+test("output is the sum of inputs", () => {
+  const p = makeProcessor({ nAudioTracks: 1, nTracks: 2 });
+  const size = 128;
+  const L = new Float32Array(size).fill(0.3);
+  const R = new Float32Array(size).fill(0.4);
+  const spillL = new Float32Array(size).fill(0.1);
+  const spillR = new Float32Array(size).fill(0.2);
+  const { outL, outR } = runHop(p, { L, R, spillL, spillR });
+  assert.ok(Math.abs(outL[0] - 0.4) < 0.001, `outL[0] was ${outL[0]}`);
+  assert.ok(Math.abs(outR[0] - 0.6) < 0.001, `outR[0] was ${outR[0]}`);
+});


### PR DESCRIPTION
Master audio meters are aligned with tracks reading; worklet computes a real program LUFS on the summed output

## What does this PR do?

Master audio meter was buggy. It was possible to observe that by placing a single audio track and to compare meters readings.
Also, (master) LUFS meter was apparently falling back to RMS readings

## Type of change

- [X ] Bug fix
- [ ] New feature (transition / preset / text anim / effect / API)
- [X] Docs
- [ ] Refactor / internal

## How was it verified?

- [X] `npm test` passes (CI runs it on Node 18 / 20 / 22)
- [X] Added or updated a test in `test/` if this touches the MCP surface, the REST API, or the SVG library
- [ ] Opened the editor and confirmed the change in **preview**
- [ ] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Master LUFS mode now displays the program’s true summed LUFS level for more accurate overall loudness monitoring.
  - Stereo track meters now reflect the louder active channel, improving readings for panned and centered audio.
  - Master loudness measurements now account for the complete output signal, including additional output channels.

- **Tests**
  - Added coverage for mono, stereo, panned, and summed-output metering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->