### PR TITLE
fix: heart-pop.svg - remove extra shape from the beginning

### DIFF
--- a/library/svg/heart-pop.svg
+++ b/library/svg/heart-pop.svg
@@ -10,17 +10,19 @@
       45%      { transform: scale(1.12); }
     }
     .float { transform-box: fill-box; transform-origin: center;
-             animation: rise 3s ease-in infinite; }
+             opacity: 0;
+             animation: rise 3s ease-in infinite both; }
     @keyframes rise {
       0%   { transform: translate(0,0) scale(0.3); opacity: 0; }
-      20%  { opacity: 0.9; }
+      22%  { opacity: 0; }
+      38%  { opacity: 0.85; }
       100% { transform: translate(var(--tx,0px),-360px) scale(1); opacity: 0; }
     }
   </style>
   <g fill="#ff4d6d">
     <path class="beat" style="--d:0s" d="M250 470 C120 380 70 300 70 220 C70 150 120 110 175 110 C215 110 240 135 250 160 C260 135 285 110 325 110 C380 110 430 150 430 220 C430 300 380 380 250 470z"/>
-    <path class="float" style="--d:0s; --tx:-70px" opacity="0.8" d="M150 460 c-40 -28 -56 -52 -56 -78 c0 -22 16 -34 33 -34 c12 0 20 8 23 15 c3 -7 11 -15 23 -15 c17 0 33 12 33 34 c0 26 -16 50 -56 78z"/>
-    <path class="float" style="--d:1s; --tx:60px"  opacity="0.7" d="M330 470 c-40 -28 -56 -52 -56 -78 c0 -22 16 -34 33 -34 c12 0 20 8 23 15 c3 -7 11 -15 23 -15 c17 0 33 12 33 34 c0 26 -16 50 -56 78z"/>
-    <path class="float" style="--d:2s; --tx:15px"  opacity="0.6" d="M250 480 c-30 -21 -42 -39 -42 -58 c0 -16 12 -26 25 -26 c9 0 15 6 17 11 c2 -5 8 -11 17 -11 c13 0 25 10 25 26 c0 19 -12 37 -42 58z"/>
+    <path class="float" style="--d:0.45s; --tx:-70px" d="M150 460 c-40 -28 -56 -52 -56 -78 c0 -22 16 -34 33 -34 c12 0 20 8 23 15 c3 -7 11 -15 23 -15 c17 0 33 12 33 34 c0 26 -16 50 -56 78z"/>
+    <path class="float" style="--d:1.45s; --tx:60px"  d="M330 470 c-40 -28 -56 -52 -56 -78 c0 -22 16 -34 33 -34 c12 0 20 8 23 15 c3 -7 11 -15 23 -15 c17 0 33 12 33 34 c0 26 -16 50 -56 78z"/>
+    <path class="float" style="--d:2.45s; --tx:15px"  d="M250 480 c-30 -21 -42 -39 -42 -58 c0 -16 12 -26 25 -26 c9 0 15 6 17 11 c2 -5 8 -11 17 -11 c13 0 25 10 25 26 c0 19 -12 37 -42 58z"/>
   </g>
 </svg>


### PR DESCRIPTION
## What does this PR do?

`heart-pop.svg` had an extra shape at the beginning of the animation sequence. Removed.

## Type of change

- [X] Bug fix
- [ ] New feature (transition / preset / text anim / effect / API)
- [ ] Docs
- [ ] Refactor / internal

## How was it verified?

- [ ] `npm test` passes (CI runs it on Node 18 / 20 / 22)
- [ ] Added or updated a test in `test/` if this touches the MCP surface, the REST API, or the SVG library
- [X] Opened the editor and confirmed the change in **preview**
- [X] Confirmed the change in an **export** (fast or realtime), if it affects rendering
- [ ] Updated `CLAUDE.md` / `README.md` if the schema, props, or API changed

## Checklist

- [X] No new runtime dependencies added
- [X] Preview and export render identically (single compositor)
- [X] Commits are focused and messages are descriptive
